### PR TITLE
Add 3.5 links on the front-page and old reference

### DIFF
--- a/source/index.markdown
+++ b/source/index.markdown
@@ -15,7 +15,7 @@ Puppet manages your servers: you describe machine configurations in an easy-to-r
 
 - [The Learning Puppet series](/learning) is a guided tutorial for new users, which includes a free VM to run exercises on and experiment with. Go from "What's that?" to "I can do it" in just a few hours.
 - [The installation guide](/guides/installation.html) can help you install and configure the current open-source Puppet releases.
-- [The Puppet 3 Reference Manual](/puppet/3/reference)
+- [The Puppet 3.5 Reference Manual](/puppet/3.5/reference), and the older [Puppet 3 Manual](/puppet/3/reference) covering Puppet 3.0-3.4.
 - [The Puppet 2.7 Reference Manual](/puppet/2.7/reference)
 - [The latest type reference](/references/latest/type.html) covers all of the built-in resource types and their available attributes. New users should start elsewhere, but experienced users will spend most of their time in this one page.
 - [The glossary](/references/glossary.html) explains the terminology you'll encounter when reading about Puppet.

--- a/source/puppet/3/reference/index.markdown
+++ b/source/puppet/3/reference/index.markdown
@@ -5,7 +5,9 @@ canonical: "/puppet/latest/reference/index.html"
 ---
 
 
-Welcome to the Puppet 3 Reference Manual! Use the navigation to the left to get around. [Documentation for Puppet 2.7 can be found here.](/puppet/2.7/reference)
+Welcome to the Puppet 3 Reference Manual! Use the navigation to the left to get around. 
+
+This manual covers Puppet versions 3.0 through 3.4. For Puppet 3.5 and above, use [the Puppet 3.5 Reference Manual](/puppet/3.5/reference). [Documentation for Puppet 2.7 can be found here.](/puppet/2.7/reference)
 
 To install Puppet 3, see [the Puppet installation guide](/guides/installation.html). For general advice on upgrading between major versions, see [Upgrading Puppet](/guides/upgrading.html).
 


### PR DESCRIPTION
Previously there was no way to navigate to the new Puppet 3.5
manual from the main doc index, nor a way to hop over to it
from the 3.0 manual (but /3/ did have a link to /3.5/).
