### PR TITLE
Update forge URL in Enterprise 2.5 Quick Start

### DIFF
--- a/source/pe/2.5/quick_start.markdown
+++ b/source/pe/2.5/quick_start.markdown
@@ -214,7 +214,7 @@ Installing a Puppet Module
 
 Puppet configures nodes by applying classes to them. Classes are chunks of Puppet code that configure a specific aspect or feature of a machine.
 
-Puppet classes are **distributed in the form of modules.** You can save time by **using pre-existing modules.** Pre-existing modules are distributed on the [Puppet Forge](http://forge.puppet.com), and **can be installed with the `puppet module` subcommand.** Any module installed on the puppet master can be used to configure agent nodes.
+Puppet classes are **distributed in the form of modules.** You can save time by **using pre-existing modules.** Pre-existing modules are distributed on the [Puppet Forge](http://forge.puppetlabs.com), and **can be installed with the `puppet module` subcommand.** Any module installed on the puppet master can be used to configure agent nodes.
 
 ### Installing two Forge Modules
 


### PR DESCRIPTION
Roughly line 217 Forge URL in hyperlink is currently forge.puppet.com.  Modified it to be the correct forge.puppetlabs.com
