### PR TITLE
Parenthesis are mandatory with rvalue-functions

### DIFF
--- a/source/puppet/3/reference/lang_functions.markdown
+++ b/source/puppet/3/reference/lang_functions.markdown
@@ -44,7 +44,7 @@ In the examples above, `template`, `include`, and `str2bool` are all functions. 
 The general form of a function call is:
 
 * The name of the function, as a bare word
-* An optional opening parenthesis
+* An opening parenthesis, that is optional when the function is used as a statement
 * Any number of **arguments,** separated with commas; the number and type of arguments are controlled by the function
 * A closing parenthesis, if an open parenthesis was used
 


### PR DESCRIPTION
This fixes a problem with the reference documentation where it was not
explained that parenthesis are only optional for statement-level
functions.

Here is an example :

```
$a = function "argument" $b = literal
```

With the "old" parser, this will result in a parse error. With the new
parser, it seems that it is interpreted like this :

```
$a = 'function';
'argument';
$b = 'literal';
```

Which might cause puzzling bugs.
