### PR TITLE
Updates to Scaling documentation

### DIFF
--- a/source/guides/inventory_service.markdown
+++ b/source/guides/inventory_service.markdown
@@ -185,7 +185,7 @@ Since your other puppet masters will be sending node facts to the designated inv
 Edit puppet.conf on every other puppet master to contain the following:
 
     [master]
-        facts_terminus = rest
+        facts_terminus = inventory_service
         inventory_server = {designated inventory master; defaults to "puppet"}
         inventory_port = 8140
 

--- a/source/guides/passenger.markdown
+++ b/source/guides/passenger.markdown
@@ -7,173 +7,128 @@ Passenger
 =========
 
 Using Passenger instead of WEBrick for web services offers numerous performance
-advantages.  This guide shows how to set it up.
+advantages.  This guide shows how to set it up in an Apache web server.
 
 * * *
-
-Supported Versions
-------------------
-
-Passenger support is present in release 0.24.6 and later versions only.  For earlier
-versions, consider [Using Mongrel](./mongrel.html).
 
 Why Passenger
 -------------
 
-Traditionally, the puppetmaster would embed a WEBrick or Mongrel
-Web Server to serve the puppet clients. This may work well for you,
-but a few people feel like using a proven web server like Apache
-would be superior for this purpose.
+Traditionally, the puppetmaster would embed a WEBrick
+Web Server to serve the Puppet clients. This may work well for
+testing and small deployments, but it's recommended to use a more
+scalable server for production environments.
 
 What is Passenger?
 ------------------
 
 [Passenger](http://www.modrails.com/) (AKA mod\_rails or mod\_rack)
-is the Apache 2.x Extension which lets you run Rails or Rack
-applications inside Apache.
+is the Apache 2.x module which lets you run Rails or Rack
+applications inside a general purpose web server, like
+[Apache httpd](http://httpd.apache.org/) or [nginx](http://nginx.org/).
 
-Puppet (>0.24.6) now ships with a Rack application which can embed
-a puppetmaster. While it should be compatible with every Rack
-application server, it has only been tested with Passenger.
+Passenger is the recommended deployment method for modern versions
+of Puppet masters, but you may run into compatibility issues with
+Puppet versions older than 0.24.6 and Passenger versions older than
+2.2.5.
 
-Depending on your operating system, the versions of Puppet, Apache
-and Passenger may not support this implementation. Specifically,
-Ubuntu Hardy ships with an older version of puppet (0.24.4) and
-doesn't include passenger at all, however updated packages for
-puppet can be found
-[here](https://launchpad.net/~bitpusher/+archive/ppa). There are
-also some passenger packages there, but as of 2009-09-28 they do
-not seem to have the latest passenger (2.2.5), so better install
-passenger from a gem as per the instructions at [modrails.com].
+* * *
 
-Note: Passenger versions 2.2.3 and 2.2.4 have known bugs regarding
-to the SSL environment variables, which make them unsuitable for
-hosting a puppetmaster. So use either 2.2.2, or 2.2.5. Note that
-while it was expected that Passenger 2.2.2 would be the last
-version which can host a 0.24.x puppetmaster, that turns out to be
-not true, cf.
-[this bug report](http://projects.puppetlabs.com/issues/2386#change-9238).
-So, passenger 2.2.5 works fine.
+Apache and Passenger Installation
+---------------------------------
 
-Installation Instructions for Puppet 0.25.x and 2.6.x
------------------------------------------------------
+Make sure `puppet master` has been run at least once (or
+`puppet agent`, if this master is not the CA), so that all required
+SSL certificates are in place.
 
-Please see
-[ext/rack/README in the puppet source](http://github.com/puppetlabs/puppet/tree/master/ext/rack)
-tree for instructions.
+### Install Apache 2
 
-Whatever you do, make sure your config.ru file is owned by the
-puppet user! Passenger will setuid to that user.
+Debian/Ubuntu:
 
-Installation Instructions for Puppet 0.24.x for Debian/Ubuntu and RHEL5
-------------------------------------------------------------------
-
-Make sure puppetmasterd ran at least once, so puppetmasterd SSL
-certificates are setup intially.
-
-### Install Apache 2, Rack and Passenger
-
-For Debian/Ubuntu:
-
-    apt-get install apache2
-    apt-get install ruby1.8-dev
-
-For RHEL5 (needs the [EPEL](https://fedoraproject.org/wiki/EPEL)
-repository enabled):
-
-    yum install httpd httpd-devel ruby-devel rubygems
-
-### Install Rack/Passenger
-
-The latest version of Passenger (2.2.5) appears to work fine on
-RHEL5:
-
-    gem install rack
-    gem install passenger
-    passenger-install-apache2-module
-
-If you want the older 2.2.2 gem, you could manually download the
-.gem file from
-[RubyForge](http://rubyforge.org/frs/?group_id=5873). Or, you could
-just add the correct versions to your gem command:
-
-      gem install -v 0.4.0 rack
-      gem install -v 2.2.2 passenger
-
-### Enable Apache modules "ssl" and "headers":
-
-    # for Debian or Ubuntu:
+    apt-get install apache2 ruby1.8-dev rubygems
     a2enmod ssl
     a2enmod headers
 
-    # for RHEL5
-    yum install mod_ssl
+RHEL/CentOS (needs the Puppet Labs repository enabled, or the
+[EPEL](https://fedoraproject.org/wiki/EPEL) repository):
+
+    yum install httpd httpd-devel mod_ssl ruby-devel rubygems
+
+### Install Rack/Passenger
+
+    gem install rack passenger
+    passenger-install-apache2-module
 
 ### Configure Apache
 
-For Debian/Ubuntu:
+Debian/Ubuntu:
 
-    cp apache2.conf /etc/apache2/sites-available/puppetmasterd  (see below for the file contents)
-    ln -s /etc/apache2/sites-available/puppetmasterd /etc/apache2/sites-enabled/puppetmasterd
-    vim /etc/apache2/conf.d/puppetmasterd (replace the hostnames)
+    # See Apache Configuration below for contents of puppetmaster file
+    cp puppetmaster /etc/apache2/sites-available/
+    a2ensite puppetmaster
 
-For RHEL5:
+RHEL/CentOS:
 
-    cp puppetmaster.conf /etc/httpd/conf.d/ (see below for file contents)
-    vim /etc/httpd/conf.d/puppetmaster.conf (replace hostnames with corrent values)
+    # See Apache Configuration below for contents of puppetmaster.conf file
+    cp puppetmaster.conf /etc/httpd/conf.d/
 
-Install the rack application [1]:
+### Install the Rack Application
 
     mkdir -p /usr/share/puppet/rack/puppetmasterd
     mkdir /usr/share/puppet/rack/puppetmasterd/public /usr/share/puppet/rack/puppetmasterd/tmp
-    cp config.ru /usr/share/puppet/rack/puppetmasterd
+    cp /usr/share/puppet/ext/rack/files/config.ru /usr/share/puppet/rack/puppetmasterd/
+    # This step is important - the owner of this file is the user the process will run under:
     chown puppet /usr/share/puppet/rack/puppetmasterd/config.ru
 
-Go:
+Apache Configuration
+--------------------
 
-    # For Debian/Ubuntu
-    /etc/init.d/apache2 restart
-
-    # For RHEL5
-    /etc/init.d/httpd restart
-
-If all works well, you'll want to make sure your puppmetmasterd
-init script does not get called anymore:
-
-    # For Debian/Ubuntu
-    update-rc.d -f puppetmaster remove
-
-    # For RHEL5
-    chkconfig puppetmaster off
-    chkconfig httpd on
-
-[1] Passenger will not let applications run as root or the Apache
-user, instead an implicit setuid will be done, to the user whom
-owns config.ru. Therefore, config.ru shall be owned by the puppet
-user.
-
-Apache Configuration for Puppet 0.24.x
---------------------------------------
+### Example Configuration
 
 This Apache Virtual Host configures the puppetmaster on the default
 puppetmaster port (8140).
 
+    # You'll need to adjust the paths in the Passenger config depending on which OS
+    # you're using, as well as the installed version of Passenger.
+    
+    # Debian/Ubuntu:
+    #LoadModule passenger_module /var/lib/gems/1.8/gems/passenger-3.0.x/ext/apache2/mod_passenger.so
+    #PassengerRoot /var/lib/gems/1.8/gems/passenger-3.0.x
+    #PassengerRuby /usr/bin/ruby1.8
+    
+    # RHEL/CentOS:
+    #LoadModule passenger_module /usr/lib/ruby/gems/1.8/gems/passenger-3.0.x/ext/apache2/mod_passenger.so
+    #PassengerRoot /usr/lib/ruby/gems/1.8/gems/passenger-3.0.x
+    #PassengerRuby /usr/bin/ruby
+    
+    # And the passenger performance tuning settings:
+    PassengerHighPerformance On
+    PassengerUseGlobalQueue On
+    # Set this to about 1.5 times the number of CPU cores in your master:
+    PassengerMaxPoolSize 12
+    # Recycle master processes after they service 1000 requests
+    PassengerMaxRequests 1000
+    # Stop processes if they sit idle for 10 minutes
+    PassengerPoolIdleTime 600
+    
     Listen 8140
     <VirtualHost *:8140>
-
-        SSLEngine on
-        SSLCipherSuite SSLv2:-LOW:-EXPORT:RC4+RSA
-        SSLCertificateFile      /var/lib/puppet/ssl/certs/puppet-server.inqnet.at.pem
-        SSLCertificateKeyFile   /var/lib/puppet/ssl/private_keys/puppet-server.inqnet.at.pem
+        SSLEngine On
+        
+        # Only allow high security cryptography. Alter if needed for compatibility.
+        SSLProtocol             All -SSLv2
+        SSLCipherSuite          HIGH:!ADH:RC4+RSA:-MEDIUM:-LOW:-EXP
+        SSLCertificateFile      /var/lib/puppet/ssl/certs/puppet-server.example.com.pem
+        SSLCertificateKeyFile   /var/lib/puppet/ssl/private_keys/puppet-server.example.pem
         SSLCertificateChainFile /var/lib/puppet/ssl/ca/ca_crt.pem
         SSLCACertificateFile    /var/lib/puppet/ssl/ca/ca_crt.pem
-        # CRL checking should be enabled; if you have problems with Apache complaining about the CRL, disable the next line
         SSLCARevocationFile     /var/lib/puppet/ssl/ca/ca_crl.pem
-        SSLVerifyClient optional
-        SSLVerifyDepth  1
-        SSLOptions +StdEnvVars
-
-        # The following client headers allow the same configuration to work with Pound.
+        SSLVerifyClient         optional
+        SSLVerifyDepth          1
+        SSLOptions              +StdEnvVars +ExportCertData
+        
+        # These request headers are used to pass the client certificate
+        # authentication information on to the Puppet master process
         RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
         RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
         RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
@@ -183,121 +138,41 @@ puppetmaster port (8140).
         <Directory /usr/share/puppet/rack/puppetmasterd/>
             Options None
             AllowOverride None
-            Order allow,deny
-            allow from all
+            Order Allow,Deny
+            Allow from All
         </Directory>
     </VirtualHost>
 
-If the current puppetmaster is not a certificate authority, you may
-need to change the following lines. The certs/ca.pem file should
-exist as long as the puppetmaster has been signed by the CA.
+If this Puppet master is not the certificate authority, you will
+need to use different paths to the CA certificate and CRL:
 
-      SSLCertificateChainFile /var/lib/puppet/ssl/certs/ca.pem
-        SSLCACertificateFile    /var/lib/puppet/ssl/certs/ca.pem
+    SSLCertificateChainFile /var/lib/puppet/ssl/certs/ca.pem
+    SSLCACertificateFile    /var/lib/puppet/ssl/certs/ca.pem
+    SSLCARevocationFile     /var/lib/puppet/ssl/crl.pem
 
-For Debian hosts you might wish to add:
-
-      LoadModule passenger_module /var/lib/gems/1.8/gems/passenger-2.2.5/ext/apache2/mod_passenger.so
-        PassengerRoot /var/lib/gems/1.8/gems/passenger-2.2.5
-        PassengerRuby /usr/bin/ruby1.8
-
-For RHEL hosts you may need to add:
-
-       LoadModule passenger_module /usr/lib/ruby/gems/1.8/gems/passenger-2.2.5/ext/apache2/mod_passenger.so
-       PassengerRoot /usr/lib/ruby/gems/1.8/gems/passenger-2.2.5
-       PassengerRuby /usr/bin/ruby
-
-For details about enabling and configuring Passenger, see the
+For additional details about enabling and configuring Passenger, see the
 [Passenger install guide](http://www.modrails.com/install.html).
 
-The config.ru file for Puppet 0.24.x
-------------------------------------
+### Start the Apache service
 
-    # This file is mostly based on puppetmasterd, which is part of
-    # the standard puppet distribution.
+Ensure that the Puppet master service is stopped before starting
+the Apache service; only one can be bound to TCP port 8140.
 
-    require 'rack'
-    require 'puppet'
-    require 'puppet/network/http_server/rack'
+Debian/Ubuntu:
 
-    # startup code stolen from bin/puppetmasterd
-    Puppet.parse_config
-    Puppet::Util::Log.level = :info
-    Puppet::Util::Log.newdestination(:syslog)
-    # A temporary solution, to at least make the master work for now.
-    Puppet::Node::Facts.terminus_class = :yaml
-    # Cache our nodes in yaml.  Currently not configurable.
-    Puppet::Node.cache_class = :yaml
+    /etc/init.d/apache2 restart
 
+RHEL/CentOS:
 
-    # The list of handlers running inside this puppetmaster
-    handlers = {
-        :Status => {},
-        :FileServer => {},
-        :Master => {},
-        :CA => {},
-        :FileBucket => {},
-        :Report => {}
-    }
+    /etc/init.d/httpd restart
 
-    # Fire up the Rack-Server instance
-    server = Puppet::Network::HTTPServer::Rack.new(handlers)
+If all works well, you'll want to make sure the WEBrick service no longer starts:
 
-    # prepare the rack app
-    app = proc do |env|
-        server.process(env)
-    end
+Debian/Ubuntu:
 
-    # Go.
-    run app
+    update-rc.d -f puppetmaster remove
 
-If you don't want to run with the CA enabled, you could drop the
-':CA => {}' line from the config.ru above.
+RHEL/CentOS:
 
-The config.ru file for 0.25.x
------------------------------
-
-Please see ext/rack in the 0.25 source tree for the proper
-config.ru file.
-
-Suggested Tweaks
-----------------
-
-Larry Ludwig's testing of passenger/puppetmasterd recommends
-adjusting these options in your apache configuration:
-
--   PassengerPoolIdleTime 300 - Set to 5 min (300 seconds) or less.
-    The shorting this option allows for puppetmasterd to get refreshed
-    at some interval. This option is also somewhat dependent upon the
-    amount of puppetd nodes connecting and at what interval.
--   PassengerMaxPoolSize 15 - to 15% more instances than what's
-    needed. This will allow idle puppetmasterd to get recycled. The net
-    effect is less memory will be used, not more.
--   PassengerUseGlobalQueue on - Since communication with the
-    puppetmaster from puppetd is a long process (more than 20 seconds
-    in most cases) and will allow for processes to get recycled better
--   PassengerHighPerformance on - The additional Passenger features
-    for apache compatibility are not needed with Puppet.
-
-As is expected with traditional web servers, once your service
-starts using swap, performance degradation will occur --- so be mindful
-of your memory/swap usage on your Puppetmaster.
-
-To monitor the age of your puppetmasterd processes within
-Passenger, run
-
-    passenger-status | grep PID | sort
-
-      PID: 14590   Sessions: 1    Processed: 458     Uptime: 3m 40s
-      PID: 7117    Sessions: 0    Processed: 10980   Uptime: 1h 43m 41s
-      PID: 7355    Sessions: 0    Processed: 9736    Uptime: 1h 38m 38s
-      PID: 7575    Sessions: 0    Processed: 9395    Uptime: 1h 32m 27s
-      PID: 9950    Sessions: 0    Processed: 6581    Uptime: 1h 2m 35s
-
-Passenger can be configured to be recycling puppetmasterd
-every few hours to ensure memory/garbage collection from Ruby is
-not a factor.
-
-
-
-
+    chkconfig puppetmaster off
+    chkconfig httpd on

--- a/source/guides/scaling_multiple_masters.markdown
+++ b/source/guides/scaling_multiple_masters.markdown
@@ -6,58 +6,129 @@ title: "Using Multiple Puppet Masters"
 Using Multiple Puppet Masters
 =====
 
-To scale beyond a certain size, an agent/master Puppet site will require more than one puppet master server. This document outlines a simple process to expand a single-master site to use multiple masters. 
+To scale beyond a certain size, or for geographic distribution or disaster recovery, a deployment may warrant having more than one puppet master server. This document outlines options for deployments with multiple masters.
 
 > Note: As of this writing, this document does not cover:
 > 
-> * How to expand the inventory service or storeconfigs
-> * How to expand PE's orchestration or live management features
+> * How to expand the inventory service or storeconfigs ([PuppetDB](/puppetdb) should be implemented for this)
+> * How to expand Puppet Enterprise's orchestration or live management features
 
 In brief:
 
-1. Centralize all certificate authority functions
-2. Bring up additional puppet master servers
-3. Keep manifests and modules in sync across your puppet masters
-4. Distribute the agent load among the available masters
+1. [Determine the method you will use to distribute the agent load among the available masters](#distributing-agent-load)
+2. [Centralize all certificate authority functions](#centralize-the-certificate-authority)
+3. [Bring up additional puppet master servers](#create-new-puppet-master-servers)
+4. [Keep manifests and modules in sync across your puppet masters](#keep-manifests-and-modules-in-sync-across-your-puppet-masters)
+5. [Implement agent load distribution](#implement-load-distribution)
 
+
+Distributing Agent Load
+-----
+
+First things first; the rest of your configuration will depend on how you're planning on distributing the agent load.  You have several options available.  Determine what your deployment will look like now, but **implement this as the last step**, only after you have the infrastructure in place to support it.
+
+### Option 1: DNS `SRV` Records
+
+This option is new in Puppet 3.0, and is the recommended deployment if your entire Puppet infrastructure is on 3.0 or newer.
+
+You can use DNS `SRV` records to assign a pool of Puppet masters for agents to communicate with.  This requires a DNS service capable of `SRV` records - all major DNS software including Windows Server's DNS and BIND are compatible.
+
+Each of your puppet nodes will be configured with a `srv_domain` instead of a `server` in their `puppet.conf`:
+
+    [main]
+      use_srv_records = true
+      srv_domain = example.com
+
+..then they will look up a `SRV` record at `_x-puppet._tcp.example.com` when they need to talk to a Puppet master.
+
+    # Equal-weight load balancing between master-a and master-b:
+    _x-puppet._tcp.example.com. IN SRV 0 5 8140 master-a.example.com.
+    _x-puppet._tcp.example.com. IN SRV 0 5 8140 master-b.example.com.
+
+Advanced configurations are also possible.  For instance, if all devices in site A are configured with a `srv_domain` of `site-a.example.com` and all nodes in site B are configured to `site-b.example.com`, you can configure them to prefer a master in the local site, but fail over to the remote site:
+    
+    # Site A has two masters - master-1 is beefier, give it 75% of the load:
+    _x-puppet._tcp.site-a.example.com. IN SRV 0 75 8140 master-1.site-a.example.com.
+    _x-puppet._tcp.site-a.example.com. IN SRV 0 25 8140 master-2.site-a.example.com.
+    _x-puppet._tcp.site-a.example.com. IN SRV 1 5 8140 master.site-b.example.com.
+    
+    # For site B, prefer the local master unless it's down, then fail back to site A
+    _x-puppet._tcp.site-b.example.com. IN SRV 0 5 8140 master.site-b.example.com.
+    _x-puppet._tcp.site-b.example.com. IN SRV 1 75 8140 master-1.site-a.example.com.
+    _x-puppet._tcp.site-b.example.com. IN SRV 1 25 8140 master-2.site-a.example.com.
+
+### Option 2: Statically Designate Servers on Agent Nodes
+
+Manually or with Puppet, change the `server` setting in each agent node's `puppet.conf` file such that the nodes are divided more or less evenly among the available masters.
+
+This option is labor-intensive and will gradually fall out of balance, but it will work without additional infrastructure.
+
+### Option 3: Use Round-Robin DNS
+
+Leave all of your agent nodes pointed at the same puppet master hostname, then configure your site's DNS to arbitrarily route all requests directed at that hostname to the pool of available masters.
+
+For instance, if all of your agent nodes are configured with `server = puppet.example.com`, you'll configure a DNS name such as:
+
+    # IP address of master 1:
+    puppet.example.com. IN A 192.0.2.50
+    # IP address of master 2:
+    puppet.example.com. IN A 198.51.100.215
+
+For this option, you'll need to configure your masters with `dns_alt_names` before their certificate request is made - [see below.](#before-running-puppet-agent-or-puppet-master)
+
+### Option 4: Use a Load Balancer
+
+You can also use a hardware load balancer or a load balancing proxy webserver to redirect requests more intelligently. Depending on how it's configured for SSL (either raw TCP proxying, or acting as its own SSL endpoint), you'll need to use a combination of the other procedures in this document.
+
+Configuring a load balancer is beyond the scope of this document.
+
+* * *
 
 Centralize the Certificate Authority
 -----
 
-The additional puppet masters at a site should only share the burden of compiling and serving catalogs; any certificate authority functions should be delegated to a single server. **Choose one server** to act as the CA, and ensure that it is reachable at a **unique hostname other than (or in addition to) `puppet`.**
+The additional Puppet masters at a site should only share the burden of compiling and serving catalogs; any certificate authority functions should be delegated to a single server. **Choose one server** to act as the CA, and ensure that it is reachable at a **unique hostname other than (or in addition to) `puppet`.**
 
 There are two main options for centralizing the CA:
 
-### Option 1: Set `ca_server` on Agent Nodes
+### Option 1: Direct agent nodes to the CA Master
+
+#### Method A: DNS `SRV` Records
+
+If you are [utilizing `SRV` records for agents](#option-1-dns-srv-records), then you can use the `_x-puppet-ca._tcp.$srv_domain` DNS name to configure clients to point to a single specific CA server, while the `_x-puppet._tcp.$srv_domain` DNS name will be handling the majority of their requests to masters and can be a set of Puppet masters without CA capabilities.
+
+#### Method B: Individual Agent Configuration
 
 On **every agent node,** you must set the [`ca_server`](/references/latest/configuration.html#ca_server) setting in [`puppet.conf`](/guides/configuring.html) (in the `[main]` configuration block) to the hostname of the server acting as the certificate authority. 
 
 * If you have a large number of existing nodes, it is easiest to do this by managing `puppet.conf` with a Puppet module and a template. 
-* Be sure to pre-set this setting when provisioning new nodes.
+* Be sure to pre-set this setting when provisioning new nodes - they will be unable to successfully complete their initial agent run if they're not communicating with the correct `ca_server`.
 
-### Option 2: Redirect Certificate Traffic
+### Option 2: Proxy Certificate Traffic
 
-Alternately, if you do not wish to change every node's `puppet.conf`, you can configure the web server front-end on every new puppet master server to redirect certificate traffic to the CA server. This method only works if your puppet master servers are using a web server that provides a method for proxying requests, like Apache with Passenger.
+Alternately, if your nodes don't have direct connectivity to your CA master, you aren't using `SRV` records, or you do not wish to change every node's `puppet.conf`, you can configure the web server on the Puppet masters other than your CA master to proxy all certificate-related traffic to the designated CA master.
 
-All certificate request URLs begin with `/certificate`; simply catch and proxy these requests using whatever capabilities your web server offers.
+> This method only works if your puppet master servers are using a web server that provides a method for proxying requests, like [Apache with Passenger](/guides/passenger.html).
 
-[mod_proxy]: http://httpd.apache.org/docs/current/mod/mod_proxy.html
+All certificate related URLs begin with `/certificate`; simply catch and proxy these requests using whatever capabilities your web server offers.
 
-> #### Example: Apache configuration with [`mod_proxy`][mod_proxy]
+> #### Example: Apache configuration with [`mod_proxy`](http://httpd.apache.org/docs/current/mod/mod_proxy.html)
 > 
-> At global scope in your Apache config file, add the following stanza, changing the BalancerMember URL to match your CA's hostname:
+> In the scope of your puppet master vhost, add the following configuration:
 > 
->     <Proxy balancer://puppet_ca>
->      BalancerMember http://puppetca.example.com:8140
->     </Proxy>
+>     SSLProxyEngine On
+>     ProxyPassMatch ^/([^/]+/certificate.*)$ https://puppetca.example.com:8140/$1
 > 
-> In the scope of your puppet master vhost, add the following rules:
+> This change must be made to the Apache configuration on every Puppet master server other than the one serving as the CA. No changes need to be made to agent nodes' configurations.
 > 
->     ProxyPassMatch ^(/.*?)/(certificate.*?)/(.*)$ balancer://puppet_ca/
->     ProxyPassReverse ^(/.*?)/(certificate.*?)/(.*)$ balancer://puppet_ca/
+> Additionally, the CA master must allow the nodes to download the certificate revocation list via the proxy, without authentication - certificate requests and retrieval of signed certificates are allowed by default, but not CRLs.  Add the following to the CA master's `auth.conf`:
 > 
-> These two changes must be made to the Apache configuration on every puppet master server other than the one serving as the CA. No changes need to be made to agent nodes' configurations.
+>     path /certificate_revocation_list
+>     auth any
+>     method find
+>     allow *
 
+* * * 
 
 Create New Puppet Master Servers
 -----
@@ -69,64 +140,46 @@ To add a new puppet master server to your deployment, begin by installing and co
 * [Installing Puppet (open source versions)](/guides/installation.html)
 * [Installing Puppet Enterprise](/pe/2.5/install_basic.html)
 
-Like with any puppet master, you'll need to use a production-grade web server rather than the default WEBrick server. We generally assume that you know how to do this if you're already at the point where you need multiple masters, but see [Scaling with Passenger][passenger] for one way to do it.
+Like with any puppet master, you'll need to use a production-grade web server rather than the default WEBrick server. We generally assume that you know how to do this if you're already at the point where you need multiple masters, but see [Scaling with Passenger](/guides/passenger.html) for one way to do it.
 
-[passenger]: /guides/passenger.html
+### Before Running `puppet agent` or `puppet master`
 
-
-### Stop the Puppet Master Service
-
-If puppet master is running, stop it.
-
-### Configure CA Delegation and Get a Certificate
-
-* In `puppet.conf`, do the following: 
+* In `puppet.conf`, do the following:
     * Set `ca` to `false` in the `[master]` config block.
-    * Set `ca_server` to the hostname of your CA server in the `[main]` config block.
-    * Make sure the `ssldir` setting is either absent from all config blocks, specified in the `[main]` block only, or identical in the `[master]` and `[agent]` blocks.
-* If the installation process created an `ssldir`, blow it away by running `sudo rm -rf $(puppet master --configprint ssldir)`.
-* Request a certificate by running:
-
-        $ sudo puppet agent --test --dns_alt_names "master2.example.com,puppet,puppet.example.com"
+    * *If you're using the [individual agent configuration method of CA centralization](#option-1-direct-agent-nodes-to-the-ca-master):*
     
-    The `dns_alt_names` setting is a comma-separated list, and should contain this master's unique hostname and any additional public DNS name(s) that agent nodes may use to contact a puppet master. Replace the example names with ones relevant to your site.
-* Log into the CA server and run `sudo puppet cert sign <NEW MASTER'S CERTNAME>`.
-* Retrieve the certificate on the new master by running `sudo puppet agent --test`.
+      Set `ca_server` to the hostname of your CA server in the `[main]` config block.
+    * If an `ssldir` is configured, make sure it's configured in the `[main]` block only.
 
-### If Necessary, Configure CA Traffic Proxying
+> If you're using the [DNS round robin method](#option-3-use-round-robin-dns) of agent load balancing, or a [load balancer](#option-4-use-a-load-balancer) in TCP proxying mode, your non-CA masters will need certificates with DNS Subject Alternative Names:
+> 
+> * Configure `dns_alt_names` in the `[main]` block of `puppet.conf`.
+> 
+>   It should be configured to cover every DNS name that might be used by a node to access this master.
+>   
+>       dns_alt_names = puppet,puppet.example.com,puppet.site-a.example.com
+>       
+> * If the agent or master has been run and already created a certificate, blow it away by running `sudo rm -rf $(puppet master --configprint ssldir)`.  If a cert has been requested from the master, you'll also need to delete it there to re-issue a new one with the alt names: `puppet cert clean master-2.example.com`.
 
-[See above.](#option-2-redirect-certificate-traffic)
+* Request a new certificate by running `puppet agent --test --waitforcert 10`.
+* Log into the CA server and run `puppet cert sign master-2.example.com`.
 
+  (You'll need to add `--allow-dns-alt-names` to the command if `dns_alt_names` were in the certificate request.)
+
+* * *
 
 Keep Manifests and Modules in Sync Across Your Puppet Masters
 -----
 
 You will need to find some way to ensure that all of your puppet masters have identical copies of your manifests, Puppet modules, and [external node classifier](/guides/external_nodes.html) data. Some options are:
 
+* Use a version control system such as Git, Mercurial, or Subversion to manage and sync your manifests, modules, and other data.
 * Run an out-of-band rsync task via cron.
-* Configure puppet agent on each master node to point to a designated model puppet master, then use Puppet itself to distribute the modules. 
+* Configure puppet agent on each master node to point to a designated model puppet master, then use Puppet itself to distribute the modules.
 
+* * *
 
-Distribute the Agent Load
+Implement Load Distribution
 -----
 
-You must somehow arrange for the puppet agent requests at your site to be distributed more or less evenly across the pool of available puppet masters. There are several ways to do this. 
-
-### Option 1: Statically Designate Servers on Agent Nodes
-
-Manually or with Puppet, change the `server` setting in each agent node's `puppet.conf` file such that the nodes are divided more or less evenly among the available masters.
-
-This option is labor-intensive and will gradually fall out of balance, but it will work without additional infrastructure.
-
-### Option 2: Use Round-Robin DNS
-
-Leave all of your agent nodes pointed at the same puppet master hostname, then configure your site's DNS to arbitrarily route all requests directed at that hostname to the pool of available masters.
-
-Configuring DNS is beyond the scope of this document; see the documentation for your DNS server software.
-
-### Option 3: Use a Load Balancer
-
-You can also use a hardware load balancer or a load balancing proxy webserver to redirect requests more intelligently. 
-
-Configuring a load balancer is beyond the scope of this document.
-
+Now that your other masters are ready, you can implement the agent load balancing mechanism that you selected [above](#distributing-agent-load).

--- a/source/puppet/index.markdown
+++ b/source/puppet/index.markdown
@@ -119,7 +119,7 @@ Manage Windows nodes side by side with your \*nix infrastructure, with Puppet 2.
 Puppet's default configuration is meant for prototyping and designing a site. Once you're ready for production deployment, learn how to adjust Puppet for peak performance.
 
 * [Scaling Puppet](/guides/scaling.html) --- general tips & tricks
-* [Using Multiple Puppet Masters](/guides/scaling_multiple_masters.html) --- a guide to adding new puppet masters to a single-master site
+* [Using Multiple Puppet Masters](/guides/scaling_multiple_masters.html) --- a guide to deployments with multiple Puppet masters
 * [Scaling With Passenger](/guides/passenger.html) --- for Puppet 0.24.6 and later
 * [Scaling With Mongrel](/guides/mongrel.html) --- for older versions of Puppet
 


### PR DESCRIPTION
The scaling guides have some old inaccuracies and readability issues left over from the conversion from wiki pages, some very dated compatibility information, and could use some information about new scalability features in 3.0.
- index: Small tweak to verbiage about the scaling_multiple_masters document
- inventory_service: Switch guidance over to the inventory_service terminus, see bug 10289
- passenger: Largely a cleanup of old 0.24-specific information and overall simplification of the document.
- scaling_multiple_masters: Update to include information about SRV record feature in 3.0.  Re-order sections to hopefully make the decision tree for deployment options clearer.  Correct or add additional detail to configuration examples.
