### PR TITLE
(#11795) Correct product name on Supported Platforms page of Puppet website

### DIFF
--- a/source/guides/platforms.markdown
+++ b/source/guides/platforms.markdown
@@ -18,7 +18,7 @@ Linux
 -   Red Hat Enterprise Linux, version 4 and higher
 -   CentOS, version 4 and higher
 -   Scientific Linux, version 4 and higher
--   Oracle Enterprise Linux, version 4 and higher
+-   Oracle Linux, version 4 and higher
 -   Debian, version 5 (Lenny) and higher
 -   Ubuntu, version 8.04 LTS and higher
 -   Fedora, version 15 and higher
@@ -37,7 +37,7 @@ Other Unix
 ----------
 
 -   Mac OS X, version 10.4 (Tiger) and higher
--   Solaris, version 10 and higher
+-   Oracle Solaris, version 10 and higher
 -   AIX, version 5.3 and higher
 -   HP-UX
 

--- a/source/pe/1.1/index.markdown
+++ b/source/pe/1.1/index.markdown
@@ -24,7 +24,7 @@ This release of Puppet Enterprise supports the following operating system versio
 | CentOS                       | 4                         | x86 and x86\_64   | agent        |
 | Ubuntu LTS                   | 10.04                     | 32- and 64-bit    | master/agent |
 | Debian                       | Lenny (5) and Squeeze (6) | i386 and amd64    | master/agent |
-| Oracle Enterprise Linux      | 5                         | x86 and x86\_64   | master/agent |
+| Oracle Linux                 | 5                         | x86 and x86\_64   | master/agent |
 | SUSE Linux Enterprise Server | 11                        | x86 and x86\_864  | master/agent |
 | Solaris                      | 10                        | SPARC and x86\_64 | agent        |
 
@@ -372,7 +372,7 @@ For systems using apt and dpkg (Ubuntu and Debian), execute the following comman
 
 	apt-get install --fix-broken
 
-For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Enterprise Linux), execute the following commands: 
+For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Linux), execute the following commands: 
 
 	yum localinstall --nogpgcheck *ruby*dev* 
 

--- a/source/pe/1.2/installing.markdown
+++ b/source/pe/1.2/installing.markdown
@@ -40,9 +40,9 @@ Puppet Enterprise can be downloaded in tarballs specific to your OS version and 
 |-----------------------------------|---------------------------------------------------------------|
 | `-all.tar`                        | anywhere                                                      |
 | `-debian-<version and arch>.tar`  | on Debian                                                     |
-| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Enterprise Linux |
+| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Linux            |
 | `-sles-<version and arch>.tar`    | on SUSE Linux Enterprise Server                               |
-| `-solaris-<version and arch>.tar` | on Solaris                                                    | 
+| `-solaris-<version and arch>.tar` | on Solaris                                                    |
 | `-ubuntu-<version and arch>.tar`  | on Ubuntu LTS                                                 |
 
 Installing PE

--- a/source/pe/1.2/intro.markdown
+++ b/source/pe/1.2/intro.markdown
@@ -32,7 +32,7 @@ Puppet Enterprise 1.2 supports the following operating system versions:
 | CentOS                       | 4                         | x86 and x86\_64   | agent        |
 | Ubuntu LTS                   | 10.04                     | 32- and 64-bit    | master/agent |
 | Debian                       | Lenny (5) and Squeeze (6) | i386 and amd64    | master/agent |
-| Oracle Enterprise Linux      | 5 and 6                   | x86 and x86\_64   | master/agent |
+| Oracle Linux                 | 5 and 6                   | x86 and x86\_64   | master/agent |
 | Scientific Linux             | 5 and 6                   | x86 and x86\_864  | master/agent |
 | SUSE Linux Enterprise Server | 11                        | x86 and x86\_864  | master/agent |
 | Solaris                      | 10                        | SPARC and x86\_64 | agent        |

