### PR TITLE
(#21029) 3.x masters require OpenSSL 0.9.8o+

### DIFF
--- a/source/guides/platforms.markdown
+++ b/source/guides/platforms.markdown
@@ -89,7 +89,7 @@ Dependency | Puppet 2.x | Puppet 3.x
 [Facter]: http://www.puppetlabs.com/projects/facter/index.html
 [Hiera]: https://github.com/puppetlabs/hiera
 
-All other prerequisite Ruby libraries should come with any standard Ruby 1.8.2+ install.  Should your OS not come with the complete standard library (or you are using a custom Ruby build), these include:
+All other prerequisite Ruby libraries should come with any standard Ruby 1.8.5+ install.  Should your OS not come with the complete standard library (or you are using a custom Ruby build), these include:
 
 * base64
 * cgi
@@ -97,7 +97,7 @@ All other prerequisite Ruby libraries should come with any standard Ruby 1.8.2+ 
 * etc
 * fileutils
 * ipaddr
-* openssl
+* openssl (>= 0.9.8o if using a 3.x Puppet master or newer)
 * strscan
 * syslog
 * uri


### PR DESCRIPTION
In 3.x, the default digest algorithm for the CA certificate was upgraded to
SHA256 from SHA1. Agents communicating with 3.x masters will need OpenSSL 0.9.8x
or newer.
