### PR TITLE
Fix collection example to use valid user parameters

### DIFF
--- a/source/guides/virtual_resources.markdown
+++ b/source/guides/virtual_resources.markdown
@@ -93,7 +93,7 @@ using or and and. You can also parenthesize these statements, as
 you might expect. So, a more complicated collection might look
 like:
 
-    User <| (group == dba or group == sysadmin) or title == luke |>
+    User <| (groups == dba or groups == sysadmin) or title == luke |>
 
 Realizing Resources
 -------------------


### PR DESCRIPTION
Switch group to groups as group is not a valid parameter of the user type.
