### PR TITLE
(#19233) No variable interpolation for regex

### DIFF
--- a/source/puppet/2.7/reference/lang_datatypes.markdown
+++ b/source/puppet/2.7/reference/lang_datatypes.markdown
@@ -371,7 +371,7 @@ Regular expressions are written as [standard Ruby regular expressions](http://ww
     }
 {% endhighlight %}
 
-Alternate forms of regex quoting are not allowed.
+Alternate forms of regex quoting are not allowed and Ruby-style variable interpolation is not available.
 
 ### Regex Options
 

--- a/source/puppet/3/reference/lang_datatypes.markdown
+++ b/source/puppet/3/reference/lang_datatypes.markdown
@@ -359,7 +359,7 @@ Regular expressions are written as [standard Ruby regular expressions](http://ww
     }
 {% endhighlight %}
 
-Alternate forms of regex quoting are not allowed.
+Alternate forms of regex quoting are not allowed and Ruby-style variable interpolation is not available.
 
 ### Regex Options
 


### PR DESCRIPTION
Currently, the Datatype docs claim that:

> Regular expressions are written as standard Ruby regular expressions (valid
> for the version of Ruby being used by Puppet)

However a notable feature of forward-slash quoted Ruby regular expressions that
we do not support is variable interpolation.
