### PR TITLE
Use _ prefix instead of _real suffix on variables

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -451,7 +451,7 @@ The following example follows the recommended style:
     class myservice($ensure='running') {
 
       if $ensure in [ running, stopped ] {
-        $ensure_real = $ensure
+        $_ensure = $ensure
       } else {
         fail('ensure parameter must be running or stopped')
       }
@@ -481,7 +481,7 @@ The following example follows the recommended style:
       }
 
       service { 'myservice':
-        ensure    => $ensure_real,
+        ensure    => $_ensure,
         hasstatus => true,
       }
     }
@@ -699,13 +699,13 @@ For example:
 
       include ntp::params
 
-      $server_real = $server ? {
+      $_server = $server ? {
         'UNSET' => $::ntp::params::server,
         default => $server,
       }
 
       notify { 'ntp':
-        message => "server=[$server_real]",
+        message => "server=[$_server]",
       }
 
     }
@@ -729,7 +729,7 @@ class ntp(
 
 Other SHOULD recommendations:
 
- * SHOULD use the \_real suffix to indicate a scope local variable for
+ * SHOULD use the `_` preffix to indicate a scope local variable for
    maintainability over time.
  * SHOULD use fully qualified namespace variables when pulling the value
    from the module params class to avoid namespace collisions.
@@ -757,13 +757,13 @@ how to switch from one to the other.
     +  $param = 'UNSET'
     +) {
     +  include paramstest::params
-    +  $param\_real = $param ? {
+    +  $\_param = $param ? {
     +    'UNSET' => $::paramstest::params::param,
     +    default => $param,
     +  }
        notify { 'TEST':
     -    message => " param=[$param] mandatory=[$mandatory]",
-    +    message => " param=[$param\_real] mandatory=[$mandatory]",
+    +    message => " param=[$\_param] mandatory=[$mandatory]",
        }
      }
 {% endhighlight %}

--- a/source/learning/files/examples/modules/ntp/manifests/init.pp
+++ b/source/learning/files/examples/modules/ntp/manifests/init.pp
@@ -48,10 +48,10 @@ class ntp ($servers = undef, $enable = true, $ensure = running) {
   }
   
   if $servers == undef {
-    $servers_real = $default_servers
+    $_servers = $default_servers
   }
   else {
-    $servers_real = $servers
+    $_servers = $servers
   }
   
   package { 'ntp':
@@ -65,6 +65,7 @@ class ntp ($servers = undef, $enable = true, $ensure = running) {
     subscribe => File['ntp.conf'],
   }
   
+  # Template uses $_servers
   file { 'ntp.conf':
     path    => '/etc/ntp.conf',
     ensure  => file,

--- a/source/learning/files/examples/modules/ntp/templates/ntp.conf.debian.erb
+++ b/source/learning/files/examples/modules/ntp/templates/ntp.conf.debian.erb
@@ -20,7 +20,7 @@ filegen clockstats file clockstats type day enable
 # pool: <http://www.pool.ntp.org/join.html>
 
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% servers_real.each do |server| -%>
+<% @_servers.each do |server| -%>
 server <%= server %>
 <% end -%>
 

--- a/source/learning/files/examples/modules/ntp/templates/ntp.conf.el.erb
+++ b/source/learning/files/examples/modules/ntp/templates/ntp.conf.el.erb
@@ -16,7 +16,7 @@ restrict -6 ::1
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% servers_real.each do |server| -%>
+<% @_servers.each do |server| -%>
 server <%= server %>
 <% end -%>
 

--- a/source/learning/modules2.markdown
+++ b/source/learning/modules2.markdown
@@ -113,14 +113,14 @@ So let's get back to our NTP module. The first thing we talked about wanting to 
       ...
 {% endhighlight %}
 
-Next, we'll change how we set that `$servers_real` variable that the template uses:
+Next, we'll change how we set that `$_servers` variable that the template uses:
 
 {% highlight ruby %}
       if $servers == undef {
-        $servers_real = $default_servers
+        $_servers = $default_servers
       }
       else {
-        $servers_real = $servers
+        $_servers = $servers
       }
 {% endhighlight %}
 
@@ -144,7 +144,7 @@ And... that's all it takes. If you declare the class with no attributes...
 
 There's a bit of trickery to notice: setting a variable or parameter to `undef` might seem odd, and we're only doing it because we want to be able to get the default servers without asking for them. (Remember, parameters can't be optional without an explicit default value.)
 
-Also, remember the business with the `$servers_real` variable? That was because the Puppet language won't let us re-assign the `$servers` variable within a given scope. If the default value we wanted was the same regardless of OS, we could just use it as the parameter default, but the extra logic to accomodate the per-OS defaults means we have to make a copy of the variable.
+Also, remember the business with the `$_servers` variable? That was because the Puppet language won't let us re-assign the `$servers` variable within a given scope. If the default value we wanted was the same regardless of OS, we could just use it as the parameter default, but the extra logic to accomodate the per-OS defaults means we have to make a copy of the variable.
 
 While we're in the NTP module, what else could we make into a parameter? Well, let's say you sometimes wanted to prevent the NTP daemon from being used as a server by other nodes. Or maybe you want to install and configure NTP, but not keep the daemon running. You could expose all of these as extra class parameters, and make changes in the manifest or the templates to use them.
 

--- a/source/learning/templates.markdown
+++ b/source/learning/templates.markdown
@@ -219,7 +219,7 @@ Next, we'll move the default NTP servers out of the config file and into the man
         }
       }
 
-      $servers_real = $default_servers
+      $_servers = $default_servers
 
       package { 'ntp':
         ensure => installed,
@@ -245,13 +245,13 @@ We're storing the servers in an array, so we can show how to iterate within a te
 
 ### Editing the Templates
 
-First, make each template use the `$servers_real` variable to create the list of `server` statements:
+First, make each template use the `$_servers` variable to create the list of `server` statements:
 
 {% highlight erb %}
     <%# /etc/puppetlabs/puppet/modules/ntp/templates/ntp %>
 
     # Managed by Class['ntp']
-    <% @servers_real.each do |this_server| -%>
+    <% @_servers.each do |this_server| -%>
     server <%= this_server %>
     <% end -%>
 
@@ -260,7 +260,7 @@ First, make each template use the `$servers_real` variable to create the list of
 
 What's this doing?
 
-* Using a non-printing Ruby tag to start a loop. We reference the `$servers_real` Puppet variable by the name `@servers_real`, then call Ruby's `each` method on it. Everything between `do |server| -%>` and the `<% end -%>` tag will be repeated for each item in the `$servers_real` array, with the value of that array item being assigned to the temporary `this_server` variable.
+* Using a non-printing Ruby tag to start a loop. We reference the `$_servers` Puppet variable by the name `@_servers`, then call Ruby's `each` method on it. Everything between `do |server| -%>` and the `<% end -%>` tag will be repeated for each item in the `$_servers` array, with the value of that array item being assigned to the temporary `this_server` variable.
 * Within the loop, we print the literal word `server`, followed by the value of the current array item.
 
 This snippet will produce something like the following:


### PR DESCRIPTION
On the whole, the style in manifests for variables that have been modified in a local scope and saved to a new variable name have shifted from using `$foo` -> `$foo_real` to using `$foo` -> `$_foo` due to the shortness of the form and semantic implications that `$_*` is not neccessarily human-friendly.
