### PR TITLE
Changed link to Facter Core Facts from 1.6 to 1.7

### DIFF
--- a/source/index.markdown
+++ b/source/index.markdown
@@ -99,7 +99,7 @@ Hiera is a key/value lookup tool for configuration data, built to make Puppet be
 
 Facter is Puppet's cross-platform system profiling library. It discovers and reports per-node facts, which are available in your Puppet manifests as variables.
 
-* [The list of core facts](/facter/1.6/core_facts.html) lists and describes every built-in fact that ships with Facter.
+* [The list of core facts](/facter/1.7/core_facts.html) lists and describes every built-in fact that ships with Facter.
 * [The custom facts guide](/guides/custom_facts.html) explains how to write and distribute your own facts.
 
 


### PR DESCRIPTION
I noticed that Core Facts is linking to an old version of Facter on http://docs.puppetlabs.com/
