### PR TITLE
(#11396) Namespace references to $operatingsystem

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -627,8 +627,19 @@ In summary:
 ### 11.6. Namespacing Variables
 
 When using top-scope variables, including facts, Puppet modules should
-explicitly specify the empty namespace (i.e., `$::operatingsystem`, not
-`$operatingsystem`) to prevent accidental scoping issues.
+explicitly specify the empty namespace to prevent accidental scoping issues.
+
+**Good:**
+
+{% highlight ruby %}
+    $::operatingsystem
+{% endhighlight %}
+
+**Bad:**
+
+{% highlight ruby %}
+    $operatingsystem
+{% endhighlight %}
 
 ### 11.7. Variable format
 


### PR DESCRIPTION
These examples refer to a Facter variable and should specify the empty
namespace in order to comply with section 11.6
## 

I have reformatted 11.6 in a separate commit to use code blocks in the same style as the other sections.
