### PR TITLE
(PP-295) Add PUPPET_AGENT_ENVIRONMENT command line option

### DIFF
--- a/source/windows/installing.markdown
+++ b/source/windows/installing.markdown
@@ -89,6 +89,7 @@ MSI Property            | Puppet Setting   | Default Value
 `PUPPET_MASTER_SERVER`  | [`server`][s]    | `puppet`
 `PUPPET_CA_SERVER`      | [`ca_server`][c] | Value of `PUPPET_MASTER_SERVER`
 `PUPPET_AGENT_CERTNAME` | [`certname`][r]  | Value of `facter fdqn` (must be lowercase)
+`PUPPET_AGENT_ENVIRONMENT` | [`environment`][e]  | `production`
 
 For example:
 
@@ -97,6 +98,7 @@ For example:
 [s]: /references/latest/configuration.html#server
 [c]: /references/latest/configuration.html#caserver
 [r]: /references/latest/configuration.html#certname
+[e]: /references/latest/configuration.html#environment
 
 Upgrading
 -----


### PR DESCRIPTION
Adds the ability to specify the environment configuration setting on
Windows during installation, for example:

```
msiexec /qn /i puppet.msi PUPPET_AGENT_ENVIRONMENT=dev
```
