### PR TITLE
Added free space psql vaccuum note.

### DIFF
--- a/source/pe/3.1/maintain_console-db.markdown
+++ b/source/pe/3.1/maintain_console-db.markdown
@@ -37,6 +37,8 @@ This task, `rake db:raw:optimize[mode]`,  runs in three modes:
 
 To run the task, change your working directory to `/opt/puppet/share/puppet-dashboard` and make sure your PATH variable contains `/opt/puppet/bin` (or use the full path to the rake binary). Then run the task `rake db:raw:optimize[mode]`. You can disregard any error messages about insufficient privileges to vacuum certain system objects because these objects should not require vacuuming. If you believe they do, you can do so manually by logging in to psql (or your tool of choice) as a database superuser.
 
+Please note that you should have at least as much free space available as is curently in use, on the partition where your postgresql data is stored, prior to attempting a full vacuum. If you are using the PE-vendored postgresql, the postgres data is kept in `/opt/puppet/var/lib/pgsql/`.
+
 The PostgreSQL docs contain more detailed information about [vacuuming](http://www.postgresql.org/docs/9.2/static/routine-vacuuming.html) and [reindexing](http://www.postgresql.org/docs/9.2/static/sql-reindex.html).
 
 


### PR DESCRIPTION
A large amount of free space (as much as is used), is generally required for a full vacuum of psql. We should note this in the docs, as it bites users fairly frequently.
