### PR TITLE
(#15756) Call functions with arrays

### DIFF
--- a/source/guides/templating.markdown
+++ b/source/guides/templating.markdown
@@ -189,7 +189,7 @@ Variables defined in the current scope are available as entries in the hash retu
 
 Puppet functions can be called by prepending "`function_`" to the beginning of the function name. For example, including one template inside another:
 
-    <%= scope.function_template("my_module/template2.erb") %>
+    <%= scope.function_template(["my_module/template2.erb"]) %>
 
 ## Syntax Checking
 


### PR DESCRIPTION
Functions must be called with arrays of arguments, even when only one 
argument is passed. This incorrect example has led users astray.
