### PR TITLE
Updated the wire format links for the deprecated versions.

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -103,9 +103,16 @@
   </li>
   <li><strong>Wire Formats</strong>
     <ul>
-      <li>{% iflink "Catalog Wire Format", "/puppetdb/master/api/wire_format/catalog_format.html" %}</li>
-      <li>{% iflink "Facts Wire Format", "/puppetdb/master/api/wire_format/facts_format.html" %}</li>
-      <li>{% iflink "Report Wire Format", "/puppetdb/master/api/wire_format/report_format.html" %}</li>
+      <li>{% iflink "Catalog Wire Format - v4", "/puppetdb/master/api/wire_format/catalog_format_v4.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v2", "/puppetdb/master/api/wire_format/facts_format_v2.html" %}</li>
+      <li>{% iflink "Report Wire Format - v3", "/puppetdb/master/api/wire_format/report_format_v3.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats - Deprecated</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format - v1", "/puppetdb/master/api/wire_format/catalog_format_v1.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v1", "/puppetdb/master/api/wire_format/facts_format_v1.html" %}</li>
+      <li>{% iflink "Report Wire Format - v1", "/puppetdb/master/api/wire_format/report_format_v1.html" %}</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Added a new heading for the new wire format versions.
