### PR TITLE
(maint) Update community nav to point to jira workflow

### DIFF
--- a/source/_includes/community_nav.html
+++ b/source/_includes/community_nav.html
@@ -2,6 +2,6 @@
 
 <ul>
   <li>{% iflink "Community Guidelines and Code of Conduct", "/community/community_guidelines.html" %}</li>
-  <li>{% iflink "Redmine Workflow for Puppet Open-Source Projects", "/community/puppet_projects_redmine_workflow.html" %}</li>
+  <li>{% iflink "JIRA Workflow for Puppet Open-Source Projects", "/community/puppet_projects_workflow.html" %}</li>
   <li>{% iflink "Trivial Patch Exemption Policy", "/community/trivial_patch_exemption.html" %}</li>
 </ul>


### PR DESCRIPTION
The redmine workflow is gone, point to jira instead.
