### PR TITLE
Switch to [master] for config block in example

### DIFF
--- a/source/guides/exported_resources.markdown
+++ b/source/guides/exported_resources.markdown
@@ -25,7 +25,7 @@ configuration on the [Using Stored Configuration](http://projects.puppetlabs.com
 Puppet will automatically create a database for storing
 configurations (using [Ruby on Rails](http://rubyonrails.org/)).
 
-    [puppetmasterd]
+    [master]
     storeconfigs = true
 
 This allows one host to configure another host; for instance, a


### PR DESCRIPTION
The block in this example had [puppetmasterd] which is no longer supported.

Signed-off-by: Ken Barber ken@bob.sh