--- a/source/pe/1.2/upgrading.markdown
+++ b/source/pe/1.2/upgrading.markdown
@@ -35,9 +35,9 @@ Puppet Enterprise can be downloaded in tarballs specific to your OS version and 
 |-----------------------------------|---------------------------------------------------------------|
 | `-all.tar`                        | anywhere                                                      |
 | `-debian-<version and arch>.tar`  | on Debian                                                     |
-| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Enterprise Linux |
+| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Linux            |
 | `-sles-<version and arch>.tar`    | on SUSE Linux Enterprise Server                               |
-| `-solaris-<version and arch>.tar` | on Solaris                                                    | 
+| `-solaris-<version and arch>.tar` | on Solaris                                                    |
 | `-ubuntu-<version and arch>.tar`  | on Ubuntu LTS                                                 |
 
 Running the Upgrader

--- a/source/pe/1.2/using.markdown
+++ b/source/pe/1.2/using.markdown
@@ -103,7 +103,7 @@ For systems using apt and dpkg (Ubuntu and Debian), run the following commands:
 
 	apt-get install --fix-broken
 
-For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Enterprise Linux), run the following commands: 
+For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Linux), run the following commands: 
 
 	yum localinstall --nogpgcheck *ruby*dev* 
 

--- a/source/pe/2.0/install_preparing.markdown
+++ b/source/pe/2.0/install_preparing.markdown
@@ -55,8 +55,8 @@ Puppet Enterprise can be downloaded in tarballs specific to your OS version and 
 |-----------------------------------|---------------------------------------------------------------|
 | `-all.tar`                        | anywhere                                                      |
 | `-debian-<version and arch>.tar`  | on Debian                                                     |
-| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Enterprise Linux |
+| `-el-<version and arch>.tar`      | on RHEL, CentOS, Scientific Linux, or Oracle Linux            |
 | `-sles-<version and arch>.tar`    | on SUSE Linux Enterprise Server                               |
-| `-solaris-<version and arch>.tar` | on Solaris                                                    | 
+| `-solaris-<version and arch>.tar` | on Solaris                                                    |
 | `-ubuntu-<version and arch>.tar`  | on Ubuntu LTS                                                 |
 

--- a/source/pe/2.0/install_system_requirements.markdown
+++ b/source/pe/2.0/install_system_requirements.markdown
@@ -20,7 +20,7 @@ Puppet Enterprise 2.0 supports the following systems:
 | CentOS                       | 4                         | x86 and x86\_64   | agent     |
 | Ubuntu LTS                   | 10.04                     | 32- and 64-bit    | all roles |
 | Debian                       | Lenny (5) and Squeeze (6) | i386 and amd64    | all roles |
-| Oracle Enterprise Linux      | 5 and 6                   | x86 and x86\_64   | all roles |
+| Oracle Linux                 | 5 and 6                   | x86 and x86\_64   | all roles |
 | Scientific Linux             | 5 and 6                   | x86 and x86\_864  | all roles |
 | SUSE Linux Enterprise Server | 11                        | x86 and x86\_864  | all roles |
 | Solaris                      | 10                        | SPARC and x86\_64 | agent     |

--- a/source/pe/2.0/maint_installing_additional.markdown
+++ b/source/pe/2.0/maint_installing_additional.markdown
@@ -28,7 +28,7 @@ For systems using apt and dpkg (Ubuntu and Debian), run the following commands:
 
 	$ sudo apt-get install --fix-broken
 
-For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Enterprise Linux), run the following commands: 
+For systems using rpm and yum (Red Hat Enterprise Linux, CentOS, and Oracle Linux), run the following commands: 
 
 	$ sudo yum localinstall --nogpgcheck *ruby*dev* 
 


### PR DESCRIPTION
Change some instances of Oracle product names in the documentation. The
OEL to OL ones were done everywhere, the Solaris ones were just done on
the platforms page.
