### PR TITLE
(maint) Move Puppet 2.6 and 2.7 under "Unsupported Releases" in the Release Notes

### DIFF
--- a/source/release_notes/index.markdown
+++ b/source/release_notes/index.markdown
@@ -11,11 +11,11 @@ description: Links to Puppet and Puppet Enterprise release notes
 ### Current Release
 - [Puppet 3][3.x]
 
-### Maintenance and Security Branches
-- [Puppet 2.7][2.7]
-- [Puppet 2.6][2.6] (security fixes only)
+<!-- ### Maintenance and Security Branches -->
 
 ### Unsupported Releases
+- [Puppet 2.7][]
+- [Puppet 2.6][]
 - [Puppet 0.25][]
 - [Puppet 0.24][]
 - [Puppet 0.23][]


### PR DESCRIPTION
Also comment out the "Maintenance and Security Branches" section, we will add Puppet 3 there when 4 is released.
