### PR TITLE
Add a section header for "Curated Guides" to the doc index

### DIFF
--- a/source/index.markdown
+++ b/source/index.markdown
@@ -48,6 +48,8 @@ Learn to use Puppet! New users: start here.
 Reference Shelf
 ---------------
 
+### Curated Guides
+
 Get detailed information about config files, APIs, and the Puppet language.
 
 * [REST API](./guides/rest_api.html) --- reference of api accessible resources


### PR DESCRIPTION
The primary purpose of this change is to provide a specific target for the
list of non-automatically-generated docs, so it pops out better in
the table of contents. Right now the TOC has a list of items
under "Reference Shelf" but the only option in the list is "Generated
References" so it's not obvious that there are other options.
