### PR TITLE
(#12728) remove stray \ in style guide

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -688,7 +688,7 @@ For example:
 
       include ntp::params
 
-      $server\_real = $server ? {
+      $server_real = $server ? {
         'UNSET' => $::ntp::params::server,
         default => $server,
       }


### PR DESCRIPTION
fix typo in the style guide
