### PR TITLE
Installation improvements

### DIFF
--- a/source/guides/installation.markdown
+++ b/source/guides/installation.markdown
@@ -132,8 +132,7 @@ WARNING: If you get the error, in `require: no such file to load`, define the RU
 [post-install instructions](http://docs.rubygems.org/read/chapter/3#page70)
 of the RubyGems User Guide.
 
-Configuring Puppet
+Learning and Configuring Puppet
 ------------------
 
-Now that the packages are installed, see [Configuring Puppet](./configuring.html) for setup instructions.
-
+Now that the packages are installed, start [Learning Puppet](../learning/) or see [Configuring Puppet](./configuring.html) for setup instructions.


### PR DESCRIPTION
The installation page may be the first page you get to from a google search for install puppet, so I added a few changes that I think will help a new puppet user
- Mention puppet apply so it doesn't seem like you have to run a server
- Link to learning puppet (which is interesting) at the end instead of just configuring puppet (which is dry and intimidating)
