### PR TITLE
Fix chained resource example using both left and right arrows

### DIFF
--- a/source/guides/language_guide.markdown
+++ b/source/guides/language_guide.markdown
@@ -534,8 +534,9 @@ Here the ntpd service requires /etc/ntp.conf and the ntp package.
 
 Please note, relationships declared in this manner are between adjacent
 resources.  In this example, the ntp package and the ntp configuration file are
-related to each other and puppet may try to manage the configuration file
-before the package is even installed, which may not be the desired behavior.
+not directly related to each other, and puppet may try to manage the
+configuration file before the package is even installed, which may not be the
+desired behavior.
 
 Chaining in this manner can provide some succinctness at the cost of
 readability.


### PR DESCRIPTION
In the resource chain:

```
File['/etc/ntp.conf'] -> Service['ntpd'] <- Package['ntp']
```

the file and package were described as related to each other, but
that indirect relationship through the service is not meaningful here.
Stating that they are not directly related to each other makes it
clear why the file may be managed before the package.
