### PR TITLE
Specify Rakefile encoding to keep Ruby 1.9+ happy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'rubygems'
 require 'bundler/setup'
 require 'rake'


### PR DESCRIPTION
The Rakefile contains a multi-byte character, thus it needs an encoding or Ruby 1.9 and newer [will refuse to process the file](http://blog.grayproductions.net/articles/ruby_19s_three_default_encodings).
