### PR TITLE
fixed typo in dashboard console and rake api pages

### DIFF
--- a/source/dashboard/manual/1.2/rake_api.markdown
+++ b/source/dashboard/manual/1.2/rake_api.markdown
@@ -62,7 +62,7 @@ All of these tasks should be run as follows, replacing `<TASK>` with the task na
 ### Group Tasks
 
 `nodegroup:list [match=<REGULAR EXPRESSION>]`
-: List node groups. Can optionally match gorups by regex.
+: List node groups. Can optionally match groups by regex.
 
 `nodegroup:add name=<NAME> [classes=<CLASSES>]`
 : Create a new node group. Classes can be specified as a comma-separated list.

--- a/source/pe/2.0/console_classes_groups.markdown
+++ b/source/pe/2.0/console_classes_groups.markdown
@@ -144,7 +144,7 @@ All of these tasks should be run as follows, replacing `<TASK>` with the task na
 ### Group Tasks
 
 `nodegroup:list [match=<REGULAR EXPRESSION>]`
-: List node groups. Can optionally match gorups by regex.
+: List node groups. Can optionally match groups by regex.
 
 `nodegroup:add name=<NAME> [classes=<CLASSES>]`
 : Create a new node group. Classes can be specified as a comma-separated list.


### PR DESCRIPTION
changed 'gropus' to 'groups' in

```
modified:   source/dashboard/manual/1.2/rake_api.markdown
modified:   source/pe/2.0/console_classes_groups.markdown
```
