### PR TITLE
Comment out InnoDB section

### DIFF
--- a/source/dashboard/manual/1.2/maintaining.markdown
+++ b/source/dashboard/manual/1.2/maintaining.markdown
@@ -48,7 +48,7 @@ Since Dashboard turns over a lot of data, its MySQL database should be periodica
 
 You should **optimize Dashboard's database monthly,** and we recommend creating a cron job to do so.
 
-InnoDB is Taking Up Too Much Disk Space
+<!--InnoDB is Taking Up Too Much Disk Space
 -----
 
 Over time, the innodb database can get quite hefty, especially in larger deployments with many nodes. In some cases it can get large enough to consume all the space in `var`, which makes bad things happen. When this happens, you can follow the steps below to slim it back down.
@@ -63,7 +63,7 @@ Over time, the innodb database can get quite hefty, especially in larger deploym
 
 5. Create new, empty databases by running this rake task: `# rake -f <FULL PATH TO DASHBOARD'S DIRECTORY>/Rakefile RAILS_ENV=production db:reset`.
 
-6. Repopulate the databases by importing the data from the backup you created in step 1 by running: `# mysql -p < /path/to/backup.sql`.
+6. Repopulate the databases by importing the data from the backup you created in step 1 by running: `# mysql -p < /path/to/backup.sql`. -->
 
 
 Cleaning Old Reports


### PR DESCRIPTION
Support discovered a bug that, when following document instructions in
InnoDB section, causes Puppet to be in a "nothing will run" state. This
edit comments out that section until a solution is found.
