### PR TITLE
(#18060) adds RAILS_ENV to demontrations rake

### DIFF
--- a/source/pe/2.7/console_classes_groups.markdown
+++ b/source/pe/2.7/console_classes_groups.markdown
@@ -105,7 +105,7 @@ The console provides rake tasks that can group nodes, create classes, and assign
 
 All of these tasks should be run as follows, replacing `<TASK>` with the task name and any arguments it requires:
 
-    $ sudo /opt/puppet/bin/rake -f /opt/puppet/share/puppet-dashboard/Rakefile <TASK>
+    $ sudo /opt/puppet/bin/rake -f /opt/puppet/share/puppet-dashboard/Rakefile RAILS_ENV=production <TASK>
 
 ### Node Tasks
 


### PR DESCRIPTION
adds RAILS_ENV=production to demo command line call for a rake task

previous documentation omitted this information and confused first time
ruby/rake folks who were just experimenting with the console commands.
