### PR TITLE
Fixed truncation that occurred when rebasing a patch.

### DIFF
--- a/source/guides/custom_facts.markdown
+++ b/source/guides/custom_facts.markdown
@@ -77,6 +77,10 @@ An example:
     end
 
 ### Loading Custom Facts
+
+Facter offers a few methods of loading facts:
+
+ * $LOAD\_PATH, or the ruby library load path
  * The environment variable 'FACTERLIB'
  * Facts distributed using pluginsync
 


### PR DESCRIPTION
Chopped off a bit of the loading facts section, fixed it here.
