### PR TITLE
puppet node_aws terminate example

### DIFF
--- a/source/guides/cloud_pack_getting_started.markdown
+++ b/source/guides/cloud_pack_getting_started.markdown
@@ -311,7 +311,7 @@ Options:
 
 Example:
 
-    puppet node_aws terminate init ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com
+    puppet node_aws terminate ec2-XXX-XXX-XXX-XX.compute-1.amazonaws.com
 
 Tear down an EC2 machine instance.
 


### PR DESCRIPTION
There was a "init" argument in there that probably came from a copy-paste. I haven't tested this yet but the fix makes sense. If it's not right, then something else is probably wrong in the documentation :)
