### PR TITLE
Fixing useradd feature documentation

### DIFF
--- a/source/references/0.24.5/type.markdown
+++ b/source/references/0.24.5/type.markdown
@@ -3701,7 +3701,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 </tr>
 </tbody>
 </table>

--- a/source/references/0.24.6/type.markdown
+++ b/source/references/0.24.6/type.markdown
@@ -3957,7 +3957,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.24.7/type.markdown
+++ b/source/references/0.24.7/type.markdown
@@ -4954,7 +4954,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.24.8/type.markdown
+++ b/source/references/0.24.8/type.markdown
@@ -4995,7 +4995,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.24.9/type.markdown
+++ b/source/references/0.24.9/type.markdown
@@ -4998,7 +4998,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.0/type.markdown
+++ b/source/references/0.25.0/type.markdown
@@ -4802,7 +4802,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.1/type.markdown
+++ b/source/references/0.25.1/type.markdown
@@ -4807,7 +4807,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.2/type.markdown
+++ b/source/references/0.25.2/type.markdown
@@ -4821,7 +4821,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.3/type.markdown
+++ b/source/references/0.25.3/type.markdown
@@ -4821,7 +4821,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.4/type.markdown
+++ b/source/references/0.25.4/type.markdown
@@ -4821,7 +4821,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/0.25.5/type.markdown
+++ b/source/references/0.25.5/type.markdown
@@ -4827,7 +4827,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/2.6.0/type.markdown
+++ b/source/references/2.6.0/type.markdown
@@ -4868,7 +4868,7 @@ about them.  It does not directly modify /etc/passwd or anything.</p>
 <tr><td>useradd</td>
 <td><strong>X</strong></td>
 <td><strong>X</strong></td>
-<td>&nbsp;</td>
+<td><strong>X</strong></td>
 <td>&nbsp;</td>
 </tr>
 </tbody>

--- a/source/references/2.6.10/type.markdown
+++ b/source/references/2.6.10/type.markdown
@@ -3665,7 +3665,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.11/type.markdown
+++ b/source/references/2.6.11/type.markdown
@@ -3665,7 +3665,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.12/type.markdown
+++ b/source/references/2.6.12/type.markdown
@@ -3665,7 +3665,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.13/type.markdown
+++ b/source/references/2.6.13/type.markdown
@@ -3675,7 +3675,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.14/type.markdown
+++ b/source/references/2.6.14/type.markdown
@@ -4163,7 +4163,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.15/type.markdown
+++ b/source/references/2.6.15/type.markdown
@@ -4163,7 +4163,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.16/type.markdown
+++ b/source/references/2.6.16/type.markdown
@@ -4163,7 +4163,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.17/type.markdown
+++ b/source/references/2.6.17/type.markdown
@@ -4163,7 +4163,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.6.9/type.markdown
+++ b/source/references/2.6.9/type.markdown
@@ -3665,7 +3665,7 @@ hpuxuseradd      | *X*               |                | *X*             |       
 ldap             |                   |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.7.1/type.markdown
+++ b/source/references/2.7.1/type.markdown
@@ -3772,7 +3772,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.7.10/type.markdown
+++ b/source/references/2.7.10/type.markdown
@@ -4339,7 +4339,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.11/type.markdown
+++ b/source/references/2.7.11/type.markdown
@@ -4339,7 +4339,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.12/type.markdown
+++ b/source/references/2.7.12/type.markdown
@@ -4384,7 +4384,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.13/type.markdown
+++ b/source/references/2.7.13/type.markdown
@@ -4384,7 +4384,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.14/type.markdown
+++ b/source/references/2.7.14/type.markdown
@@ -4392,7 +4392,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.16/type.markdown
+++ b/source/references/2.7.16/type.markdown
@@ -4392,7 +4392,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.17/type.markdown
+++ b/source/references/2.7.17/type.markdown
@@ -4392,7 +4392,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.18/type.markdown
+++ b/source/references/2.7.18/type.markdown
@@ -4392,7 +4392,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.19/type.markdown
+++ b/source/references/2.7.19/type.markdown
@@ -4399,7 +4399,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.20-rc1/type.markdown
+++ b/source/references/2.7.20-rc1/type.markdown
@@ -4406,7 +4406,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.20/type.markdown
+++ b/source/references/2.7.20/type.markdown
@@ -4406,7 +4406,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.3/type.markdown
+++ b/source/references/2.7.3/type.markdown
@@ -3774,7 +3774,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 
 #### Parameters
 

--- a/source/references/2.7.4/type.markdown
+++ b/source/references/2.7.4/type.markdown
@@ -3833,7 +3833,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      |                   |                      |              |
 
 #### Parameters

--- a/source/references/2.7.5/type.markdown
+++ b/source/references/2.7.5/type.markdown
@@ -3833,7 +3833,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      |                   |                      |              |
 
 #### Parameters

--- a/source/references/2.7.6/type.markdown
+++ b/source/references/2.7.6/type.markdown
@@ -3836,7 +3836,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.8/type.markdown
+++ b/source/references/2.7.8/type.markdown
@@ -4082,7 +4082,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/2.7.9/type.markdown
+++ b/source/references/2.7.9/type.markdown
@@ -4082,7 +4082,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 |                | *X*             |                      |                   |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/3.0.0/type.markdown
+++ b/source/references/3.0.0/type.markdown
@@ -4485,7 +4485,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/3.0.1/type.markdown
+++ b/source/references/3.0.1/type.markdown
@@ -4490,7 +4490,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/3.0.2/type.markdown
+++ b/source/references/3.0.2/type.markdown
@@ -4497,7 +4497,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      |                       | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      |                       | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  |                       | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                       |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  |                       | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      |                       | *X*               |                      |              |
 
 #### Parameters

--- a/source/references/3.1.0/type.markdown
+++ b/source/references/3.1.0/type.markdown
@@ -4501,7 +4501,7 @@ hpuxuseradd      | *X*               |                 |                | *X*   
 ldap             |                   |                 |                |                 |                      |                       | *X*               |                      |              |
 pw               | *X*               |                 | *X*            | *X*             |                      |                       | *X*               |                      |              |
 user_role_add    | *X*               |                 |                | *X*             | *X*                  |                       | *X*               | *X*                  |              |
-useradd          | *X*               |                 | *X*            | *X*             |                      |                       |                   |                      | *X*          |
+useradd          | *X*               |                 | *X*            | *X*             | *X*                  |                       | *X*               |                      | *X*          |
 windows_adsi     |                   |                 |                | *X*             |                      |                       | *X*               |                      |              |
 
 #### Parameters


### PR DESCRIPTION
The manages password and manages password age features of useradd were
inaccurately documented.

Support to manage passwords was added for 'useradd' in 0.22.4
Support to manage password ages was added for 'useradd'  in 2.6.2

This change retrofits all documents to reflect the appropriate features at the
time they were introduced
