### PR TITLE
Noted need for --allow-dns-alt-names in console cert signing request

### DIFF
--- a/source/pe/3.2/trouble_regenerate_certs_monolithic.markdown
+++ b/source/pe/3.2/trouble_regenerate_certs_monolithic.markdown
@@ -74,7 +74,7 @@ Note that this process **destroys the certificate authority and all other certif
 2. Remove all the credentials in this directory with `sudo rm -rf /opt/puppet/share/puppet-dashboard/certs/*`.
 3. Run `sudo /opt/puppet/bin/rake RAILS_ENV=production cert:create_key_pair`.
 4. Run `sudo /opt/puppet/bin/rake RAILS_ENV=production cert:request`. It will probably fail to retrieve a cert, unless autosigning is enabled.
-5. Use `puppet cert list` and `puppet cert sign` to sign the console certificate request.
+5. Use `puppet cert list` and then `puppet cert sign` with `--allow-dns-alt-names` to sign the console certificate request.
 5. Run `sudo /opt/puppet/bin/rake RAILS_ENV=production cert:retrieve`.
 6. Ensure the console can access the new credentials with `sudo chown -R puppet-dashboard:puppet-dashboard /opt/puppet/share/puppet-dashboard/certs`.
 7. Restart the console service with `sudo service pe-httpd restart`.


### PR DESCRIPTION
We should note to customers that they need to sign the console cert request with --allow-dns-alt-names to avoid confusion when they get the big red error message about it.
