### PR TITLE
Added instructions for accessing the pe-postgres user.

### DIFF
--- a/source/pe/3.0/maintain_console-db.markdown
+++ b/source/pe/3.0/maintain_console-db.markdown
@@ -62,6 +62,7 @@ Database backups
 
 You can back up and restore the console's database using the standard [PostgreSQL tool, `pg dump`](http://www.postgresql.org/docs/9.2/static/app-pgdump.html). Best practices recommend hourly local backups and backups to a remote system nightly for the `console`, `console_auth` and `puppetdb` databases, or as dictated by your company policy.
 
+The easiest way to gain access to the PE-configured PostgreSQL database is to use the `pe-postgres` user, via `su - pe-postgres -s '/bin/bash'`. All PostgreSQL-related command should succeed as that user.
 
 Changing the Console's Database User/Password
 -----


### PR DESCRIPTION
We tell users to use the built in postgres commands to access the databse, but don't make it clear how exactly to do that.

I realize that we shouldn't necessarily be in the business of documenting postgres, but this is something fairly specific to the way our particular postgres install is configured, when you build an all-in-one master.
