### PR TITLE
( DOC-9 ) Fix ordering of units for report prune rake task

### DIFF
--- a/source/pe/3.1/maintain_console-db.markdown
+++ b/source/pe/3.1/maintain_console-db.markdown
@@ -54,7 +54,7 @@ For example, to delete reports more than one month old:
 
 Although this task **should be run regularly as a cron job,** the actual frequency at which you set it to run will depend on your site's policies.
 
-If you run the `reports:prune` task without any arguments, it will display further usage instructions. The available units of time are `mon`, `yr`, `day`, `min`, `wk`, and `hr`.
+If you run the `reports:prune` task without any arguments, it will display further usage instructions. The available units of time are `yr`, `mon`, `wk`, `day`, `hr`, and `min`.
 
 
 Database backups


### PR DESCRIPTION
This patch changes the ordering of the units for the report pruning rake task from random to descending chronologically. This makes the docs easier to read and understand.
