### PR TITLE
Removed 80 character limit from style_guide.

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -89,7 +89,6 @@ Module manifests complying with this style guide:
 * Must use two-space soft tabs
 * Must not use literal tab characters
 * Must not contain trailing white space
-* Should not exceed an 80 character line width
 * Should align fat comma arrows (`=>`) within blocks of attributes
 
 ## 7. Comments


### PR DESCRIPTION
Found that an 80 character line limit for style is not realistic so
  we are removing it.
