### PR TITLE
(#11168) Mention Puppet Enterprise in the installation guide

### DIFF
--- a/source/guides/installation.markdown
+++ b/source/guides/installation.markdown
@@ -20,6 +20,11 @@ in order to run puppet in client server mode.
 If you will just be running [Puppet standalone](./tools.html#puppet-apply-or-puppet)
 you don't need a Puppet master server and installation on just one machine will suffice.
 
+You may want to consider installing [Puppet Enterprise](http://puppetlabs.com/puppet/puppet-enterprise/) 
+for the easiest installation path, if you need professional support, or if some
+of the additional features built on Puppet would be useful.  Check out the
+[comparison](http://puppetlabs.com/puppet/compare/) and read the [FAQ](http://puppetlabs.com/puppet/faq/) to see if it might be right for you.
+
 For most platforms, you can install 'puppet' via your package
 manager of choice.  For a few platforms, you will need to install
 using the [tarball](http://www.puppetlabs.com/downloads/puppet/) or


### PR DESCRIPTION
Even though there's a banner on the docs site for Puppet Enterprise, it
should be mentioned when people install puppet from the installation
guide, especially since that's the first page that you hit when you
Google 'install puppet'.

I tried to mention Puppet Enterprise without being tacky about pushing
the commercial product, and linked directly to the comparison and FAQ so
that it was clear why you might choose to pay for Puppet Enterprise or
not.
