### PR TITLE
New module face will be in Puppet 2.7.14, not 2.7.12.

### DIFF
--- a/source/puppet/2.7/reference/modules_installing.markdown
+++ b/source/puppet/2.7/reference/modules_installing.markdown
@@ -15,7 +15,7 @@ title: "Installing Modules"
 Installing Modules
 =====
 
-<span class="versionnote">This reference applies to Puppet 2.7.12 and later and Puppet Enterprise 2.5 and later. Earlier versions will not behave identically.</span>
+<span class="versionnote">This reference applies to Puppet 2.7.14 and later and Puppet Enterprise 2.5 and later. Earlier versions will not behave identically.</span>
 
 > ![Windows note](/images/windows-logo-small.jpg) The puppet module tool does not currently work on Windows.
 > 


### PR DESCRIPTION
The installation doc on modules references 2.7.12 as the release when the puppet module face changes are released, when it will be in 2.7.14.
