### PR TITLE
Update sample hiera config for Pysch parser

### DIFF
--- a/source/hiera/1/configuring.markdown
+++ b/source/hiera/1/configuring.markdown
@@ -64,8 +64,8 @@ Each top-level key in the hash **must be a Ruby symbol with a colon (`:`) prefix
 :json:
   :datadir: /etc/puppet/hieradata
 :hierarchy:
-  - %{::clientcert}
-  - %{::custom_location}
+  - "%{::clientcert}"
+  - "%{::custom_location}"
   - common
 {% endhighlight %}
 


### PR DESCRIPTION
The previous sample hiera config was invalid yaml, which the Syck parser would
coerce into a string. The Pysch parser is less forgiving, and throws an error
like "Failed to start Hiera: Psych::SyntaxError:
(/etc/puppetlabs/puppet/hiera.yaml): found character that cannot start any
token while scanning for the next token at line 6 column 5" when that config is
used. % is a special delimeter in Yaml, so to use it as intended with Hiera, it
must be wrapped in quotes so that Pysch knows it is a string.
