### PR TITLE
templating: add a short explanation on how to use facts correctly

### DIFF
--- a/source/guides/templating.markdown
+++ b/source/guides/templating.markdown
@@ -140,12 +140,23 @@ If you need to test to see if a variable is defined before using it, the followi
     myvar has <%= myvar %> value
     <% end %>
 
-## Out of scope variables
+## Out of scope variables and facts
 
 You can access out of scope variables explicitly with the lookupvar
 function:
 
     <%= scope.lookupvar('apache::user') %>
+
+Same goes for client-specific variables (facts). For instance, in order to
+access the "`domain`" fact use the following:
+
+    <%= scope.lookupvar('::domain') %>
+
+Support for dynamic lookup of referenced variables i.e.
+
+    <%= domain %>
+
+will be removed in Puppet 2.8.
 
 ## Access to defined tags and classes
 


### PR DESCRIPTION
templating: add a short explanation on how to use facts correctly using lookupvar

Signed-off-by: Yury V. Zaytsev yury@shurup.com
