### PR TITLE
(maint) Fix link from 3.5 to 3.x reference guides

### DIFF
--- a/source/puppet/3.5/reference/index.markdown
+++ b/source/puppet/3.5/reference/index.markdown
@@ -9,7 +9,7 @@ Welcome to the Puppet 3.5 Reference Manual! Use the navigation to the left to ge
 
 **Previous Versions**
 
-- [Documentation for Puppet 3.0 through 3.4 can be found here.](/puppet/3.0/reference)
+- [Documentation for Puppet 3.0 through 3.4 can be found here.](/puppet/3/reference)
 - [Documentation for Puppet 2.7 can be found here.](/puppet/2.7/reference)
 
 To install Puppet 3.5, see [the Puppet installation guide](/guides/installation.html). For general advice on upgrading between major versions, see [Upgrading Puppet](/guides/upgrading.html).


### PR DESCRIPTION
The 3.5 reference guide linked to `/puppet/3.0/reference`, but the documentation is actually served from `/puppet/3/reference`.
