### PR TITLE
(#19294) Allow double quotes for strings when string contains single quotes

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -105,8 +105,9 @@ most visible to text editors and other code lexers.
 
 All strings that do not contain variables should be enclosed in
 single quotes.  Double quotes should be used when variable interpolation is
-required.  Quoting is optional when the string is an alphanumeric
-bare word and is not a resource title.
+required.  Double quotes may also be used to make a string more readable when
+it contains single quotes.  Quoting is optional when the string is an
+alphanumeric bare word and is not a resource title.
 
 All variables should be enclosed in braces when interpolated in a
 string.  For example:


### PR DESCRIPTION
Basically, single quotes within a string need to be escaped when the string is
wrapped in single quotes, thus making the overall line harder to read, breaking
philosophy #1.

The tooling obviously throws an error when you try to use double quotes here,
but without clear guidance one just ends up in a debate. My patch is about being
clearer for this edge-case, for the sake of philosophy #1 (readability).

Signed-off-by: Ken Barber ken@bob.sh
