### PR TITLE
PuppetDB toc: Add new v4 end-points to master index

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -52,6 +52,25 @@
       <li>{% iflink "Command API", "/puppetdb/master/api/commands.html" %}</li>
     </ul>
   </li>
+  <li><strong>Query API Version 4 (experimental)</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v4/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v4/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/master/api/query/v4/paging.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v4/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v4/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v4/nodes.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v4/catalogs.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v4/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v4/metrics.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v4/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v4/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v4/evenT-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v4/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v4/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v4/version.html" %}</li>
+    </ul>
+  </li>
   <li><strong>Query API Version 3</strong>
     <ul>
       <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v3/query.html" %}</li>


### PR DESCRIPTION
We have added v4 elements to the source documentation, this adds the links to
the ToC as well.

Signed-off-by: Ken Barber ken@bob.sh
