### PR TITLE
Update language to refer to puppet agent and master

### DIFF
--- a/source/guides/troubleshooting.markdown
+++ b/source/guides/troubleshooting.markdown
@@ -444,7 +444,7 @@ variable which was set in the foo class.
 ### err: Could not retrieve catalog: Invalid parameter 'foo' for type 'bar'
 
 When you are developing new custom types, you should restart both
-the puppetmasterd and the puppetd before running the configuration
+the puppet master and the puppet agent before running the configuration
 using the new custom type. The pluginsync feature will then
 synchronise the files and the new code will be loaded when both
 daemons are restarted.


### PR DESCRIPTION
The `puppetmasterd` and `puppetd` names / commands are deprecated. Newer
releases of Puppet use `puppet agent` and `puppet master`, and very new
releases don't have those older commands at all.
