### PR TITLE
(#13968) Improves list of illegal char for install

### DIFF
--- a/source/pe/2.7/install_basic.markdown
+++ b/source/pe/2.7/install_basic.markdown
@@ -160,7 +160,7 @@ If the installer detects another web server on the node, it will suggest the fir
 
 Access to the console's web interface is [limited to approved users and governed by a lightweight system of roles](./console_auth.html). During installation, you must create an initial admin user for the console by providing an email address and password. 
 
-The only forbidden characters for a console password are `\` (backslash), `'` (single quote), and `$` (dollar sign).
+The only forbidden characters for a console password are `\` (backslash), `'` (single quote), `&` (ampersand), and `$` (dollar sign). This also goes for other passwords used for installation, alphanumeric characters are recommended.
 
 #### SMTP Server
 


### PR DESCRIPTION
Adds ampersand to the list

Adds note to follow this guideline for all passwords, not just the
console password, reccomends alphanumeric.

Previously only mentions the console password, and the user can
customize the mysql password as well.
