### PR TITLE
PuppetDB: Remove v1 query API from master

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -81,15 +81,6 @@
       <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v2/metrics.html" %}</li>
     </ul>
   </li>
-  <li><strong>Query API Version 1</strong>
-    <ul>
-      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v1/facts.html" %}</li>
-      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v1/resources.html" %}</li>
-      <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v1/nodes.html" %}</li>
-      <li>{% iflink "Status Endpoint", "/puppetdb/master/api/query/v1/status.html" %}</li>
-      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v1/metrics.html" %}</li>
-    </ul>
-  </li>
   <li><strong>Wire Formats</strong>
     <ul>
       <li>{% iflink "Catalog Wire Format", "/puppetdb/master/api/wire_format/catalog_format.html" %}</li>


### PR DESCRIPTION
We have retired the v1 query API in the master revision of PuppetDB (known as
the 2.x branch). This patch removes the v1 parts from the LHS index of the
docs page.

Signed-off-by: Ken Barber ken@bob.sh
