### PR TITLE
Describe dependency options for Modulefile

### DIFF
--- a/source/puppet/2.7/reference/modules_publishing.markdown
+++ b/source/puppet/2.7/reference/modules_publishing.markdown
@@ -107,6 +107,31 @@ Modulefiles support the following pieces of metadata:
 * `author` --- The module's author. If not provided, this field will default to the username portion of the module's `name` field.
 * `source` --- The module's source. This field's purpose is not specified.
 
+Dependancies in the Modulefile
+-----
+
+If you choose to rely on another Forge module, you can express this in the 'dependency' field of your Modulefile. The following is a list of operators that can be used like in the following complete example.
+
+`dependency 'puppetlabs/stdlib', '>= 2.2.1'`
+
+### Operators
+### `>1.2.3` (Greater than a specific version.)
+### `<1.2.3` (Less than a specific version.)
+### `>=1.2.3` (Greater than or equal to a specific version.)
+### `<=1.2.3` (Less than or equal to a specific version.)
+### `>=1.0.0 <2.0.0` (Range of versions)
+### `1.2.3` (A specific version.)
+### `1.x` (A semantic major version.)
+Example. 1.0.1 but _not_ 2.0.1. It's also shorthand for `>=1.0.0 <2.0.0`.
+### `1.2.x` (A semantic major & minor version.)
+Example. 1.2.3 but not 1.3.0. It's also shorthand for `>=1.2.0 <1.3.0`.
+
+> ### A Note on Semantic Versioning
+-----
+> When building your Modulefile, you're setting both a module version and optionally expressing dependancies on others module versions. Following the [Semantic Versioning](http://semver.org/spec/v1.0.0.html) specification is strongly recommended. Doing so not only provides a contract to others that might use your module but provides a way for you to rely on others modules without unexpected change.
+
+> For example, if you depend on puppetlabs-stdlib but want to protect against breaking changes, you could write the following line in your Modulefile (assuming the current module version of 2.2.1).  
+> `dependency 'puppetlabs/stdlib', '2.x'`
 
 Build Your Module
 ------

--- a/source/puppet/3/reference/modules_publishing.markdown
+++ b/source/puppet/3/reference/modules_publishing.markdown
@@ -107,6 +107,32 @@ Modulefiles support the following pieces of metadata:
 * `author` --- The module's author. If not provided, this field will default to the username portion of the module's `name` field.
 * `source` --- The module's source. This field's purpose is not specified.
 
+Dependancies in the Modulefile
+-----
+
+If you choose to rely on another Forge module, you can express this in the 'dependency' field of your Modulefile. The following is a list of operators that can be used like in the following complete example.
+
+`dependency 'puppetlabs/stdlib', '>= 2.2.1'`
+
+### Operators
+### `>1.2.3` (Greater than a specific version.)
+### `<1.2.3` (Less than a specific version.)
+### `>=1.2.3` (Greater than or equal to a specific version.)
+### `<=1.2.3` (Less than or equal to a specific version.)
+### `>=1.0.0 <2.0.0` (Range of versions)
+### `1.2.3` (A specific version.)
+### `1.x` (A semantic major version.)
+Example. 1.0.1 but _not_ 2.0.1. It's also shorthand for `>=1.0.0 <2.0.0`.
+### `1.2.x` (A semantic major & minor version.)
+Example. 1.2.3 but not 1.3.0. It's also shorthand for `>=1.2.0 <1.3.0`.
+
+> ### A Note on Semantic Versioning
+-----
+> When building your Modulefile, you're setting both a module version and optionally expressing dependancies on others module versions. Following the [Semantic Versioning](http://semver.org/spec/v1.0.0.html) specification is strongly recommended. Doing so not only provides a contract to others that might use your module but provides a way for you to rely on others modules without unexpected change.
+
+> For example, if you depend on puppetlabs-stdlib but want to protect against breaking changes, you could write the following line in your Modulefile (assuming the current module version of 2.2.1).  
+> `dependency 'puppetlabs/stdlib', '2.x'`
+
 
 Build Your Module
 ------


### PR DESCRIPTION
NOT for merging by anyone but the Puppet Labs Docs Team. 

Docs Team, 

Though we've supported these concepts in PMT since 2.7.14, they've gone largely undocumented. Of particular note are the expressions for pinning to a Semantic versioning promise, like 2.x. 

I tried to stay consistent with style as best I could, but please feel free to muck with it or make suggestions as you see fit. 

---

Prior to this commit, the modules_publishing document in the Puppet
reference guide only provided a simple example on how to construct
a dependency on another module in ones Modulefile.

This commit improves the situation by adding a list of valid
operaters, some associated descriptive text and a note on why one
should use semantic versioning for both their modules version and
when expressing dependencies on other modules. It attempt to adhere
to the style found in modules_publishing as well as in lang_expressions.

Support for this content has been in the PMT since Puppet 2.7.14.

Reference Content:
[Puppet Source Spec Tests](https://github.com/puppetlabs/puppet/blob/master/spec/unit/semver_spec.rb)
[npmjs.org](https://npmjs.org/doc/semver.html#Ranges)
[semver.org](http://semver.org/spec/v1.0.0.html)
[Pieter van de Bruggen](human://puppet-forge.engineer)
