### PR TITLE
Fix path to "Setting Up Puppet"

### DIFF
--- a/source/guides/configuring.markdown
+++ b/source/guides/configuring.markdown
@@ -251,4 +251,4 @@ Puppet device, added in Puppet 2.7, configures network hardware using a catalog 
 Setting Up Puppet
 =================
 
-Now that Puppet is installed and configured, let's get to [Setting Up Puppet](./guides/setting_up.html).
+Now that Puppet is installed and configured, let's get to [Setting Up Puppet](./setting_up.html).


### PR DESCRIPTION
Fix path to "Setting Up Puppet" page from "Configuring Puppet" page.
