### PR TITLE
(#15156) Add pluginsync info for Augeas lenses

### DIFF
--- a/source/guides/plugins_in_modules.markdown
+++ b/source/guides/plugins_in_modules.markdown
@@ -42,6 +42,8 @@ In Puppet version 0.25.x and later, plugins are stored in the `lib` directory of
     {modulepath}
     └── {module}
         └── lib
+            |── augeas
+            │   └── lenses
             ├── facter
             └── puppet
                 ├── parser
@@ -72,6 +74,10 @@ A custom type for bare Git repositories:
 A custom fact for the root of all home directories (that is, `/home` on Linux, `/Users` on Mac OS X, etc.): 
 
     {modulepath}/{module}/lib/facter/homeroot.rb
+
+A custom Augeas lens:
+
+    {modulepath}/{module}/lib/augeas/lenses/custom.aug
 
 And so on. 
 


### PR DESCRIPTION
Since #13379, Augeas lenses can be loaded from a pluginsync directory, so
document where this is.
