### PR TITLE
Update to RHEL6 instructions, requires additional channel

### DIFF
--- a/source/guides/puppetlabs_package_repositories.markdown
+++ b/source/guides/puppetlabs_package_repositories.markdown
@@ -24,7 +24,7 @@ The [yum.puppetlabs.com](https://yum.puppetlabs.com) repository supports the fol
 
 {% include platforms_redhat_like.markdown %}
 
-Enabling this repository will let you install Puppet without requiring any other external repositories like EPEL.
+Enabling this repository will let you install Puppet in Enterprise Linux 5 without requiring any other external repositories like EPEL. For Enterprise Linux 6, you will need to [enable the Optional Channel](https://access.redhat.com/site/documentation/en-US/OpenShift_Enterprise/1/html/Client_Tools_Installation_Guide/Installing_Using_the_Red_Hat_Enterprise_Linux_Optional_Channel.html) for the rubygems dependency.
 
 To enable the repository, run the command below that corresponds to your OS version and architecture:
 


### PR DESCRIPTION
To install puppet on RHEL6, an additional channel (repo) is required,
the RHEL6 Optional Channel. Rather than provide explicit directions, as
they have changed a few times over the life of RHEL6, a link is provide
to redhat.com for the viewer to follow.
