### PR TITLE
(doc) Fix variable name typo in custom function ruby exmple

### DIFF
--- a/source/guides/custom_functions.markdown
+++ b/source/guides/custom_functions.markdown
@@ -102,7 +102,7 @@ function like this:
 {% highlight ruby %}
     module Puppet::Parser::Functions
       newfunction(:rand, :type => :rvalue) do |args|
-        rand(vals.empty? ? 0 : args[0])
+        rand(args.empty? ? 0 : args[0])
       end
     end
 {% endhighlight %}


### PR DESCRIPTION
There's no other reference to 'vals' and 'args' seems appropriate
so this was likely a typo.
