### PR TITLE
lookupvar for empty variable returns nil not undefined

### DIFF
--- a/source/guides/custom_functions.markdown
+++ b/source/guides/custom_functions.markdown
@@ -41,7 +41,7 @@ your functions:
     loaded.
 -   To use a *fact* about a client, use `lookupvar('{fact name}')`
     instead of `Facter['{fact name}'].value`.  If the *fact* does not
-    exist, `lookupvar` returns `:undefined`. See examples below.
+    exist, `lookupvar` returns `nil`. See examples below.
 
 ### Where to put your functions
 
@@ -165,7 +165,7 @@ functions.
 {% highlight ruby %}
     module Puppet::Parser::Functions
       newfunction(:has_fact, :type => :rvalue) do |arg|
-        lookupvar(arg[0]) != :undefined
+        lookupvar(arg[0]) != nil
       end
     end
 {% endhighlight %}


### PR DESCRIPTION
As per Andy Parker's work, `lookupvar` in custom functions and
`scope.lookupvar` in a template will now return `nil` not `:undefined`
when a fact or variable has no value.
