### PR TITLE
Fixed language around upgrading with multiple roles on single node

### DIFF
--- a/source/pe/3.2/install_upgrading.markdown
+++ b/source/pe/3.2/install_upgrading.markdown
@@ -19,7 +19,7 @@ The process involves the following steps, which *must be performed in the follow
 4. Upgrade Console
 5. Upgrade Agents
 
-If more than one of these roles is present on a given node (for example your master and console run on the same node), the installer will upgrade each role in the correct order.
+If you have an all-in-one master (e.g. the master, console, and PuppetDB are installed on the same node) the installer will upgrade each role in order, automatically.
 
 > ![windows logo](./images/windows-logo-small.jpg) To upgrade Windows agents, simply download and run the new MSI package as described in [Installing Windows Agents](./install_windows.html). However, be sure to upgrade your master, console, and database nodes first.
 


### PR DESCRIPTION
It's not actually possible to have the "master and console on the same
node" without doing an all-in-one installation - the original language
makes it sound like you can have master and console on one node, and
PuppetDB on another. Not the case.
