### PR TITLE
Updated with valid rake tasks for console password reset.

### DIFF
--- a/source/pe/3.0/trouble_console-db.markdown
+++ b/source/pe/3.0/trouble_console-db.markdown
@@ -21,8 +21,8 @@ If you have forgotten the password of the console's initial admin user, you can 
 
 On the console server, run the following commands:
 
-    $ cd /opt/puppet/share/console-auth
-    $ sudo /opt/puppet/bin/rake db:create_user USERNAME="adminuser@example.com" PASSWORD="<password>" ROLE="Admin"
+    $ cd /opt/puppet/share/puppet-dashboard
+    $ sudo /opt/puppet/bin/bundle exec /opt/puppet/bin/rake -s -f /opt/puppet/share/console-auth/Rakefile db:create_user USERNAME="adminuser@example.com" PASSWORD="<password>" ROLE="Admin" RAILS_ENV=production
 
 You can now log in to the console as the user you just created, and use the normal admin tools to reset other users' passwords.
 

--- a/source/pe/3.1/trouble_console-db.markdown
+++ b/source/pe/3.1/trouble_console-db.markdown
@@ -21,8 +21,8 @@ If you have forgotten the password of the console's initial admin user, you can 
 
 On the console server, run the following commands:
 
-    $ cd /opt/puppet/share/console-auth
-    $ sudo /opt/puppet/bin/rake db:create_user USERNAME="adminuser@example.com" PASSWORD="<password>" ROLE="Admin"
+    $ cd /opt/puppet/share/puppet-dashboard
+    $ sudo /opt/puppet/bin/bundle exec /opt/puppet/bin/rake -s -f /opt/puppet/share/console-auth/Rakefile db:create_user USERNAME="adminuser@example.com" PASSWORD="<password>" ROLE="Admin" RAILS_ENV=production
 
 You can now log in to the console as the user you just created, and use the normal admin tools to reset other users' passwords.
 


### PR DESCRIPTION
As per Jira PE-2252, the method for invoking console-auth rake tasks has
changed.

This updates the docs to reflect that.
