### PR TITLE
Updated Passenger Documentation for Passenger 4.0.x

### DIFF
--- a/source/guides/passenger.markdown
+++ b/source/guides/passenger.markdown
@@ -149,11 +149,20 @@ puppetmaster port (8140). You can also see a similar file at `ext/rack/files/apa
         PassengerAppRoot /usr/share/puppet/rack/puppetmasterd
 
         <Directory /usr/share/puppet/rack/puppetmasterd/>
-            Options None
-            AllowOverride None
-            Order Allow,Deny
-            Allow from All
+          Options None
+          AllowOverride None
+          # Apply the right behavior depending on Apache version.
+          <IfVersion < 2.4>
+            Order allow,deny
+            Allow from all
+          </IfVersion>
+          <IfVersion >= 2.4>
+            Require all granted
+          </IfVersion>
         </Directory>
+
+        ErrorLog /var/log/httpd/puppet-server.example.com_ssl_error.log
+        CustomLog /var/log/httpd/puppet-server.example.com_ssl_access.log combined
     </VirtualHost>
 
 If this puppet master is not the certificate authority, you will


### PR DESCRIPTION
Several settings in the example vhost are no longer correct and can confuse users looking to set up Apache + Passenger for their Puppetmasters.  The commented version of Passenger has been updated to 4.0.x to reflect the current state of affairs, the RackAutodetect and PassengerUseGlobalQueue which throw errors and warnings have been removed, the PassengerAppRoot variable has been specified to allow the application to launch, and HTTPD 2.2.x and 2.4.x compatible directives have been added to the Directory permissions for future-proofing.
