### PR TITLE
(#16676) Remove references to partial-line comments working

### DIFF
--- a/source/guides/configuring.markdown
+++ b/source/guides/configuring.markdown
@@ -73,7 +73,7 @@ On Windows, Puppet Enterprise and open source Puppet use the same confdir.
 
 ### File Format
 
-`puppet.conf` uses an INI-like format, with `[config blocks]` containing indented groups of `setting = value` lines. Comment lines `# start with an octothorpe`; partial-line comments are not allowed in versions prior to 2.7.3, due to a known bug. 
+`puppet.conf` uses an INI-like format, with `[config blocks]` containing indented groups of `setting = value` lines.  Comment lines `# start with an octothorpe`; partial-line comments are not allowed.
 
 You can interpolate the value of a setting by using its name as a `$variable`. (Note that `$environment` has special behavior: most of the Puppet applications will interpolate their own environment, but puppet master will use the environment of the agent node it is serving.)
 


### PR DESCRIPTION
The description of partial-line comments in puppet.conf as
working in puppet version >= 2.7.3 is inaccurate. They were
fixed for the _other_ puppet config file parsers with #6026,
but not puppet.conf.

This change has a corresponding patch to the `--genconfig`
output for puppet itself, in http://git.io/WNItBw
