### PR TITLE
Maint: Fix broken links

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -109,9 +109,9 @@
               <li class="page_item page-item-783"><a href="http://www.puppetlabs.com/services/overview/" title="Overview">Overview</a></li>
 <li class="page_item page-item-839"><a href="http://www.puppetlabs.com/services/support/" title="Enterprise Support">Enterprise Support</a></li>
 <li class="page_item page-item-845"><a href="http://www.puppetlabs.com/services/training-workshops/" title="On-Site Training &amp; Consulting">On-Site Training &amp; Consulting</a></li>
-<li class="page_item page-item-849"><a href="/category/events/upcoming/" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
+<li class="page_item page-item-849"><a href="http://www.puppetlabs.com/category/events/upcoming/" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
 <li class="page_item page-item-851"><a href="http://www.puppetlabs.com/services/partners/" title="Partners">Partners</a></li>
-<li class="page_item page-item-1037"><a href="/resources/customer-support" title="Customer Support">Customer Support</a></li>
+<li class="page_item page-item-1037"><a href="http://www.puppetlabs.com/resources/customer-support" title="Customer Support">Customer Support</a></li>
             </ul>
           </li>
           <li id="resources-tab" class="with-submenu">

--- a/source/_layouts/frontpage.html
+++ b/source/_layouts/frontpage.html
@@ -110,9 +110,9 @@
               <li class="page_item page-item-783"><a href="http://www.puppetlabs.com/services/overview/" title="Overview">Overview</a></li>
 <li class="page_item page-item-839"><a href="http://www.puppetlabs.com/services/support/" title="Enterprise Support">Enterprise Support</a></li>
 <li class="page_item page-item-845"><a href="http://www.puppetlabs.com/services/training-workshops/" title="On-Site Training &amp; Consulting">On-Site Training &amp; Consulting</a></li>
-<li class="page_item page-item-849"><a href="/category/events/upcoming/" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
+<li class="page_item page-item-849"><a href="http://www.puppetlabs.com/category/events/upcoming/" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
 <li class="page_item page-item-851"><a href="http://www.puppetlabs.com/services/partners/" title="Partners">Partners</a></li>
-<li class="page_item page-item-1037"><a href="/resources/customer-support" title="Customer Support">Customer Support</a></li>
+<li class="page_item page-item-1037"><a href="http://www.puppetlabs.com/resources/customer-support" title="Customer Support">Customer Support</a></li>
             </ul>
           </li>
           <li id="resources-tab" class="with-submenu">

--- a/source/_layouts/pe2experimental.html
+++ b/source/_layouts/pe2experimental.html
@@ -111,9 +111,9 @@
               <li class="page_item page-item-783"><a href="http://www.puppetlabs.com/services/overview/" title="Overview">Overview</a></li>
 <li class="page_item page-item-839"><a href="http://www.puppetlabs.com/services/support/" title="Enterprise Support">Enterprise Support</a></li>
 <li class="page_item page-item-845"><a href="http://www.puppetlabs.com/services/training-workshops/" title="On-Site Training &amp; Consulting">On-Site Training &amp; Consulting</a></li>
-<li class="page_item page-item-849"><a href="/category/events/upcoming/" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
+<li class="page_item page-item-849"><a href="http://www.puppetlabs.com/category/events/upcoming" title="Events &amp; Public Training">Events &amp; Public Training</a></li>
 <li class="page_item page-item-851"><a href="http://www.puppetlabs.com/services/partners/" title="Partners">Partners</a></li>
-<li class="page_item page-item-1037"><a href="/resources/customer-support" title="Customer Support">Customer Support</a></li>
+<li class="page_item page-item-1037"><a href="http://www.puppetlabs.com/resources/customer-support" title="Customer Support">Customer Support</a></li>
             </ul>
           </li>
           <li id="resources-tab" class="with-submenu">


### PR DESCRIPTION
If you are on the docs.puppetlabs.com site, then selecting Service >
Events & Training or Customer Supports gives a 404. Referencing these
pages from www.puppetlabs.com gives the desired result.
