### PR TITLE
(#11072) Development lifecycle inline wiki content

### DIFF
--- a/source/guides/development_lifecycle.markdown
+++ b/source/guides/development_lifecycle.markdown
@@ -6,9 +6,22 @@ title: Development Lifecycle
 Development Lifecycle
 =====================
 
-If you'd like to work on Puppet and submit a contribution, we'd be glad to have you.
+# Contributing to Puppet Labs Projects (Puppet, Dashboard, Facter and more)
 
-* * *
+So you want to contribute to a Puppet Labs project? Awesome!
 
-Since this information changes often, please see the [Puppet Wiki](http://projects.puppetlabs.com/projects/puppet/wiki/Development_Lifecycle) for the latest details.
+We would like to make contributing as easy as possible since your contributions are greatly appreciated.
 
+That said, there are a few guidelines that make reviewing and applying contributions easier.  We hope that the information below will answer any questions you might have about helping out with the Puppet Labs projects.
+
+If you have any questions about contributing to a Puppet Labs project that aren't answered here, the [Getting Help](http://projects.puppetlabs.com/projects/puppet/wiki/Getting_Help) page has a list of additional resources for finding those answers.
+
+# Steps
+
+Check the `CONTRIBUTING.md` in the root of the project tree:
+
+  * [Puppet](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)
+  * [Facter](https://github.com/puppetlabs/facter/blob/master/CONTRIBUTING.md)
+  * [Puppet Dashboard](https://github.com/puppetlabs/puppet-dashboard/blob/master/CONTRIBUTING.md)
+
+These should all be the same, but there may be some project specific notes in each.  If the project you wish to contribute to does not have a `CONTRIBUTING.md`, then you should follow the one from the Puppet repository.


### PR DESCRIPTION
http://docs.puppetlabs.com/guides/development_lifecycle.html links to a
wiki page
http://projects.puppetlabs.com/projects/puppet/wiki/Development_Lifecycle
that has little info and just links to github. The wiki page used to
have all the info about how to contribute to Puppet and changed fairly
frequently, but now that the info has been moved out it shouldn’t change
often at all and should just be part of the docs site. The wiki page
will need to stay as a place holder also since not to long ago that’s
where we told people to look for dev info, but no reason to have people
follow a frustrating set of links just to get to the info.
