### PR TITLE
Adding :: variable scope before facter variables in the learning docs.

### DIFF
--- a/source/learning/definedtypes.markdown
+++ b/source/learning/definedtypes.markdown
@@ -185,7 +185,7 @@ Not that my .plan macro wasn't pretty great, but let's be serious for a minute. 
       } else {
         $srvname = $servername
       }
-      case $operatingsystem {
+      case $::operatingsystem {
         'centos', 'redhat', 'fedora': { $vdir   = '/etc/httpd/conf.d'
                                         $logdir = '/var/log/httpd'}
         'ubuntu', 'debian':           { $vdir   = '/etc/apache2/sites-enabled'

--- a/source/learning/modules1.markdown
+++ b/source/learning/modules1.markdown
@@ -53,7 +53,7 @@ Well, hey: you have a block of code hanging around from last chapter's exercises
     # ntp-class1.pp
     
     class ntp {
-      case $operatingsystem {
+      case $::operatingsystem {
         centos, redhat: { 
           $service_name = 'ntpd'
           $conf_file    = 'ntp.conf.el'
@@ -92,7 +92,7 @@ Class names have to start with a lowercase letter, and can contain lowercase alp
 
 Class names can also use a double colon (`::`) as a namespace separator. (Yes, this should [look familiar](./variables.html#variables).) This is a good way to show which classes are related to each other; for example, you can tell right away that something's going on between `apache::ssl` and `apache::vhost`. This will become more important about [two feet south of here][manifestsdir]. 
 
-Also, class definitions introduce new variable scopes. That means any variables you assign within won't be accessible by their short names outside the class; to get at them from elsewhere, you would have to use the fully-qualified name (e.g. `$apache::ssl::certificate_expiration`). It also means you can localize --- mask --- variable short names in use outside the class; if you assign a `$fqdn` variable in a class, you would get the new value instead of the value of the Facter-supplied variable, unless you used the fully-qualified fact name (`$::fqdn`). 
+Also, class definitions introduce new variable scopes. That means any variables you assign within won't be accessible by their short names outside the class; to get at them from elsewhere, you would have to use the fully-qualified name (e.g. `$apache::ssl::certificate_expiration`). It also means you can localize --- mask --- variable short names in use outside the class; if you assign a `$::fqdn` variable in a class, you would get the new value instead of the value of the Facter-supplied variable, unless you used the fully-qualified fact name (`$::fqdn`). 
 
 ### Declaring
 
@@ -109,7 +109,7 @@ You actually already know the syntax to do that. A class definition just enables
     # ntp-class1.pp
     
     class ntp {
-      case $operatingsystem {
+      case $::operatingsystem {
         centos, redhat: { 
           $service_name = 'ntpd'
           $conf_file    = 'ntp.conf.el'
@@ -199,7 +199,7 @@ Modules are re-usable bundles of code and data. Puppet autoloads manifests from 
     # init.pp
     
     class ntp {
-      case $operatingsystem {
+      case $::operatingsystem {
         centos, redhat: { 
           $service_name = 'ntpd'
           $conf_file    = 'ntp.conf.el'

--- a/source/learning/modules2.markdown
+++ b/source/learning/modules2.markdown
@@ -124,7 +124,7 @@ And making that work right is almost as easy as the last edit. Here's the comple
 {% highlight ruby %}
     #/etc/puppetlabs/puppet/modules/ntp/manifests/init.pp
     class ntp ($servers = undef, $enable = true, $ensure = running) {
-      case $operatingsystem {
+      case $::operatingsystem {
         centos, redhat: { 
           $service_name    = 'ntpd'
           $conf_template   = 'ntp.conf.el.erb'
@@ -207,7 +207,7 @@ Module Documentation
     #   }
     #
     class ntp ($servers = undef, $enable = true, $ensure = running) {
-      case $operatingsystem { ...
+      case $::operatingsystem { ...
       ...
 {% endhighlight %}
 

--- a/source/learning/templates.markdown
+++ b/source/learning/templates.markdown
@@ -121,7 +121,7 @@ First, we'll change the `init.pp` manifest:
     # init.pp
     
     class ntp {
-      case $operatingsystem {
+      case $::operatingsystem {
         centos, redhat: { 
           $service_name    = 'ntpd'
           $conf_template   = 'ntp.conf.el.erb'

--- a/source/learning/variables.markdown
+++ b/source/learning/variables.markdown
@@ -161,7 +161,7 @@ Conditions can get pretty sophisticated: you can use any valid [expression][] in
 Also probably familiar: the case statement. (Or switch, or whatever your language of choice calls it.) 
 
 {% highlight ruby %}
-    case $operatingsystem {
+    case $::operatingsystem {
       centos: { $apache = "httpd" }
       # Note that these matches are case-insensitive.
       redhat: { $apache = "httpd" }
@@ -187,7 +187,7 @@ String matching is case-insensitive, like the `==` comparison operator. Regular 
 Here's a regex example:
 
 {% highlight ruby %}
-    case $ipaddress_eth0 {
+    case $::ipaddress_eth0 {
       /^127[\d.]+$/: { 
         notify {'misconfig': 
           message => "Possible network misconfiguration: IP address of $0",
@@ -199,7 +199,7 @@ Here's a regex example:
 And here's the example from above, rewritten and more readable:
 
 {% highlight ruby %}
-    case $operatingsystem {
+    case $::operatingsystem {
       centos, redhat: { $apache = "httpd" }
       debian, ubuntu: { $apache = "apache2" }
       default: { fail("Unrecognized operating system for webserver") }
@@ -213,7 +213,7 @@ Selectors might be less familiar; they're kind of like the [ternary operator](ht
 Instead of choosing between a set of code blocks, selectors choose between a group of possible values. You can't use them on their own; instead, they're usually used to assign a variable. 
 
 {% highlight ruby %}
-    $apache = $operatingsystem ? {
+    $apache = $::operatingsystem ? {
       centos                => 'httpd',
       redhat                => 'httpd',
       /(?i)(ubuntu|debian)/ => "apache2-$1",
@@ -222,7 +222,7 @@ Instead of choosing between a set of code blocks, selectors choose between a gro
     }
 {% endhighlight %}
 
-Careful of the syntax, there: it looks kind of like we're saying `$apache = $operatingsystem`, but we're not. The question mark flags `$operatingsystem` as the pivot of a selector, and the actual value that gets assigned is determined by which option `$operatingsystem` matches. Also note how the syntax differs from the case syntax: it uses hash rockets and line-end commas instead of colons and blocks, and you can't use lists of values in a match. (If you want to match against a list, you have to fake it with a regular expression.)
+Careful of the syntax, there: it looks kind of like we're saying `$apache = $::operatingsystem`, but we're not. The question mark flags `$::operatingsystem` as the pivot of a selector, and the actual value that gets assigned is determined by which option `$::operatingsystem` matches. Also note how the syntax differs from the case syntax: it uses hash rockets and line-end commas instead of colons and blocks, and you can't use lists of values in a match. (If you want to match against a list, you have to fake it with a regular expression.)
 
 It can look a little awkward, but there are plenty of situations where it's the most concise way to get a value sorted out; if you're ever not comfortable with it, you can just use a case statement to assign the variable instead. 
 
@@ -231,7 +231,7 @@ Selectors can also be used directly as values for a resource attribute, but try 
 Exercises
 ---------
 
-> **Exercise:** Use the $operatingsystem fact to write a manifest that installs a build environment on Debian-based ("debian" and "ubuntu") and Enterprise Linux-based ("centos," "redhat") machines. (Both types of system require the `gcc` package, but Debian-type systems also require `build-essential`.)
+> **Exercise:** Use the $::operatingsystem fact to write a manifest that installs a build environment on Debian-based ("debian" and "ubuntu") and Enterprise Linux-based ("centos," "redhat") machines. (Both types of system require the `gcc` package, but Debian-type systems also require `build-essential`.)
 
 > **Exercise:** Write a manifest that installs and configures NTP for Debian-based and Enterprise Linux-based Linux systems. This will be a package/file/service pattern where you'll be shipping different config files ([Debian version](./files/ntp/files/ntp.conf.debian), [Red Hat version](./files/ntp/files/ntp.conf.el) --- remember the `file` type's "source" attribute) and using different service names (`ntp` and `ntpd`, respectively).
 > 


### PR DESCRIPTION
Added :: before varaiable such as  throughout the learning docs.

The learning docs recommend that you fully qualify the facter variables but don't always do that.

I think this patch corrects all of those in the learning docs.
