### PR TITLE
(maint) Add link to RDoc markup document in Style Guide

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -755,8 +755,12 @@ limited, stand alone manner.
 
 ## 13. Puppet Doc
 
-Classes and defined resource types should be documented inline using the
-following conventions:
+Classes and defined resource types should be documented inline using
+[RDoc markup](http://links.puppetlabs.com/rdoc_markup).  These inline
+documentation comments are important because online documentation can then be
+easily generated using the
+[puppet doc](http://links.puppetlabs.com/puppet_manifest_documentation)
+command.
 
 For classes:
 


### PR DESCRIPTION
Without this patch the style guide gives an example of the inline puppet
manifest documentation but does not mention the markup format is RDoc.

This patch makes it clear module authors should specifically write
inline documentation in RDoc and provides a reference link to where to
learn about the syntax of the RDoc markup.

It also makes it clear why this is important; to automatically generate
documentation using puppet doc.
