### PR TITLE
Added gcc to the list of packages required to install Passenger on Enterprise Linux.

### DIFF
--- a/source/guides/passenger.markdown
+++ b/source/guides/passenger.markdown
@@ -52,7 +52,7 @@ Debian/Ubuntu:
 RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 [EPEL](https://fedoraproject.org/wiki/EPEL) repository):
 
-    $ sudo yum install httpd httpd-devel mod_ssl ruby-devel rubygems
+    $ sudo yum install httpd httpd-devel mod_ssl ruby-devel rubygems gcc
 
 ### Install Rack/Passenger
 


### PR DESCRIPTION
Added the gcc package to the yum command for Passenger on Enterprise Linux. Without gcc, gem install passenger will not run successfully, causing confusion and great frustration for many users.
