### PR TITLE
fixed unused variable in First Function example

### DIFF
--- a/source/guides/custom_functions.markdown
+++ b/source/guides/custom_functions.markdown
@@ -65,7 +65,7 @@ might look like this:
       newfunction(:write_line_to_file) do |args|
         filename = args[0]
         str = args[1]
-        File.open(args[0], 'a') {|fd| fd.puts str }
+        File.open(filename, 'a') {|fd| fd.puts str }
       end
     end
 {% endhighlight %}


### PR DESCRIPTION
filename was assigned the value args[0], but afterwards args[0] was still used directly. I changed it to filename.
