### PR TITLE
(#8543) Update cloudpack getting started

### DIFF
--- a/source/guides/cloud_pack_getting_started.markdown
+++ b/source/guides/cloud_pack_getting_started.markdown
@@ -1,65 +1,92 @@
 ---
 layout: default
-title: Getting Started With CloudPack
+title: Getting Started With Cloud Provisioner
 ---
 
 [fog]: http://fog.io/
 [pe]: http://info.puppetlabs.com/download
-[cp]: https://github.com/puppetlabs/puppet-cloudpack
+[cp]: https://github.com/puppetlabs/puppetlabs-cloud-provisioner
 
-Getting Started With Puppet CloudPack
+Getting Started With Puppet Cloud Provisioner
 =====================================
 
-Learn how to install and start using CloudPack, Puppet's preview Faces extension for node bootstrapping.
+Learn how to install and start using Cloud Provisioner, Puppet's extension for
+node bootstrapping.
 
-* * * 
+* * *
 
 Overview
 --------
 
-Puppet CloudPack is a Puppet extension that adds new actions for creating and puppetizing new machines, especially Amazon AWS EC2 instances. 
+Puppet Cloud Provisioner is a Puppet extension that adds new actions for
+creating and puppetizing new machines in Amazon's EC2.
 
-CloudPack gives you an easy command line interface to the following tasks:
+Cloud Provisioner gives you an easy command line interface to the following
+tasks:
 
 * Create a new Amazon EC2 instance
-* Install Puppet Enterprise on a remote machine of your choice
-* Add a new puppet agent node to a Puppet Dashboard node group
-* Do all of the above (plus sign the new node's certificate) with a single `puppet node bootstrap` invocation
+* Install Puppet on a remote machine of your choice
+* Remotely sign a node's certificate
+* Do all of the above with a single `puppet node bootstrap` invocation
 
 Installing
 ----------
 
-To install Puppet CloudPack, simply clone [the repository][cp] on your control node and add its lib directory to your `$RUBYLIB` or Ruby load path. 
+Puppet Cloud Provisioner should be installed with the puppet-module tool. First
+make sure that the tool is installed:
+
+    # gem install puppet-module
+
+Now install Cloud Provisioner with the puppet-module tool on your control node:
+
+    # puppet-module install puppetlabs/cloud_provisioner
+
+Add its lib directory to your `$RUBYLIB` or Ruby load path:
+
+    # export RUBYLIB=$(pwd)/puppetlabs-cloud_provisioner/lib:$RUBYLIB
+
+You can verify that it is installed correctly by running:
+
+    # puppet help node
+
+Verifying that you see the Cloud Provisioner specific commands (create,
+install, ...) in the output.
 
 Prerequisites
 -------------
 
-Puppet CloudPack has several requirements beyond those of Puppet. 
+Puppet Cloud Provisioner has several requirements beyond those of Puppet.
 
 ### Software
 
-CloudPack can only be used with **Puppet 2.7 or greater.** Classification of new nodes requires Puppet Dashboard 1.1.2 (unreleased at the time of this writing) or greater.
+Cloud Provisioner can only be used with **Puppet 2.7.2 or greater.**
 
-CloudPack also requires [Fog][], a Ruby cloud services library. You'll need to **ensure that Fog is installed** on the machine running CloudPack:
+Cloud Provisioner requires [Fog][], a Ruby cloud services library. You'll need
+to **ensure that Fog is installed** on the machine running Cloud Provisioner:
 
-    # gem install fog
+    # gem install fog -v 0.7.2
 
-Depending on your operating system and Ruby environment, you may need to manually install some of Fog's dependencies. 
+Cloud Provisier also requires the GUID library for generating unique
+identifiers.
 
-If you wish to use CloudPack to install Puppet on new nodes, you'll also need **a copy of the [Puppet Enterprise][pe] universal tarball.** As of this writing, the distro-specific tarballs are not supported.
+    # gem install guid
 
-The machine running the CloudPack faces will need a working `/usr/bin/uuidgen` binary.
+Depending on your operating system and Ruby environment, you may need to
+manually install some of Fog's dependencies.
 
 ### Services
 
-Currently, Amazon EC2 is the only supported cloud platform for creating new machine instances; you'll need a pre-existing **Amazon EC2 account** to use this feature. 
+Currently, Amazon EC2 is the only supported cloud platform for creating new
+machine instances; you'll need a pre-existing **Amazon EC2 account** to use
+this feature.
 
 Configuration
 -------------
 
 ### Fog
 
-For CloudPack to work, Fog needs to be configured with your AWS access key ID and secret access key. Create a `~/.fog` file as follows: 
+For Cloud Provisioner to work, Fog needs to be configured with your AWS access
+key ID and secret access key. Create a `~/.fog` file as follows:
 
     :default:
       :aws_access_key_id:     XXXXXXXXXXXXXXXXXXXXX
@@ -84,162 +111,197 @@ aws\_access\_key\_id and aws\_secret\_access\_key are properly set in the
 
 ### EC2
 
-Your EC2 account will need to have at least one **32-bit AMI of a supported Puppet Enterprise OS,**[^platforms] at least one Amazon-managed **SSH keypair,** and a security group that **allows outbound traffic on port 8140 and SSH traffic from the machine running the CloudPack actions.** As of this writing, all of these resources **must be in the `us-east-1` region;** this will change in a later release of the CloudPack. We also hope to support 64-bit AMIs at a later date.
+Your EC2 account will need to have at least one Amazon-managed **SSH keypair,**
+and a security group that **allows outbound traffic on port 8140 and SSH
+traffic from the machine running the Cloud Provisioner actions.**
 
-Your puppet master server will also have to be reachable from your newly created instances.
+Your puppet master server will also have to be reachable from your newly
+created instances.
 
-[^platforms]: Currently, the supported platforms for Puppet Enterprise are CentOS 5, RHEL 5, Debian 5, and Ubuntu 10.04 LTS.
+[^platforms]: Currently, supported platforms are restricted by the install
+script chosen. Testing has only currently been done on Ubuntu 11.04 (Natty) and
+CentOS 5.4.
 
 ### Provisioning
 
-In order to use the `install` action, any newly provisioned instances will need to have their root user enabled, or will need a user account configured to `sudo` as root without a password.
+In order to use the `install` action, any newly provisioned instances will need
+to have their root user enabled, or will need a user account configured to
+`sudo` as root without a password.
 
 ### puppet master
 
-If you want to automatically sign certificates with the CloudPack, you'll have to allow the computer running the CloudPack actions to access the puppet master's `certificate_status` REST endpoint. This can be configured in the master's [auth.conf](http://docs.puppetlabs.com/guides/rest_auth_conf.html) file:
+If you want to automatically sign certificates with the Cloud Provisioner,
+you'll have to allow the computer running the Cloud Provisioner actions to
+access the puppet master's `certificate_status` REST endpoint. This can be
+configured in the master's
+[auth.conf](http://docs.puppetlabs.com/guides/rest_auth_conf.html) file:
 
     path /certificate_status
     method save
     auth yes
     allow {certname}
 
-If you're running the CloudPack actions on a machine other than your puppet master, you'll have to ensure it can communicate with the puppet master over port 8140 and your Puppet Dashboard server over port 3000. 
+If you're running the Cloud Provisioner actions on a machine other than your
+puppet master, you'll have to ensure it can communicate with the puppet master
+over port 8140.
 
 ### Certificates and Keys
 
-You'll also have to make sure the control node has a certificate signed by the puppet master's CA. If the control node is already known to the puppet master (e.g. it is or was a puppet agent node), you'll be able to use the existing certificate, but we recommend generating a per-user certificate for a more explicit and readable security policy. On the control node, run:
+You'll also have to make sure the control node has a certificate signed by the
+puppet master's CA. If the control node is already known to the puppet master
+(e.g. it is or was a puppet agent node), you'll be able to use the existing
+certificate, but we recommend generating a per-user certificate for a more
+explicit and readable security policy. On the control node, run:
 
     puppet certificate generate {certname} --ca-location remote
 
-Then sign the certificate as usual on the master (`puppet cert sign {certname}`). On the control node again, run:
+Then sign the certificate as usual on the master (`puppet cert sign
+{certname}`). On the control node again, run:
 
     puppet certificate find ca --ca-location remote
     puppet certificate find {certname} --ca-location remote
 
-This should let you operate under the new certname when you run puppet commands with the --certname {certname} option. 
+This should let you operate under the new certname when you run puppet commands
+with the `--certname {certname}` option.
 
-The control node will also need a private key to allow SSH access to the new machine; for EC2 nodes, this is the private key from the keypair used to create the instance. If you are working with non-EC2 nodes, please note that the `install` action does not currently support keys with passphrases.
-
-### Installer Configuration
-
-To install Puppet Enterprise on a node, you'll need a complete answers file to be read by the installer. See the PE documentation for more details. Note that the certname from the answers file is ignored, and the new instance will be given a UUID as its certname. 
+The control node will also need a private key to allow SSH access to the new
+machine; for EC2 nodes, this is the private key from the keypair used to create
+the instance. If you are working with non-EC2 nodes, please note that the
+`install` action does not currently support keys with passphrases.
 
 Usage
 -----
 
-Puppet CloudPack provides five new actions on the `node` face: 
+Puppet Cloud Provisioner provides five new actions on the `node` face:
 
 * `create`: Creates a new EC2 machine instance.
-* `install`: Install's Puppet Enterprise on an arbitrary machine, including non-cloud hardware.
-* `classify`: Add a new node to a Puppet Dashboard node group.
-* `init`: Perform the `install` and `classify` actions, and automatically sign the new agent node's certificate. 
-* `bootstrap`: Create a new EC2 machine instance and perform the `init` action on it.
+* `install`: Install's Puppet on an arbitrary machine, including non-cloud
+hardware.
+* `init`: Perform the `install` and `classify` actions, and automatically sign
+the new agent node's certificate.
+* `bootstrap`: Create a new EC2 machine instance and perform the `init` action
+on it.
 * `terminate`: Tear down an EC2 machine instance.
+* `list`: List running instances in the specified zone.
+* `fingerprint`: Make a best effort to securely obtain the SSH host key
+fingerprint.
 
 ### puppet node create
 
 Argument(s): none.
 
-Options: 
+Options:
 
-* `--image, -i` --- The name of the AMI to use when creating the instance. **Required.**
-* `--keypair` --- The Amazon-managed SSH keypair to use for accessing the instance. **Required.**
-* `--group, -g, --security-group` --- The security group(s) to apply to the instance. Can be a single group or a path-separator (colon, on *nix systems) separated list of groups. 
+* `--image, -i` --- The name of the AMI to use when creating the instance.
+**Required.**
+* `--keypair` --- The Amazon-managed SSH keypair to use for accessing the
+instance. **Required.**
+* `--group, -g, --security-group` --- The security group(s) to apply to the
+instance. Can be a single group or a path-separator (colon, on *nix systems)
+separated list of groups.
+* `--region` --- The geographic region of the instance. Defaults to us-east-1.
+* `--type --- Type of instance to be launched.
 
 Example:
 
-    $ puppet node create --image ami-XxXXxXXX --keypair puppetlabs.admin
+    $ puppet node create --image ami-XxXXxXXX --keypair puppetlabs.admin --type m1.small
 
-Creates a new EC2 machine instance, prints its SSH host key fingerprints, and returns its DNS name. If the process fails, Puppet will automatically clean up after itself and tear down the instance. 
-
-For security reasons, SSH fingerprints are obtained by observing the AWS console for the machine. This entails a noticeable wait, and the console output is sometimes not provided; if this happens, the instance will be kept alive and you will have to obtain host fingerprints through AWS. 
+Creates a new EC2 machine instance and returns its DNS name. If the process
+fails, Puppet will automatically clean up after itself and tear down the
+instance.
 
 ### puppet node install
 
 Argument(s): the hostname of the system to install Puppet on.
 
-Options: 
+Options:
 
 * `--login, -l, --username` --- The user to log in as. **Required.**
-* `--keyfile` --- The SSH private key file to use. This key cannot require a passphrase. **Required.**
-* `--installer-payload, --puppet` --- The location of the [Puppet Enterprise][pe] universal tarball. **Required.**
-* `--installer-answers` --- The location of an answers file to use with the PE installer. **Required.**
+* `--keyfile` --- The SSH private key file to use. This key cannot require a
+passphrase. **Required.**
+* `--install-script` --- The install script that should be used to install
+Puppet. Current supported options are: gems, puppet-enterprise, puppet-enterprise-s3
+* `--installer-payload, --puppet` --- The location of the [Puppet
+Enterprise][pe] universal tarball. (Used with puppet-enterprise install script)
+* `--installer-answers` --- The location of an answers file to use with the PE
+installer. (Used with puppet-enterprise and puppet-enterprise-s3 install
+scripts).
+* `--puppet-version` --- The version of puppet to install with the gems install
+script.
+* `--facter-version` --- The version of facter to install with the gems install
+script.
+* `--pe-version` --- The version of PE to install with the puppet-enterprise
+script.  e.g. `1.1`
 
-Example: 
+Example:
 
     puppet node install ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com \
     --login root --keyfile ~/.ssh/puppetlabs-ec2_rsa \
-    --installer-payload ~/puppet-enterprise-1.0-all.tar.gz \
-    --installer-answers ~/pe-agent-answers
+    --install-script gems --puppet-version 2.6.9
 
-Install Puppet Enterprise on an arbitrary system and return the new agent node's certname. This action currently requires the universal PE tarball; per-distro tarballs are not supported. 
+Installs Puppet on an arbitrary system and return the new agent
+node's certname.
 
-Interactive installation is not supported, so you'll need an answers file. See the PE manual for complete documentation of the answers file format.
+Interactive installation of PE is not supported, so you'll need an answers
+file. See the PE manual for complete documentation of the answers file format.
+A reasonable default has been supplied in the ext directory.
 
-This action is not restricted to cloud machine instances, and will install PE on any machine accessible by SSH. 
-
-### puppet node classify
-
-Argument(s): the certname of the agent node to classify. 
-
-Options: 
-
-* `--node-group, --as` --- The Puppet Dashboard node group to use. **Required.**
-* `--report_server` --- The hostname of your Puppet Dashboard server. Required unless properly configured in puppet.conf. This is a global Puppet option.
-* `--report_port` --- The port on which Puppet Dashboard is listening. Required unless properly configured in puppet.conf. This is a global Puppet option.
-* `--certname` --- The certname (Subject CN) of a certificate authorized by the puppet master to remotely sign CSRs. Required unless properly configured in puppet.conf. This is a global Puppet option.
-
-Example: 
-
-    puppet node classify ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com \
-    --as webserver_generic --report_server dashboard.puppetlabs.lan \
-    --report_port 3000 --certname cloud_admin
-
-Make Puppet Dashboard aware of a newly created agent node and add it to a node group, thus allowing it to receive proper configurations on its next run. This action will have no material effect unless you're using Puppet dashboard for node classification. 
-
-This action is not restricted to cloud machine instances. It can be run multiple times for a single node. 
+This action is not restricted to cloud machine instances, and will install PE
+on any machine accessible by SSH.
 
 ### puppet node init
 
 Argument(s): the hostname of the system to install Puppet on.
 
-Options: See "install" and "classify."
+Options: See "install"
 
-Example: 
+Example:
 
     puppet node init ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com \
     --login root --keyfile ~/.ssh/puppetlabs-ec2_rsa \
-    --installer-payload ~/puppet-enterprise-1.0-all.tar.gz\
-     --installer-answers ~/pe-agent-answers --as webserver_generic \
-    --report_server dashboard.puppetlabs.lan --report_port 3000 --certname cloud_admin
+    --certname cloud_admin
 
-Install Puppet Enterprise on an arbitrary system (see "install"), classify it in Dashboard (see "classify"), and automatically sign its certificate request (using the `certificate` face's `sign` action). 
+Install Puppet on an arbitrary system (see "install") and automatically sign
+its certificate request (using the `certificate` face's `sign` action).
 
 ### puppet node bootstrap
 
 Argument(s): none.
 
-Options: See "create," "install," and "classify."
+Options: See "create" and "install"
 
-Example: 
+Example:
 
     puppet node bootstrap --image ami-XxXXxXXX --keypair \
     puppetlabs.admin --login root --keyfile ~/.ssh/puppetlabs-ec2_rsa \
-    --installer-payload ~/puppet-enterprise-1.0-all.tar.gz \
-    --installer-answers ~/pe-agent-answers --as webserver_generic \
-    --report_server dashboard.puppetlabs.lan --report_port 3000 \
     --certname cloud_admin
 
-Create a new EC2 machine instance and pass the new node's hostname to the `init` action.
+Create a new EC2 machine instance and pass the new node's hostname to the
+`init` action.
 
 ### puppet node terminate
 
 Argument(s): the hostname of the machine instance to tear down.
 
-Options: none.
+Options:
 
-Example: 
+* `--region` --- The geographic region of the instance. Defaults to us-east-1.
+
+Example:
 
     puppet node terminate init ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com
 
-Tear down an EC2 machine instance. 
+Tear down an EC2 machine instance.
+
+### puppet node list
+
+Argument(s): None
+
+Options:
+
+* `--region` --- The geographic region of the instance. Defaults to us-east-1.
+
+Example:
+
+    puppet node list --region us-west-1
+


### PR DESCRIPTION
This change updates the getting started guide to reflect the changes made in
the 0.6.0rc1 release since the 0.0.1 tag.  The getting started guide was
originally written with the 0.0.1 feature set and these instructions are no
longer relevant with the new release.

Reviewed-by: Jeff McCune
