### PR TITLE
The installation instructions for debian/ubuntu via puppetlabs repo don't work

### DIFF
--- a/source/guides/installation.markdown
+++ b/source/guides/installation.markdown
@@ -4,7 +4,7 @@ title: Installing Puppet
 ---
 
 {% capture yum5package %}http://yum.puppetlabs.com/el/5/products/i386/puppetlabs-release-5-1.noarch.rpm{% endcapture %}
-{% capture aptpackage %}http://apt.puppetlabs.com/puppetlabs-release_1.0-2_all.deb{% endcapture %}
+{% capture aptpackage %}http://apt.puppetlabs.com/puppetlabs-release_1.0-3_all.deb{% endcapture %}
 {% capture yum6package %}http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-1.noarch.rpm{% endcapture %}
 {% capture yumf16package %}http://yum.puppetlabs.com/fedora/f16/products/i386/puppetlabs-release-16-1.noarch.rpm{% endcapture %}
 {% capture yumf15package %}http://yum.puppetlabs.com/fedora/f15/products/i386/puppetlabs-release-15-1.noarch.rpm{% endcapture %}
@@ -170,7 +170,7 @@ Puppet Labs provides an official package repo at [apt.puppetlabs.com](http://apt
 To enable the Puppet Labs repo, run the following commands on all of your target systems:
 
     $ wget {{ aptpackage }}
-    $ sudo dpkg -i puppetlabs-release_1.0-2_all.deb
+    $ sudo dpkg -i puppetlabs-release_1.0-3_all.deb
 
 ##### Using Vendor Packages
 


### PR DESCRIPTION
The debian package for registering the puppetlabs debian repository is 404.
The attached commit fixes this.
