### PR TITLE
puppet-module installs to cloud_provisioner, not puppetlabs-cloud_provisioner

### DIFF
--- a/source/guides/cloud_pack_getting_started.markdown
+++ b/source/guides/cloud_pack_getting_started.markdown
@@ -75,7 +75,7 @@ Now use puppet-module to install Cloud Provisioner on your control node:
 
 Add its lib directory to your `$RUBYLIB` or Ruby load path:
 
-    # export RUBYLIB=$(pwd)/puppetlabs-cloud_provisioner/lib:$RUBYLIB
+    # export RUBYLIB=$(pwd)/cloud_provisioner/lib:$RUBYLIB
 
 You can verify that it is installed correctly by running:
 


### PR DESCRIPTION
```
puppet-module install puppetlabs/cloud_provisioner
```

will install to the folder cloud_provisioner, not puppetlabs-cloud_provisioner.
