### PR TITLE
Update package repository guide

### DIFF
--- a/source/guides/puppetlabs_package_repositories.markdown
+++ b/source/guides/puppetlabs_package_repositories.markdown
@@ -5,7 +5,7 @@ layout: legacy
 
 [peinstall]: /pe/2.5/install_basic.html
 
-Puppet Labs maintains official package repositories for several of the more popular Linux distributions. These repos contain the latest available packages for Puppet, Facter, PuppetDB, Puppet Dashboard, MCollective, and several prerequisites and add-ons for Puppet Labs products. 
+Puppet Labs maintains official package repositories for several of the more popular Linux distributions. These repos contain the latest available packages for Puppet, Facter, PuppetDB, Puppet Dashboard, MCollective, and several prerequisites and add-ons for Puppet Labs products.
 
 We also maintain repositories for Puppet Enterprise users. These repos contain additional PE components, as well as modified packages for tools like PuppetDB which will integrate more smoothly with PE's namespaced installation layout.
 
@@ -24,32 +24,33 @@ To enable the repository, run the command below that corresponds to your OS vers
 
 #### Enterprise Linux 5
 
-    $ sudo rpm -ivh http://yum.puppetlabs.com/el/5/products/i386/puppetlabs-release-5-5.noarch.rpm
+    $ sudo rpm -ivh http://yum.puppetlabs.com/el/5/products/i386/puppetlabs-release-5-6.noarch.rpm
 
 #### Enterprise Linux 6
 
-    $ sudo rpm -ivh http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-5.noarch.rpm
+    $ sudo rpm -ivh http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-6.noarch.rpm
 
 ### For Debian and Ubuntu
 
 The [apt.puppetlabs.com](http://apt.puppetlabs.com) repository supports the following OS versions:
 
-* Debian 6 "Squeeze" (current stable release)
+* Debian 6 "Squeeze" (current stable release) (also supported by [Puppet Enterprise][peinstall])
 * Debian 5 "Lenny" (previous stable release)
 * Debian "Wheezy" (current testing distribution)
 * Debian "Sid" (current unstable distribution)
-* Ubuntu 12.04 LTS "Precise Pangolin"
+* Ubuntu 12.04 LTS "Precise Pangolin" (also supported by [Puppet Enterprise][peinstall])
 * Ubuntu 10.04 LTS "Lucid Lynx" (also supported by [Puppet Enterprise][peinstall])
 * Ubuntu 8.04 LTS "Hardy Heron"
+* Ubuntu 12.10 "Quantal Quetzal"
 * Ubuntu 11.10 "Oneiric Ocelot"
 * Ubuntu 11.04 "Natty Narwhal"
 * Ubuntu 10.10 "Maverick Meerkat"
 
 To enable the repository:
 
-1. Download the "puppetlabs-release" package for your OS version. 
+1. Download the "puppetlabs-release" package for your OS version.
     * You can see a full list of these packages on the front page of <http://apt.puppetlabs.com/>. They are all named `puppetlabs-release-<CODE NAME>.deb`.
-2. Install the package by running `dpkg -i <PACKAGE NAME>`. 
+2. Install the package by running `dpkg -i <PACKAGE NAME>`.
 
 For example, to enable the repository for Ubuntu 12.04 Precise Pangolin:
 
@@ -59,15 +60,19 @@ For example, to enable the repository for Ubuntu 12.04 Precise Pangolin:
 
 ### For Fedora
 
-The [yum.puppetlabs.com](http://yum.puppetlabs.com) repository supports Fedora 15 and 16. To enable the repository, run the command below that corresponds to your OS version:
+The [yum.puppetlabs.com](http://yum.puppetlabs.com) repository supports Fedora 15, 16 and 17. To enable the repository, run the command below that corresponds to your OS version:
 
 #### Fedora 15
 
-    $ sudo rpm -ivh http://yum.puppetlabs.com/fedora/f15/products/i386/puppetlabs-release-15-5.noarch.rpm
+    $ sudo rpm -ivh http://yum.puppetlabs.com/fedora/f15/products/i386/puppetlabs-release-15-6.noarch.rpm
 
 #### Fedora 16
 
-    $ sudo rpm -ivh http://yum.puppetlabs.com/fedora/f16/products/i386/puppetlabs-release-16-5.noarch.rpm
+    $ sudo rpm -ivh http://yum.puppetlabs.com/fedora/f16/products/i386/puppetlabs-release-16-6.noarch.rpm
+
+#### Fedora 17
+
+    $ sudo rpm -ivh http://yum.puppetlabs.com/fedora/f17/products/i386/puppetlabs-release-17-6.noarch.rpm
 
 Puppet Enterprise Repositories
 -----


### PR DESCRIPTION
This commit updates the package_repository guide for updates to the release
packages. It also adds quantal to the list of packaged ubuntu releases and adds
fedora 17 to the list of packaged fedora releases. It also marks Precise and
Squeeze as supported by Puppet Enterprise.
