### PR TITLE
Bug/master/template scope

### DIFF
--- a/source/guides/scope_and_puppet.markdown
+++ b/source/guides/scope_and_puppet.markdown
@@ -94,8 +94,8 @@ These rules seem simple enough, so an example is in order:
     class postfix::custom inherits postfix {
          File ["/etc/postfix/main.cf"] {
               content => undef,
-              source => ["puppet:///files/$hostname/main.cf",
-                               "puppet:///files/$nodetype/main.cf" ]
+              source => [ "puppet:///files/$hostname/main.cf",
+                          "puppet:///files/$nodetype/main.cf" ]
          }
     
     } 


### PR DESCRIPTION
```
(Minor) Fix template source

The template function does not accept puppet:/// URI's.
This change corrects the template function to use the
module path and adds a comment indicating where the file
lives.

Signed-off-by: Jeff McCune <jeff@puppetlabs.com>
```
