### PR TITLE
PDB-370 Prepare 1.6.0 PuppetDB documentation for final release

### DIFF
--- a/source/_includes/puppetdb1.6.html
+++ b/source/_includes/puppetdb1.6.html
@@ -1,7 +1,5 @@
 <h2 id="puppetdb">PuppetDB 1.6</h2>
 
-<p class="versionnote">This documentation is for an unreleased version of PuppetDB! If you are running PuppetDB from source on the 1.6 branch, this is the documentation for you; otherwise, please see the documentation for the <a href="/puppetdb/latest/">latest official release</a>.</p>
-
 <ul>
   <li><strong>General Information</strong>
     <ul>

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -9,6 +9,7 @@ PuppetDB is the fast, scalable, and reliable data warehouse for Puppet. It cache
 Stable Versions
 -----
 
+* [PuppetDB 1.6](./1.6)
 * [PuppetDB 1.5](./1.5)
 
 Legacy Versions
@@ -28,5 +29,4 @@ Development and Pre-release Versions
 
 This version of the documentation represents a future feature or major release. This content only applies to the code available in the master branch of the PuppetDB git repository or a release candidate, so if you have downloaded a stable release you should consult the documentation above.
 
-* [PuppetDB 1.6](./1.6)
 * [PuppetDB (master)](./master)


### PR DESCRIPTION
This does two things:
- Removes the warning that this is a pre-release version
- Changes the index so that 1.6 is now marked as 'stable'

Signed-off-by: Ken Barber ken@bob.sh
