### PR TITLE
Gemfiles: update gem source URL to https://rubygems.org/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
-source "http://gems.rubyforge.org"
-source "http://gemcutter.org"
+source 'https://rubygems.org/'
 
 gem 'jekyll', :git => 'git://github.com/puppetlabs/jekyll.git', :branch => 'puppetdocs'
 gem 'maruku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,7 @@ GIT
       maruku (~> 0.5)
 
 GEM
-  remote: http://gems.rubyforge.org/
-  remote: http://gemcutter.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (3.2.14)
       activesupport (= 3.2.14)


### PR DESCRIPTION
This seems to be the conventional URL that most other Bundler-based projects use, and the old URLs both redirect there, anyway.
