### PR TITLE
PDB-264 Prepare documentation for PuppetDB 1.6.0rc1

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -20,6 +20,7 @@ defaultnav:
   /puppetdb/1.3: puppetdb1.3.html
   /puppetdb/1.4: puppetdb1.4.html
   /puppetdb/1.5: puppetdb1.5.html
+  /puppetdb/1.6: puppetdb1.6.html
   /puppetdb/master: puppetdb_master.html
   /puppet/0.24/reference: puppet_0_24.html
   /puppet/0.25/reference: puppet_0_25.html
@@ -67,6 +68,11 @@ externalsources:
     url: /puppetdb/1.5
     repo: git://github.com/puppetlabs/puppetdb.git
     commit: origin/1.5.x
+    subdirectory: documentation
+  puppetdb_1.6:
+    url: /puppetdb/1.6
+    repo: git://github.com/puppetlabs/puppetdb.git
+    commit: origin/1.6.x
     subdirectory: documentation
   puppetdb_master:
     url: /puppetdb/master

--- a/source/_includes/puppetdb1.6.html
+++ b/source/_includes/puppetdb1.6.html
@@ -1,0 +1,100 @@
+<h2 id="puppetdb">PuppetDB 1.6</h2>
+
+<p class="versionnote">This documentation is for an unreleased version of PuppetDB! If you are running PuppetDB from source on the 1.6 branch, this is the documentation for you; otherwise, please see the documentation for the <a href="/puppetdb/latest/">latest official release</a>.</p>
+
+<ul>
+  <li><strong>General Information</strong>
+    <ul>
+      <li>{% iflink "Overview & Requirements", "/puppetdb/1.6/index.html" %}</li>
+      <li>{% iflink "Frequently Asked Questions", "/puppetdb/1.6/puppetdb-faq.html" %}</li>
+      <li>{% iflink "Release Notes", "/puppetdb/1.6/release_notes.html" %}</li>
+      <li>{% iflink "Known Issues", "/puppetdb/1.6/known_issues.html" %}</li>
+      <li>{% iflink "Community Add-ons", "/puppetdb/1.6/community_add_ons.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Installation</strong>
+    <ul>
+      <li>{% iflink "Migrating Existing Data", "/puppetdb/1.6/migrate.html" %}</li>
+      <li>{% iflink "Installing via Puppet Module", "/puppetdb/1.6/install_via_module.html" %}</li>
+      <li>{% iflink "Installing From Packages", "/puppetdb/1.6/install_from_packages.html" %}</li>
+      <li>{% iflink "Installing from Source", "/puppetdb/1.6/install_from_source.html" %}</li>
+      <li>{% iflink "Upgrading PuppetDB", "/puppetdb/1.6/upgrade.html" %}</li>
+      <li>{% iflink "Connecting Puppet Masters", "/puppetdb/1.6/connect_puppet_master.html" %}</li>
+      <li>{% iflink "Connecting Standalone Puppet", "/puppetdb/1.6/connect_puppet_apply.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Configuration</strong>
+    <ul>
+      <li>{% iflink "Configuring PuppetDB", "/puppetdb/1.6/configure.html" %}</li>
+      <li>{% iflink "Setting Up SSL for PostgreSQL", "/puppetdb/1.6/postgres_ssl.html" %}</li>
+    </ul>
+  <li><strong>Usage/Admin</strong>
+    <ul>
+      <li>{% iflink "Using PuppetDB", "/puppetdb/1.6/using.html" %}</li>
+      <li>{% iflink "Maintaining and Tuning", "/puppetdb/1.6/maintain_and_tune.html" %}</li>
+      <li>{% iflink "Migrating Data", "/puppetdb/1.6/migrate.html" %}</li>
+      <li>{% iflink "Scaling Recommendations", "/puppetdb/1.6/scaling_recommendations.html" %}</li>
+      <li>{% iflink "Debugging with Remote REPL", "/puppetdb/1.6/repl.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Troubleshooting</strong>
+    <ul>
+      <li>{% iflink "KahaDB Corruption", "/puppetdb/1.6/trouble_kahadb_corruption.html" %}</li>
+      <li>{% iflink "Low Catalog Duplication", "/puppetdb/1.6/trouble_low_catalog_duplication.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>API</strong>
+    <ul>
+      <li>{% iflink "Overview", "/puppetdb/1.6/api/index.html" %}</li>
+      <li>{% iflink "Query Tutorial", "/puppetdb/1.6/api/query/tutorial.html" %}</li>
+      <li>{% iflink "Curl Tips", "/puppetdb/1.6/api/query/curl.html" %}</li>
+      <li>{% iflink "Command API", "/puppetdb/1.6/api/commands.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 3</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/1.6/api/query/v3/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/1.6/api/query/v3/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/1.6/api/query/v3/paging.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/1.6/api/query/v3/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/1.6/api/query/v3/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/1.6/api/query/v3/nodes.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/1.6/api/query/v3/catalogs.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/1.6/api/query/v3/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/1.6/api/query/v3/metrics.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/1.6/api/query/v3/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/1.6/api/query/v3/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/1.6/api/query/v3/evenT-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/1.6/api/query/v3/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/1.6/api/query/v3/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/1.6/api/query/v3/version.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 2</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/1.6/api/query/v2/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/1.6/api/query/v2/operators.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/1.6/api/query/v2/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/1.6/api/query/v2/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/1.6/api/query/v2/nodes.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/1.6/api/query/v2/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/1.6/api/query/v2/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 1</strong>
+    <ul>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/1.6/api/query/v1/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/1.6/api/query/v1/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/1.6/api/query/v1/nodes.html" %}</li>
+      <li>{% iflink "Status Endpoint", "/puppetdb/1.6/api/query/v1/status.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/1.6/api/query/v1/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format", "/puppetdb/1.6/api/wire_format/catalog_format.html" %}</li>
+      <li>{% iflink "Facts Wire Format", "/puppetdb/1.6/api/wire_format/facts_format.html" %}</li>
+      <li>{% iflink "Report Wire Format", "/puppetdb/1.6/api/wire_format/report_format.html" %}</li>
+    </ul>
+  </li>
+</ul>

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -23,9 +23,10 @@ The following documentation links are no longer actively maintained. You should 
 * [PuppetDB 1](./1)
 * [PuppetDB 0.9](./0.9)
 
-Development Versions
+Development and Pre-release Versions
 -----
 
-This version of the documentation represents a future feature or major release. This content only applies to the code available in the master branch of the PuppetDB git repository, so if you have downloaded a stable release you should consult the documentation above.
+This version of the documentation represents a future feature or major release. This content only applies to the code available in the master branch of the PuppetDB git repository or a release candidate, so if you have downloaded a stable release you should consult the documentation above.
 
+* [PuppetDB 1.6](./1.6)
 * [PuppetDB (master)](./master)


### PR DESCRIPTION
This commit prepares the documentation site for the upcoming 1.6.0rc1 release
of PuppetDB.

This slightly differs from our normal approach, in that we normally do not do
an RC release. This time, we are doing all the normal work for a feature
release but modifying the index change so that the pre-release is categorized
accordingly, and the 1.5 documentation stays prominent until we do the final.

When we do the final release, the link for 'latest' and the index update will
be required.

Signed-off-by: Ken Barber ken@bob.sh
