### PR TITLE
PuppetDB feature release 1.4 indexing changes

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -17,6 +17,7 @@ defaultnav:
   /puppetdb/1.1: puppetdb1.1.html
   /puppetdb/1.2: puppetdb1.2.html
   /puppetdb/1.3: puppetdb1.3.html
+  /puppetdb/1.4: puppetdb1.4.html
   /puppetdb/master: puppetdb_master.html
   /puppet/0.24/reference: puppet_0_24.html
   /puppet/0.25/reference: puppet_0_25.html
@@ -51,6 +52,11 @@ externalsources:
     url: /puppetdb/1.3
     repo: git://github.com/puppetlabs/puppetdb.git
     commit: origin/1.3.x
+    subdirectory: documentation
+  puppetdb_1.4:
+    url: /puppetdb/1.4
+    repo: git://github.com/puppetlabs/puppetdb.git
+    commit: origin/1.4.x
     subdirectory: documentation
   puppetdb_master:
     url: /puppetdb/master

--- a/source/_includes/puppetdb1.4.html
+++ b/source/_includes/puppetdb1.4.html
@@ -1,0 +1,84 @@
+<h2 id="puppetdb">PuppetDB 1.4</h2>
+
+<ul>
+  <li><strong>General Information</strong>
+    <ul>
+      <li>{% iflink "Overview & Requirements", "/puppetdb/1.4/index.html" %}</li>
+      <li>{% iflink "Frequently Asked Questions", "/puppetdb/1.4/puppetdb-faq.html" %}</li>
+      <li>{% iflink "Release Notes", "/puppetdb/1.4/release_notes.html" %}</li>
+      <li>{% iflink "Known Issues", "/puppetdb/1.4/known_issues.html" %}</li>
+      <li>{% iflink "Community Add-ons", "/puppetdb/1.4/community_add_ons.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Installation</strong>
+    <ul>
+      <li>{% iflink "Migrating Existing Data", "/puppetdb/1.4/migrate.html" %}</li>
+      <li>{% iflink "Installing via Puppet Module", "/puppetdb/1.4/install_via_module.html" %}</li>
+      <li>{% iflink "Installing From Packages", "/puppetdb/1.4/install_from_packages.html" %}</li>
+      <li>{% iflink "Installing from Source", "/puppetdb/1.4/install_from_source.html" %}</li>
+      <li>{% iflink "Upgrading PuppetDB", "/puppetdb/1.4/upgrade.html" %}</li>
+      <li>{% iflink "Connecting Puppet Masters", "/puppetdb/1.4/connect_puppet_master.html" %}</li>
+      <li>{% iflink "Connecting Standalone Puppet", "/puppetdb/1.4/connect_puppet_apply.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Configuration</strong>
+    <ul>
+      <li>{% iflink "Configuring PuppetDB", "/puppetdb/1.4/configure.html" %}</li>
+      <li>{% iflink "Setting Up SSL for PostgreSQL", "/puppetdb/1.4/postgres_ssl.html" %}</li>
+    </ul>
+  <li><strong>Usage/Admin</strong>
+    <ul>
+      <li>{% iflink "Using PuppetDB", "/puppetdb/1.4/using.html" %}</li>
+      <li>{% iflink "Maintaining and Tuning", "/puppetdb/1.4/maintain_and_tune.html" %}</li>
+      <li>{% iflink "Migrating Data", "/puppetdb/1.4/migrate.html" %}</li>
+      <li>{% iflink "Scaling Recommendations", "/puppetdb/1.4/scaling_recommendations.html" %}</li>
+      <li>{% iflink "Debugging with Remote REPL", "/puppetdb/1.4/repl.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Troubleshooting</strong>
+    <ul>
+      <li>{% iflink "KahaDB Corruption", "/puppetdb/1.4/trouble_kahadb_corruption.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>API</strong>
+    <ul>
+      <li>{% iflink "Overview", "/puppetdb/1.4/api/index.html" %}</li>
+      <li>{% iflink "Query Tutorial", "/puppetdb/1.4/api/query/tutorial.html" %}</li>
+      <li>{% iflink "Curl Tips", "/puppetdb/1.4/api/query/curl.html" %}</li>
+      <li>{% iflink "Command API", "/puppetdb/1.4/api/commands.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 2</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/1.4/api/query/v2/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/1.4/api/query/v2/operators.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/1.4/api/query/v2/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/1.4/api/query/v2/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/1.4/api/query/v2/nodes.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/1.4/api/query/v2/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/1.4/api/query/v2/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 1</strong>
+    <ul>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/1.4/api/query/v1/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/1.4/api/query/v1/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/1.4/api/query/v1/nodes.html" %}</li>
+      <li>{% iflink "Status Endpoint", "/puppetdb/1.4/api/query/v1/status.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/1.4/api/query/v1/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Experimental</strong>
+    <ul>
+      <li>{% iflink "Report Endpoint", "/puppetdb/1.4/api/query/experimental/report.html" %}</li>
+      <li>{% iflink "Event Endpoint", "/puppetdb/1.4/api/query/experimental/event.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format", "/puppetdb/1.4/api/wire_format/catalog_format.html" %}</li>
+      <li>{% iflink "Facts Wire Format", "/puppetdb/1.4/api/wire_format/facts_format.html" %}</li>
+      <li>{% iflink "Report Wire Format", "/puppetdb/1.4/api/wire_format/report_format.html" %}</li>
+    </ul>
+  </li>
+</ul>

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -9,6 +9,7 @@ PuppetDB is the fast, scalable, and reliable data warehouse for Puppet. It cache
 Documentation Versions
 -----
 
+* [PuppetDB 1.4](./1.4)
 * [PuppetDB 1.3](./1.3)
 * [PuppetDB 1.2](./1.2)
 * [PuppetDB 1.1](./1.1)


### PR DESCRIPTION
(Hi, I need a pre-review of this one, as we're prepping for a new PuppetDB feature release. We'll give you a shout when we're ready to merge ...)

This includes indexing changes for the new feature release for PuppetDB 1.4:
- A new version index page has been included, and referenced from the main
  index page.
- The source retrieval config now references the new 1.4.x branch.

Signed-off-by: Ken Barber ken@bob.sh
