### PR TITLE
Note broken apt module

### DIFF
--- a/source/pe/3.2/appendix.markdown
+++ b/source/pe/3.2/appendix.markdown
@@ -344,6 +344,14 @@ or, when attempting to request a catalog:
 
 If you encounter these errors, simply re-start the `pe-postgresql` service.
 
+### puppetlabs-apt 1.4.0 uses functions that are not shipped as part of puppetlabs-stdlib 3.2.0
+
+PE 3.2.x ships with puppetlabs-apt 1.4.0 and puppetlabs-stdlib 3.2.0 preinstalled. The puppetlabs-apt module attempts to use a function from stdlib that is not present in puppetlabs-stdlib 3.2.0.
+
+To work around this issue, you may upgrade to puppetlabs-apt 1.4.2, which is the latest supported release, using the puppet module tool:
+
+`puppet module upgrade puppetlabs-apt`
+
 ### Razor Known Issues
 Please see the page [Razor Setup Recommendations and Known Issues](./razor_knownissues.html). 
 


### PR DESCRIPTION
Default PE install contains an apt module that is "broken" in that it
depends on stdlib functions that are not present in the supported
version of stdlib, which we ship.

Also notes workaround.

https://tickets.puppetlabs.com/browse/FM-1173
