### PR TITLE
fix hiera.yml for 1.9.x yaml parser

### DIFF
--- a/source/hiera/1/puppet.markdown
+++ b/source/hiera/1/puppet.markdown
@@ -247,9 +247,9 @@ Assuming a hierarchy of:
 
 {% highlight yaml %}
     :hierarchy:
-      - %{::clientcert}
-      - %{::osfamily}
-      - common
+      - '%{::clientcert}'
+      - '%{::osfamily}'
+      - 'common'
 {% endhighlight %}
 
 ...and given Hiera data like the following:


### PR DESCRIPTION
The yaml parser in ruby 1.9 and 2.0 doesn't believe that strings can start with
an unquoted `%` and will explode with a `found character that cannot start any
token while scanning for the next token` error.
