### PR TITLE
(#21831) Add transaction_uuid to the 'Differences' section

### DIFF
--- a/source/_includes/reportformat/4.markdown
+++ b/source/_includes/reportformat/4.markdown
@@ -112,4 +112,5 @@ Puppet::Transaction::Event#status has the following meanings:
 
 ### Differences from Report Format 3
 
+* Puppet::Transaction::Report gained `transaction_uuid`.
 * Puppet::Resource::Status gained `containment_path`.


### PR DESCRIPTION
This should have been included in https://github.com/puppetlabs/puppet-docs/pull/192.
