### PR TITLE
(#21215) link to 2.7 generated references, not latest

### DIFF
--- a/source/puppet/2.7/reference/lang_conditional.markdown
+++ b/source/puppet/2.7/reference/lang_conditional.markdown
@@ -9,7 +9,7 @@ layout: default
 [regex]: ./lang_datatypes.html#regular-expressions
 [facts]: ./lang_variables.html#facts
 [equality]: ./lang_expressions.html#equality
-[fail]: /references/latest/function.html#fail
+[fail]: /references/2.7.latest/function.html#fail
 [regex_compare]: ./lang_expressions.html#regex-match
 [expressions]: ./lang_expressions.html
 [bool_convert]: ./lang_datatypes.html#automatic-conversion-to-boolean

--- a/source/puppet/2.7/reference/lang_datatypes.markdown
+++ b/source/puppet/2.7/reference/lang_datatypes.markdown
@@ -7,7 +7,7 @@ title: "Language: Data Types"
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax
-[regsubst]: /references/latest/function.html#regsubst
+[regsubst]: /references/2.7.latest/function.html#regsubst
 [function]: ./lang_functions.html
 [variables]: ./lang_variables.html
 [expression]: ./lang_expressions.html

--- a/source/puppet/2.7/reference/lang_exported.markdown
+++ b/source/puppet/2.7/reference/lang_exported.markdown
@@ -4,7 +4,7 @@ title: "Language: Exported Resources"
 ---
 
 [resources]: ./lang_resources.html
-[nagios_service]: /references/latest/type.html#nagiosservice
+[nagios_service]: /references/2.7.latest/type.html#nagiosservice
 [concat]: http://forge.puppetlabs.com/ripienaar/concat
 [title]: ./lang_resources.html#title
 [namevar]: ./lang_resources.html#namenamevar

--- a/source/puppet/2.7/reference/lang_functions.markdown
+++ b/source/puppet/2.7/reference/lang_functions.markdown
@@ -3,7 +3,7 @@ title: "Language: Functions"
 layout: default
 ---
 
-[func_ref]: /references/latest/function.html
+[func_ref]: /references/2.7.latest/function.html
 [compilation]: ./lang_summary.html#compilation-and-catalogs
 [forge]: http://forge.puppetlabs.com
 [custom]: /guides/custom_functions.html

--- a/source/puppet/2.7/reference/lang_node_definitions.markdown
+++ b/source/puppet/2.7/reference/lang_node_definitions.markdown
@@ -7,11 +7,11 @@ title: "Language: Node Definitions"
 [hiera]: https://github.com/puppetlabs/hiera
 <!-- TODO: need better link for site.pp and certname-->
 [sitepp]: lang_summary.html#files
-[certname]: /references/latest/configuration.html#certname
+[certname]: /references/2.7.latest/configuration.html#certname
 [classes]: ./lang_classes.html
 [nodescope]: ./lang_scope.html#node-scope
 [topscope]: ./lang_scope.html#top-scope
-[extlookup]: /references/latest/function.html#extlookup
+[extlookup]: /references/2.7.latest/function.html#extlookup
 [custom_functions]: /guides/custom_functions.html
 [import]: ./lang_import.html
 [regex]: ./lang_datatypes.html#regular-expressions
@@ -21,7 +21,7 @@ title: "Language: Node Definitions"
 [enc]: /guides/external_nodes.html
 [facts]: ./lang_variables.html#facts-and-built-in-variables
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[strict]: /references/latest/configuration.html#stricthostnamechecking
+[strict]: /references/2.7.latest/configuration.html#stricthostnamechecking
 [conditional]: ./lang_conditional.html
 
 

--- a/source/puppet/2.7/reference/lang_relationships.markdown
+++ b/source/puppet/2.7/reference/lang_relationships.markdown
@@ -10,9 +10,9 @@ title: "Language: Relationships and Ordering"
 [array]: ./lang_datatypes.html#arrays
 [class]: ./lang_classes.html
 [event]: ./lang_resources.html#behavior
-[service]: /references/latest/type.html#service
-[exec]: /references/latest/type.html#exec
-[mount]: /references/latest/type.html#mount
+[service]: /references/2.7.latest/type.html#service
+[exec]: /references/2.7.latest/type.html#exec
+[mount]: /references/2.7.latest/type.html#mount
 [metaparameters]: ./lang_resources.html#metaparameters
 [require_function]: ./lang_classes.html#declaring-a-class-with-require
 

--- a/source/puppet/2.7/reference/lang_reserved.markdown
+++ b/source/puppet/2.7/reference/lang_reserved.markdown
@@ -18,8 +18,8 @@ title: "Language: Reserved Words and Acceptable Names"
 [resources]: ./lang_resources.html
 [class]: ./lang_classes.html
 [qualified_var]: ./lang_variables.html#accessing-out-of-scope-variables
-[type_ref]: /references/latest/type.html
-[func_ref]: /references/latest/function.html
+[type_ref]: /references/2.7.latest/type.html
+[func_ref]: /references/2.7.latest/function.html
 
 Reserved Words
 -----

--- a/source/puppet/2.7/reference/lang_resources.markdown
+++ b/source/puppet/2.7/reference/lang_resources.markdown
@@ -9,7 +9,7 @@ title: "Language: Resources"
 [scope]: ./lang_scope.html
 [report]: /guides/reporting.html
 [append_attributes]: ./lang_classes.html#appending-to-resource-attributes
-[types]: /references/latest/type.html
+[types]: /references/2.7.latest/type.html
 [bareword]: ./lang_datatypes.html#bare-words
 [string]: ./lang_datatypes.html#strings
 [array]: ./lang_datatypes.html#arrays

--- a/source/puppet/2.7/reference/lang_summary.markdown
+++ b/source/puppet/2.7/reference/lang_summary.markdown
@@ -6,7 +6,7 @@ title: "Language: Summary"
 
 [autoload]: ./lang_namespaces.html#autoloader-behavior
 [config]: /guides/configuring.html
-[usecacheonfailure]: /references/latest/configuration.html#usecacheonfailure
+[usecacheonfailure]: /references/2.7.latest/configuration.html#usecacheonfailure
 [fileserve]: ./modules_fundamentals.html#files
 [sitepp]: /references/glossary.html#site-manifest
 [classes]: ./lang_classes.html
@@ -14,9 +14,9 @@ title: "Language: Summary"
 [resources]: ./lang_resources.html
 [chaining]: ./lang_relationships.html#chaining-arrows
 [modules]: ./modules_fundamentals.html
-[package]: /references/latest/type.html#package
-[file]: /references/latest/type.html#file
-[service]: /references/latest/type.html#service
+[package]: /references/2.7.latest/type.html#package
+[file]: /references/2.7.latest/type.html#file
+[service]: /references/2.7.latest/type.html#service
 [case]: ./lang_conditional.html#case-statements
 [fact]: ./lang_variables.html#facts-and-built-in-variables
 [variables]: ./lang_variables.html

--- a/source/puppet/2.7/reference/lang_tags.markdown
+++ b/source/puppet/2.7/reference/lang_tags.markdown
@@ -13,11 +13,11 @@ title: "Language: Tags"
 [collectors]: ./lang_collectors.html
 [reports]: /guides/reporting.html#make-masters-process-reports
 [report_format_2]: http://projects.puppetlabs.com/projects/puppet/wiki/Report_Format_2
-[tagmail]: /references/latest/report.html#tagmail
+[tagmail]: /references/2.7.latest/report.html#tagmail
 [tagmail_conf]: /guides/configuring.html#tagmailconf
-[tagmeta]: /references/latest/metaparameter.html#tag
-[tagfunction]: /references/latest/function.html#tag
-[tags_setting]: /references/latest/configuration.html#tags
+[tagmeta]: /references/2.7.latest/metaparameter.html#tag
+[tagfunction]: /references/2.7.latest/function.html#tag
+[tags_setting]: /references/2.7.latest/configuration.html#tags
 [tagnames]: ./lang_reserved.html#tags
 [relationships]: ./lang_relationships.html
 [containment]: ./lang_containment.html

--- a/source/puppet/2.7/reference/lang_virtual.markdown
+++ b/source/puppet/2.7/reference/lang_virtual.markdown
@@ -6,7 +6,7 @@ title: "Language: Virtual Resources"
 [resources]: ./lang_resources.html
 [references]: ./lang_datatypes.html#resource-references
 [classes]: ./lang_classes.html
-[realize_function]: /references/latest/function.html#realize
+[realize_function]: /references/2.7.latest/function.html#realize
 [include]: ./lang_classes.html#declaring-a-class-with-include
 [collectors]: ./lang_collectors.html
 [search_expression]: ./lang_collectors.html#search-expressions

--- a/source/puppet/2.7/reference/modules_installing.markdown
+++ b/source/puppet/2.7/reference/modules_installing.markdown
@@ -86,7 +86,7 @@ To install a module from the Puppet Forge, simply identify the desired module by
 
 ### Installing From Another Module Repository
 
-The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/latest/configuration.html#modulerepository) setting in [`puppet.conf`](/guides/configuring.html) or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `http://forge.puppetlabs.com`.
+The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/2.7.latest/configuration.html#modulerepository) setting in [`puppet.conf`](/guides/configuring.html) or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `http://forge.puppetlabs.com`.
 
 After setting the repository, follow the instructions above for installing from the Forge. 
 


### PR DESCRIPTION
When viewing the Puppet 2.7 docs, links to Generated References
should link to 2.7.latest to align with the version they're looking at.
Before this commit it linked to 'latest', or version 3 which may cause
confusion.

Reference: http://projects.puppetlabs.com/issues/21215
