### PR TITLE
added notice and example that the seed can also be a string

### DIFF
--- a/source/references/0.24.5/function.markdown
+++ b/source/references/0.24.5/function.markdown
@@ -102,7 +102,7 @@ statement.</p>
 
 ### fqdn_rand
 
-<p>Generates random  numbers based on the node's fqdn. The first argument sets the range. The second argument specifies a number to add to the seed and is optional.</p>
+<p>Generates random  numbers based on the node's fqdn. The first argument sets the range. The second argument specifies a number or string to add to the seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>
 </ul>

--- a/source/references/0.24.6/function.markdown
+++ b/source/references/0.24.6/function.markdown
@@ -102,7 +102,7 @@ statement.</p>
 
 ### fqdn_rand
 
-<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number to add to the  seed and is optional.</p>
+<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number or string to add to the  seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>
 </ul>

--- a/source/references/0.24.7/function.markdown
+++ b/source/references/0.24.7/function.markdown
@@ -102,7 +102,7 @@ statement.</p>
 
 ### fqdn_rand
 
-<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number to add to the  seed and is optional.</p>
+<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number or string to add to the  seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>
 </ul>

--- a/source/references/0.24.8/function.markdown
+++ b/source/references/0.24.8/function.markdown
@@ -102,7 +102,7 @@ statement.</p>
 
 ### fqdn_rand
 
-<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number to add to the  seed and is optional.</p>
+<p>Generates random numbers based on the node's fqdn. The first argument  sets the range.  The second argument specifies a number or string to add to the  seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>
 </ul>

--- a/source/references/0.24.9/function.markdown
+++ b/source/references/0.24.9/function.markdown
@@ -114,7 +114,7 @@ can be passed, and the first file that exists will be read in.</p>
 ### fqdn_rand
 
 <p>Generates random numbers based on the node's fqdn. The first argument
-sets the range.  The second argument specifies a number to add to the
+sets the range.  The second argument specifies a number or string to add to the
 seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>

--- a/source/references/0.25.0/function.markdown
+++ b/source/references/0.25.0/function.markdown
@@ -114,7 +114,7 @@ can be passed, and the first file that exists will be read in.</p>
 ### fqdn_rand
 
 <p>Generates random numbers based on the node's fqdn. The first argument
-sets the range.  The second argument specifies a number to add to the
+sets the range.  The second argument specifies a number or string to add to the
 seed and is optional.</p>
 <ul>
 <li><strong>Type</strong>: rvalue</li>

--- a/source/references/2.6.10/function.markdown
+++ b/source/references/2.6.10/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.11/function.markdown
+++ b/source/references/2.6.11/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.12/function.markdown
+++ b/source/references/2.6.12/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.13/function.markdown
+++ b/source/references/2.6.13/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.14/function.markdown
+++ b/source/references/2.6.14/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.15/function.markdown
+++ b/source/references/2.6.15/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.16/function.markdown
+++ b/source/references/2.6.16/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.17/function.markdown
+++ b/source/references/2.6.17/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.18/function.markdown
+++ b/source/references/2.6.18/function.markdown
@@ -189,10 +189,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.5/function.markdown
+++ b/source/references/2.6.5/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.6/function.markdown
+++ b/source/references/2.6.6/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.7/function.markdown
+++ b/source/references/2.6.7/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.8/function.markdown
+++ b/source/references/2.6.8/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.6.9/function.markdown
+++ b/source/references/2.6.9/function.markdown
@@ -188,10 +188,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.0/function.markdown
+++ b/source/references/2.7.0/function.markdown
@@ -201,10 +201,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.1/function.markdown
+++ b/source/references/2.7.1/function.markdown
@@ -201,10 +201,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.10/function.markdown
+++ b/source/references/2.7.10/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.11/function.markdown
+++ b/source/references/2.7.11/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.12/function.markdown
+++ b/source/references/2.7.12/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.13/function.markdown
+++ b/source/references/2.7.13/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.14/function.markdown
+++ b/source/references/2.7.14/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.16/function.markdown
+++ b/source/references/2.7.16/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.17/function.markdown
+++ b/source/references/2.7.17/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.18/function.markdown
+++ b/source/references/2.7.18/function.markdown
@@ -226,10 +226,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.19/function.markdown
+++ b/source/references/2.7.19/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.20/function.markdown
+++ b/source/references/2.7.20/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.21/function.markdown
+++ b/source/references/2.7.21/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.22/function.markdown
+++ b/source/references/2.7.22/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.3/function.markdown
+++ b/source/references/2.7.3/function.markdown
@@ -201,10 +201,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.4/function.markdown
+++ b/source/references/2.7.4/function.markdown
@@ -213,10 +213,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.5/function.markdown
+++ b/source/references/2.7.5/function.markdown
@@ -213,10 +213,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.6/function.markdown
+++ b/source/references/2.7.6/function.markdown
@@ -213,10 +213,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.8/function.markdown
+++ b/source/references/2.7.8/function.markdown
@@ -213,10 +213,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/2.7.9/function.markdown
+++ b/source/references/2.7.9/function.markdown
@@ -213,10 +213,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.0.0/function.markdown
+++ b/source/references/3.0.0/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.0.1/function.markdown
+++ b/source/references/3.0.1/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.0.2/function.markdown
+++ b/source/references/3.0.2/function.markdown
@@ -227,10 +227,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.1.0/function.markdown
+++ b/source/references/3.1.0/function.markdown
@@ -238,10 +238,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.1.1/function.markdown
+++ b/source/references/3.1.1/function.markdown
@@ -238,10 +238,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.2.1/function.markdown
+++ b/source/references/3.2.1/function.markdown
@@ -322,10 +322,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.2.2/function.markdown
+++ b/source/references/3.2.2/function.markdown
@@ -322,10 +322,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 

--- a/source/references/3.2.3/function.markdown
+++ b/source/references/3.2.3/function.markdown
@@ -325,10 +325,11 @@ fqdn_rand
 ---------
 Generates random numbers based on the node's fqdn. Generated random values
 will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
+The second argument specifies a number or string to add to the seed and is optional, for example:
 
     $random_number = fqdn_rand(30)
     $random_number_seed = fqdn_rand(30,30)
+    $random_number_seedstring = fqdn_rand(30,"foobar")
 
 - *Type*: rvalue
 


### PR DESCRIPTION
It wasn't clear to me why the seed has to be a number, when the seed just gets appended to the fqdn string.

https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/functions/fqdn_rand.rb

So I added an example with a string and a notice to the fqdn_rand section.
