### PR TITLE
Clarify Facter 2.0.1 release notes

### DIFF
--- a/source/facter/2.0/release_notes.markdown
+++ b/source/facter/2.0/release_notes.markdown
@@ -17,19 +17,15 @@ Facter 2.0.1 is the first release in the Facter 2 series. (See the [note below](
 
 [FACT-134: Perform basic sanity checks on Facter output](https://tickets.puppetlabs.com/browse/FACT-134)
 
-Ensures that Facter facts can only return valid data.
+Facter now does sanity checking on the output of facts. Facter previously assumed that all facts would be of type String but did not enforce this; Facter now validates that facts are one of (Integer, Float, TrueClass, FalseClass, NilClass, String, Array, Hash).
 
 [FACT-237: Allow fact resolutions to be built up piece-wise](https://tickets.puppetlabs.com/browse/FACT-237)
 
-Introduces aggregate resolutions for facts.
-
-[FACT-238: Extract common behaviors in aggregate and simple resolutions](https://tickets.puppetlabs.com/browse/FACT-238)
-
-Refines the Facter API to account for the new distinction between simple and aggregate resolutions.
-
 [FACT-239: Expose different resolution types in DSL](https://tickets.puppetlabs.com/browse/FACT-239)
 
-Expands the Facter DSL to add more flexibility in declaring new facts and resolutions.
+Introduces aggregate resolutions for facts. Aggregate resolutions allow facts
+to be extended at runtime and provide a simplified way of building up complex
+fact values.
 
 [FACT-341: Windows operatingsystemrelease support](https://tickets.puppetlabs.com/browse/FACT-341)
 
@@ -44,11 +40,7 @@ Removes vendored code for CFPropertyList in favor of treating it as a separate d
 
 [FACT-163: Fact loading logic is overly complicated](https://tickets.puppetlabs.com/browse/FACT-163)
 
-Simplifies the loading of facts by removing some extraneous tasks.
-
-[FACT-234: Add Facts showing the UUID of partitions](https://tickets.puppetlabs.com/browse/FACT-234)
-
-Adds a `blockdevice_{dev}_uuid` fact that shows a partition's UUID.
+In Facter 1.x the fact search path would be recursively loaded, but only when using Facter via the command line. In Facter 2.0 only fact files at the top level of the search path will be loaded, which matches the behavior when loading facts with Puppet.
 
 [FACT-266: Backport Facter::Util::Confine improvements to Facter 2](https://tickets.puppetlabs.com/browse/FACT-266)
 
@@ -62,17 +54,9 @@ Code that had previously been marked deprecated has now been removed.
 
 Previous versions of Facter would interpret an empty string (and only an empty string) as `nil`. Now that facts can return more than just strings (i.e., they can directly return `nil`), empty strings no longer have this special case.
 
-[FACT-327: Facter command functionality should be pluggable/modular](https://tickets.puppetlabs.com/browse/FACT-327)
-
-The internal Facter API has been refactored to allow for different behavior for executing commands depending on the version of Ruby.
-
 [FACT-186: Build Windows-specific gem](https://tickets.puppetlabs.com/browse/FACT-186)
 
 Adds Windows-specific gem dependencies for Facter 2.
-
-[FACT-159: Specify command line output of structured facts](https://tickets.puppetlabs.com/browse/FACT-159)
-
-Facter's CLI tool outputs plaintext by default, even for structured facts. JSON and YAML formats are also available.
 
 [FACT-194: Merge external facts support to Facter 2](https://tickets.puppetlabs.com/browse/FACT-194)
 
@@ -91,17 +75,9 @@ The man page for Facter 2 now includes the new command line options.
 
 ### Bug Fixes
 
-[FACT-93: Facter Solaris is outputting to stderr](https://tickets.puppetlabs.com/browse/FACT-93)
-
-Solaris-specific facts were outputting to standard error. They now output to /dev/null.
-
 [FACT-202: Fix undefined path in macaddress.rb](https://tickets.puppetlabs.com/browse/FACT-202)
 
 One of the possible resolutions for the `macaddress` fact would incorrectly return `nil`. This release fixes the bug.
-
-[FACT-326: Facter 2 throws NameError using uninitialized constant](https://tickets.puppetlabs.com/browse/FACT-326)
-
-This bug caused facter to throw a NameError during acceptance tests due to an uninitialized constant. The bug has been fixed.
 
 
 Facter 2.0.0


### PR DESCRIPTION
This expands documentation on important release notes and removes
links to several issues that are either inconsequential, introduced and
resolved only in the facter-2 branch, or are internal refactors.
