### PR TITLE
[#20604] This commit addresses a documentation issue highlighted in #206...

### DIFF
--- a/source/hiera/1/hierarchy.markdown
+++ b/source/hiera/1/hierarchy.markdown
@@ -27,9 +27,9 @@ Each element in the hierarchy must be a **string,** which may or may not include
     # /etc/hiera.yaml
     ---
     :hierarchy:
-      - %{::clientcert}
-      - %{::environment}
-      - virtual_%{::is_virtual}
+      - "%{::clientcert}"
+      - "%{::environment}"
+      - "virtual_%{::is_virtual}"
       - common
 
 > **Terminology:** 
@@ -86,9 +86,9 @@ Assume the following hierarchy:
     # /etc/hiera.yaml
     ---
     :hierarchy:
-      - %{::clientcert}
-      - %{::environment}
-      - virtual_%{::is_virtual}
+      - "%{::clientcert}"
+      - "%{::environment}"
+      - "virtual_%{::is_virtual}"
       - common
 
 ...and the following set of data sources:


### PR DESCRIPTION
...04.

With out this patch, the documentation for hiera is inconsistent in how it shows strings with variables in them. On one page it shows them quoted (this is correct) and on another, it shows this unquoted (this is wrong).
This leads to confusion by users and customers and sometimes difficult to track down errors during puppet runs.

There are graphics on the hiearchies page that still needs to be updated (./images/hierarchy1.png and ./images/hierarchy2.png )
