### PR TITLE
Update source/puppet/3/reference/ruby_dsl.markdown

### DIFF
--- a/source/puppet/3/reference/ruby_dsl.markdown
+++ b/source/puppet/3/reference/ruby_dsl.markdown
@@ -88,6 +88,14 @@ To append to a variable, use:
 scope.setvar("p", scope["p"] + value)
 {% endhighlight %}
 
+### Reloading of Ruby DSL Logic
+
+A puppet master will reload Ruby DSL logic when files have changed between catalog compilations.
+
+A future version may optimize the reloading of Ruby DSL logic. In the first release a puppet master will
+always invalidate the cache of parsed manifests for an environment when a Ruby DSL manifest is part of
+the evaluation. This was required to enable correct reloading of changed Ruby DSL manifests.
+
 ## New in the Puppet Ruby DSL
 
 ### Resource References


### PR DESCRIPTION
Explains that cache of parsed manifests is always invalidates to ensure that
Ruby DSL manifests are correctly reloaded and that this may change to the better in the future.
