### PR TITLE
(#14301) Selectors cannot return hash literals

### DIFF
--- a/source/puppet/2.7/reference/lang_conditional.markdown
+++ b/source/puppet/2.7/reference/lang_conditional.markdown
@@ -335,7 +335,7 @@ These are not normal variables, and have some special behaviors:
 
 Values may be any of the following:
 
-* A literal value
+* Any literal value, with the exception of hash literals
 * A variable
 * A [function][functions] call that returns a value
 * Another selector

--- a/source/puppet/3/reference/lang_conditional.markdown
+++ b/source/puppet/3/reference/lang_conditional.markdown
@@ -386,7 +386,7 @@ These are not normal variables, and have some special behaviors:
 
 Values may be any of the following:
 
-* A literal value
+* Any literal value, with the exception of hash literals
 * A variable
 * A [function][functions] call that returns a value
 * Another selector


### PR DESCRIPTION
Selectors can return any `rvalue` as defined by the grammer. Hash literals fall
under the category of `expressions` and are rejected by the parser when used as
the return value of a selector.
