### PR TITLE
Fix typo in PuppetDB 1.6 index

### DIFF
--- a/source/_includes/puppetdb1.6.html
+++ b/source/_includes/puppetdb1.6.html
@@ -64,7 +64,7 @@
       <li>{% iflink "Metrics Endpoint", "/puppetdb/1.6/api/query/v3/metrics.html" %}</li>
       <li>{% iflink "Reports Endpoint", "/puppetdb/1.6/api/query/v3/reports.html" %}</li>
       <li>{% iflink "Events Endpoint", "/puppetdb/1.6/api/query/v3/events.html" %}</li>
-      <li>{% iflink "Event Counts Endpoint", "/puppetdb/1.6/api/query/v3/evenT-counts.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/1.6/api/query/v3/event-counts.html" %}</li>
       <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/1.6/api/query/v3/aggregate-event-counts.html" %}</li>
       <li>{% iflink "Server Time Endpoint", "/puppetdb/1.6/api/query/v3/server-time.html" %}</li>
       <li>{% iflink "Version Endpoint", "/puppetdb/1.6/api/query/v3/version.html" %}</li>


### PR DESCRIPTION
I've inadvertently introduced a capital T somehow into the index, this patch
fixes that.

Signed-off-by: Ken Barber ken@bob.sh
