### PR TITLE
(#11746) Update google analytics tracking code on docs.puppetlabs.com.

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -11,18 +11,19 @@
     <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://puppetlabs.com/xmlrpc.php?rsd" />
     <link rel='index' title='Puppet Labs' href='http://docs.puppetlabs.com' />
 
-<!-- Google stats -->
+<!-- Google analytics -->
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-1537572-5']);
+  _gaq.push(['_setDomainName', 'puppetlabs.com']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();
 </script>
-<script type="text/javascript">
-try {
-var pageTracker = _gat._getTracker("UA-1537572-5");
-pageTracker._setDomainName(".puppetlabs.com");
-pageTracker._trackPageview();
-} catch(err) {}</script>
-<!-- End Google stats -->
+<!-- End Google analytics -->
 
 
     <!-- FIXME: absolute paths -->


### PR DESCRIPTION
I believe this now uses the "async method" for doing Google analytics,
rather than, well, the previous method.

No idea what I did to fail to push this branch previously, but hey, it's there now.
