### PR TITLE
(#18268) (#21243) (#22368) (#22700) Windows Installer Improvements

### DIFF
--- a/source/windows/installing.markdown
+++ b/source/windows/installing.markdown
@@ -71,6 +71,7 @@ Once the installer finishes:
 
     ![Start Menu icons][startmenu]
 
+ * Starting with version `3.3.1` of Puppet and `3.1.0` of Puppet Enterprise, Puppet is automatically added to the machine's PATH environment variable. This means you can open any command line and call `puppet`, `facter` and the few other batch files that are in the `bin` directory of the [Puppet installation](#program-directory). This will also add necessary items for the Puppet environment to the shell, but only for the duration of execution of each of the particular commands.
 
 Automated Installation
 -----
@@ -83,13 +84,17 @@ You can also specify `/l*v install.txt` to log the progress of the installation 
 
 The following public MSI properties can also be specified:
 
-MSI Property            | Puppet Setting   | Default Value
-------------------------|------------------|--------------
-`INSTALLDIR`            | n/a              | Version-dependent, [see below](#program-directory)
-`PUPPET_MASTER_SERVER`  | [`server`][s]    | `puppet`
-`PUPPET_CA_SERVER`      | [`ca_server`][c] | Value of `PUPPET_MASTER_SERVER`
-`PUPPET_AGENT_CERTNAME` | [`certname`][r]  | Value of `facter fdqn` (must be lowercase)
-`PUPPET_AGENT_ENVIRONMENT` | [`environment`][e]  | `production`
+Minimum Version      | MSI Property                  | Puppet Setting    | Default Value
+---------------------|-------------------------------|-------------------|--------------
+2.7.12 / PE 2.5.0    |`INSTALLDIR`                   | n/a               | Version-dependent; [see below](#program-directory)
+2.7.12 / PE 2.5.0    |`PUPPET_MASTER_SERVER`         | [`server`][s]     | `puppet`
+2.7.12 / PE 2.5.0    |`PUPPET_CA_SERVER`             | [`ca_server`][c]  | Value of `PUPPET_MASTER_SERVER`
+2.7.12 / PE 2.5.0    |`PUPPET_AGENT_CERTNAME`        | [`certname`][r]   | Value of `facter fdqn` (must be lowercase)
+3.3.1  / PE 3.1.0    |`PUPPET_AGENT_ENVIRONMENT`     | [`environment`][e]| `production`
+3.4.0 (unreleased)   |`PUPPET_AGENT_STARTUP_MODE`    | n/a               | `Automatic`; [see startup mode](#agent-startup-mode)
+3.4.0 (unreleased)   |`PUPPET_AGENT_ACCOUNT_USER`    | n/a               | `LocalSystem`; [see agent account](#agent-account)
+3.4.0 (unreleased)   |`PUPPET_AGENT_ACCOUNT_PASSWORD`| n/a               | No Value; [see agent account](#agent-account)
+3.4.0 (unreleased)   |`PUPPET_AGENT_ACCOUNT_DOMAIN`  | n/a               | `.`; [see agent account](#agent-account)
 
 For example:
 
@@ -164,6 +169,17 @@ puppet    | Puppet source
 service   | code to run puppet agent as a service
 sys       | Ruby and other tools
 
+### Agent Startup Mode
+
+The agent is set to `Automatic` startup by default, but allows for you to pass `Manual` or `Disabled` as well.
+
+ * `Automatic` means that the Puppet agent will start with windows and be running all the time in the background. This is the what you would choose when you want to run Puppet with a master.
+ * `Manual` means that the agent will start up only when it is started in the services console or through `net start` on the command line. Typically this used in advanced usages of Puppet.
+ * `Disabled` means that the agent will be installed but disabled and will not be able to start in the services console (unless you change the start up type in the services console first). This is desirable when you want to install puppet but you only want to invoke it as you specify and not use it with a master.
+
+### Agent Account
+
+By default, Puppet installs the agent with the built in `SYSTEM` account. This account does not have access to the network, therefore it is suggested that another account that has network access be specified. The account must be an existing account. In the case of a domain user, the account does not need to have accessed the box. If this account is not a local administrator and it is specified as part of the install, it will be added to the `Administrators` group on that particular node. The account will also be granted [`Logon as Service`](http://msdn.microsoft.com/en-us/library/ms813948.aspx) as part of the installation process. As an example, if you wanted to set the agent account to a domain user `AbcCorp\bob` you would call the installer from the command line appending the following items: `PUPPET_AGENT_ACCOUNT_DOMAIN=AbcCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password`.
 
 ### Data Directory
 
@@ -180,7 +196,7 @@ Windows' <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/bb7624
 
 OS Version| Path                                 | Default
 ----------|--------------------------------------|-----------------
-7, 2008   | `%PROGRAMDATA%`                      | `C:\ProgramData`
+7+, 2008+ | `%PROGRAMDATA%`                      | `C:\ProgramData`
 2003      | `%ALLUSERSPROFILE%\Application Data` | `C:\Documents and Settings\All Users\Application Data`
 
 Since the CommonAppData directory is a system folder, it is hidden by default. See <http://support.microsoft.com/kb/812003> for steps to show system and hidden files and folders.


### PR DESCRIPTION
Adding minimum version information to the documentation 
relating to new and unreleased versions of puppet code.
#22700 adds documentation relating to adding Puppet

to the path variable automatically and documents the 
first version of the installer that allows that.
#21243 - documentation surrounding the puppet agent

account user and how it is specified in the installer.
#22368 - enhances the previously submitted documentation

on 22368 with the puppet agent variable to add the 
minimum version.
#18628 - adds the documentation surrounding the

startup mode for windows and the different items you
can pass to the installer.
