### PR TITLE
(#14704) Capitalized bare words are not strings

### DIFF
--- a/source/puppet/2.7/reference/lang_datatypes.markdown
+++ b/source/puppet/2.7/reference/lang_datatypes.markdown
@@ -80,7 +80,8 @@ Strings are unstructured text fragments of any length. They may or may not be su
 Bare (that is, not quoted) words are usually treated as single-word strings. To be treated as a string, a bare word must:
 
 * Not be a [reserved word][reserved]
-* Begin with a letter, and contain only letters, digits, hyphens (-), and underscores (_).
+* Begin with a lower case letter, and contain only letters, digits, hyphens (-), and underscores (_).
+  Bare words that begin with upper case letters are interpreted as [resource references](#resource-references).
 
 Bare word strings are usually used with attributes that accept a limited number of one-word values, such as `ensure`.
 

--- a/source/puppet/3/reference/lang_datatypes.markdown
+++ b/source/puppet/3/reference/lang_datatypes.markdown
@@ -80,7 +80,8 @@ Strings are unstructured text fragments of any length. They may or may not be su
 Bare (that is, not quoted) words are usually treated as single-word strings. To be treated as a string, a bare word must:
 
 * Not be a [reserved word][reserved]
-* Begin with a letter, and contain only letters, digits, hyphens (-), and underscores (_).
+* Begin with a lower case letter, and contain only letters, digits, hyphens (-), and underscores (_).
+  Bare words that begin with upper case letters are interpreted as [resource references](#resource-references).
 
 Bare word strings are usually used with attributes that accept a limited number of one-word values, such as `ensure`.
 


### PR DESCRIPTION
Clarify that bare words must start with a lower case letter in order to be
interpreted as strings. Bare words beginning with capital letters are
interpreted by the parser as resource references.
