### PR TITLE
Broken link fix

### DIFF
--- a/source/dashboard/manual/1.2/bootstrapping.markdown
+++ b/source/dashboard/manual/1.2/bootstrapping.markdown
@@ -289,7 +289,7 @@ Puppet 0.25.x lacks the `http` report handler, so you'll need to do a few extra 
 
 You can use Dashboard's external node classifier (ENC) alongside traditional Puppet DSL node definitions. However, if you use your own custom ENC (or LDAP nodes), you won't be able to use Dashboard's ENC.
 
-To use Dashboard's ENC, you'll need to set the puppet master's `node_terminus` and `external_nodes` settings, and make sure the master can access Dashboard's node classification script, which is located at `bin/external_nodes`. This script's behavior can be overridden by setting environment variables; unless you're [serving Dashboard over HTTPS][https], the only one you'll need to set is `PUPPET_DASHBOARD_URL`.
+To use Dashboard's ENC, you'll need to set the puppet master's `node_terminus` and `external_nodes` settings, and make sure the master can access Dashboard's node classification script, which is located at `bin/external_nodes`. This script's behavior can be overridden by setting environment variables; unless you're [serving Dashboard over HTTPS](http://docs.puppetlabs.com/dashboard/manual/1.2/configuring.html#security), the only one you'll need to set is `PUPPET_DASHBOARD_URL`.
 
     # puppet.conf (on puppet master)
     [master]


### PR DESCRIPTION
Fixed a broken link. It was specifying localhost:9292 instead of docs.puppetlabs.com for the domain.
