### PR TITLE
Swap fileserver wiki link for fileserver docs

### DIFF
--- a/source/guides/rest_api.markdown
+++ b/source/guides/rest_api.markdown
@@ -224,7 +224,7 @@ Get a file from the file server.
 
 GET `/file_{metadata, content}/{file}`
 
-File serving is covered in more depth on the [wiki](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration)
+File serving is covered in more depth in the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html)
 
 ### Node
 

--- a/source/references/2.6.1/type.markdown
+++ b/source/references/2.6.1/type.markdown
@@ -827,7 +827,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.10/type.markdown
+++ b/source/references/2.6.10/type.markdown
@@ -832,7 +832,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.11/type.markdown
+++ b/source/references/2.6.11/type.markdown
@@ -832,7 +832,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.12/type.markdown
+++ b/source/references/2.6.12/type.markdown
@@ -832,7 +832,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.13/type.markdown
+++ b/source/references/2.6.13/type.markdown
@@ -842,7 +842,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.14/type.markdown
+++ b/source/references/2.6.14/type.markdown
@@ -915,7 +915,7 @@ slightly: `apply` will look such a file up on the module path
 on the local host, whereas `agent` will connect to the
 puppet server that it received the manifest from.
 
-See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
 and use file services within Puppet.
 
 If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.15/type.markdown
+++ b/source/references/2.6.15/type.markdown
@@ -915,7 +915,7 @@ slightly: `apply` will look such a file up on the module path
 on the local host, whereas `agent` will connect to the
 puppet server that it received the manifest from.
 
-See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
 and use file services within Puppet.
 
 If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.16/type.markdown
+++ b/source/references/2.6.16/type.markdown
@@ -915,7 +915,7 @@ slightly: `apply` will look such a file up on the module path
 on the local host, whereas `agent` will connect to the
 puppet server that it received the manifest from.
 
-See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
 and use file services within Puppet.
 
 If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.17/type.markdown
+++ b/source/references/2.6.17/type.markdown
@@ -915,7 +915,7 @@ slightly: `apply` will look such a file up on the module path
 on the local host, whereas `agent` will connect to the
 puppet server that it received the manifest from.
 
-See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
 and use file services within Puppet.
 
 If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.18/type.markdown
+++ b/source/references/2.6.18/type.markdown
@@ -916,7 +916,7 @@ slightly: `apply` will look such a file up on the module path
 on the local host, whereas `agent` will connect to the
 puppet server that it received the manifest from.
 
-See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
 and use file services within Puppet.
 
 If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.2/type.markdown
+++ b/source/references/2.6.2/type.markdown
@@ -827,7 +827,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.3/type.markdown
+++ b/source/references/2.6.3/type.markdown
@@ -826,7 +826,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.4/type.markdown
+++ b/source/references/2.6.4/type.markdown
@@ -826,7 +826,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.5/type.markdown
+++ b/source/references/2.6.5/type.markdown
@@ -802,7 +802,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.6/type.markdown
+++ b/source/references/2.6.6/type.markdown
@@ -802,7 +802,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.7/type.markdown
+++ b/source/references/2.6.7/type.markdown
@@ -808,7 +808,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.8/type.markdown
+++ b/source/references/2.6.8/type.markdown
@@ -832,7 +832,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.6.9/type.markdown
+++ b/source/references/2.6.9/type.markdown
@@ -832,7 +832,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.7.0/type.markdown
+++ b/source/references/2.7.0/type.markdown
@@ -829,7 +829,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first

--- a/source/references/2.7.1/type.markdown
+++ b/source/references/2.7.1/type.markdown
@@ -829,7 +829,7 @@ source
     on the local host, whereas `agent` will connect to the
     puppet server that it received the manifest from.
 
-    See the [fileserver configuration documentation](http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration) for information on how to configure
+    See the [fileserver configuration documentation](http://docs.puppetlabs.com/guides/file_serving.html) for information on how to configure
     and use file services within Puppet.
 
     If you specify multiple file sources for a file, then the first


### PR DESCRIPTION
Many pages point to a wiki page for more information concerning fileserver
configuration:

  http://projects.puppetlabs.com/projects/puppet/wiki/File_Serving_Configuration

This page has been decomissioned and now points to an official puppet-docs
guide:

  http://docs.puppetlabs.com/guides/file_serving.html

This commit swaps the wiki links out for a direct link to the official docs.
