### PR TITLE
Now that el4 is EOL, Ruby 1.8.1 should no longer be listed as supported ...

### DIFF
--- a/source/guides/faq.markdown
+++ b/source/guides/faq.markdown
@@ -244,8 +244,6 @@ at [Puppet Labs' Github page](https://github.com/puppetlabs/puppet).
 
 Ruby 1.8.5 and 1.8.7 work with all Puppet versions, and are supported with full automated testing for 2.6 and 2.7 releases. Starting with Puppet 2.7, Puppet Labs is also supporting Ruby 1.9.2 and higher, although Puppet 2.7.0 has a handful of known issues under Ruby 1.9.
 
-Ruby 1.8.1 is supported for agent use only on a best-effort basis under Puppet 2.6 and 2.7; we do not cover 1.8.1 with our automated testing.
-
 Although Puppet has been known to work with other Ruby versions, Puppet Labs does not test these versions. Puppet has significant known compatibility issues under Ruby 1.8.6, 1.9.0, and 1.9.1; these versions are not recommended.
 
 Upgrading


### PR DESCRIPTION
...(even best effort) for Puppet.
