### PR TITLE
Add missing {environment}/ prefix to GET /c_r_l/ca

### DIFF
--- a/source/guides/rest_api.markdown
+++ b/source/guides/rest_api.markdown
@@ -110,7 +110,7 @@ Example:
 
 Get the certificate revocation list.
 
-GET `/certificate_revocation_list/ca`
+GET `{environment}/certificate_revocation_list/ca`
 
 Example:
 


### PR DESCRIPTION
This resolves a variance between the published API and both its example and our live 3.2.x puppetmasters.
