### PR TITLE
(PDB-608) Prepare PuppetDB indexes for 2.0.0-rc1

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -25,6 +25,7 @@ defaultnav:
   /puppetdb/1.4: puppetdb1.4.html
   /puppetdb/1.5: puppetdb1.5.html
   /puppetdb/1.6: puppetdb1.6.html
+  /puppetdb/2.0: puppetdb2.0.html
   /puppetdb/master: puppetdb_master.html
   /puppet/0.24/reference: puppet_0_24.html
   /puppet/0.25/reference: puppet_0_25.html
@@ -79,6 +80,11 @@ externalsources:
     url: /puppetdb/1.6
     repo: git://github.com/puppetlabs/puppetdb.git
     commit: origin/1.6.x
+    subdirectory: documentation
+  puppetdb_2.0:
+    url: /puppetdb/2.0
+    repo: git://github.com/puppetlabs/puppetdb.git
+    commit: origin/stable
     subdirectory: documentation
   puppetdb_master:
     url: /puppetdb/master

--- a/source/_includes/puppetdb2.0.html
+++ b/source/_includes/puppetdb2.0.html
@@ -1,0 +1,123 @@
+<h2 id="puppetdb">PuppetDB 2.0</h2>
+
+<!-- we point this explicitly at 1.6 because the latest link just --
+  -- points back at this doc. Once we have a 2.0 final this can be removed -->
+<p class="versionnote">This documentation is for an unreleased version
+  of PuppetDB! If you are running this specific pre-release of PuppetDB, this is the documentation for you; otherwise, please see the documentation for the <a href="/puppetdb/1.6/">latest official release</a>.</p>
+
+<ul>
+  <li><strong>General Information</strong>
+    <ul>
+      <li>{% iflink "Overview & Requirements", "/puppetdb/2.0/index.html" %}</li>
+      <li>{% iflink "Frequently Asked Questions", "/puppetdb/2.0/puppetdb-faq.html" %}</li>
+      <li>{% iflink "Release Notes", "/puppetdb/master/release_notes.html" %}</li>
+      <li>{% iflink "Known Issues", "/puppetdb/2.0/known_issues.html" %}</li>
+      <li>{% iflink "Community Add-ons", "/puppetdb/2.0/community_add_ons.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Installation</strong>
+    <ul>
+      <li>{% iflink "Migrating Existing Data", "/puppetdb/2.0/migrate.html" %}</li>
+      <li>{% iflink "Installing via Puppet Module", "/puppetdb/2.0/install_via_module.html" %}</li>
+      <li>{% iflink "Installing From Packages", "/puppetdb/2.0/install_from_packages.html" %}</li>
+      <li>{% iflink "Installing from Source", "/puppetdb/2.0/install_from_source.html" %}</li>
+      <li>{% iflink "Upgrading PuppetDB", "/puppetdb/2.0/upgrade.html" %}</li>
+      <li>{% iflink "Connecting Puppet Masters", "/puppetdb/2.0/connect_puppet_master.html" %}</li>
+      <li>{% iflink "Connecting Standalone Puppet", "/puppetdb/2.0/connect_puppet_apply.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Configuration</strong>
+    <ul>
+      <li>{% iflink "Configuring PuppetDB", "/puppetdb/2.0/configure.html" %}</li>
+      <li>{% iflink "Setting Up SSL for PostgreSQL", "/puppetdb/2.0/postgres_ssl.html" %}</li>
+    </ul>
+  <li><strong>Usage/Admin</strong>
+    <ul>
+      <li>{% iflink "Using PuppetDB", "/puppetdb/2.0/using.html" %}</li>
+      <li>{% iflink "Maintaining and Tuning", "/puppetdb/2.0/maintain_and_tune.html" %}</li>
+      <li>{% iflink "Migrating Data", "/puppetdb/2.0/migrate.html" %}</li>
+      <li>{% iflink "Anonymizing Data", "/puppetdb/2.0/anonymization.html" %}</li>
+      <li>{% iflink "Scaling Recommendations", "/puppetdb/2.0/scaling_recommendations.html" %}</li>
+      <li>{% iflink "Debugging with Remote REPL", "/puppetdb/2.0/repl.html" %}</li>
+      <li>{% iflink "Load Testing", "/puppetdb/2.0/load_testing_tool.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Troubleshooting</strong>
+    <ul>
+      <li>{% iflink "KahaDB Corruption", "/puppetdb/2.0/trouble_kahadb_corruption.html" %}</li>
+      <li>{% iflink "Low Catalog Duplication", "/puppetdb/2.0/trouble_low_catalog_duplication.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>API</strong>
+    <ul>
+      <li>{% iflink "Overview", "/puppetdb/2.0/api/index.html" %}</li>
+      <li>{% iflink "Query Tutorial", "/puppetdb/2.0/api/query/tutorial.html" %}</li>
+      <li>{% iflink "Curl Tips", "/puppetdb/2.0/api/query/curl.html" %}</li>
+      <li>{% iflink "Command API", "/puppetdb/2.0/api/commands.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 4 (experimental)</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/2.0/api/query/v4/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/2.0/api/query/v4/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/2.0/api/query/v4/paging.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/2.0/api/query/v4/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/2.0/api/query/v4/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/2.0/api/query/v4/nodes.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/2.0/api/query/v4/catalogs.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/2.0/api/query/v4/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/2.0/api/query/v4/metrics.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/2.0/api/query/v4/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/2.0/api/query/v4/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/2.0/api/query/v4/event-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/2.0/api/query/v4/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/2.0/api/query/v4/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/2.0/api/query/v4/version.html" %}</li>
+      <li>{% iflink "Environments Endpoint", "/puppetdb/2.0/api/query/v4/environments.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 3</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/2.0/api/query/v3/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/2.0/api/query/v3/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/2.0/api/query/v3/paging.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/2.0/api/query/v3/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/2.0/api/query/v3/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/2.0/api/query/v3/nodes.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/2.0/api/query/v3/catalogs.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/2.0/api/query/v3/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/2.0/api/query/v3/metrics.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/2.0/api/query/v3/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/2.0/api/query/v3/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/2.0/api/query/v3/event-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/2.0/api/query/v3/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/2.0/api/query/v3/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/2.0/api/query/v3/version.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 2 (Deprecated)</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/2.0/api/query/v2/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/2.0/api/query/v2/operators.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/2.0/api/query/v2/facts.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/2.0/api/query/v2/resources.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/2.0/api/query/v2/nodes.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/2.0/api/query/v2/fact-names.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/2.0/api/query/v2/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format - v4", "/puppetdb/2.0/api/wire_format/catalog_format_v4.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v2", "/puppetdb/2.0/api/wire_format/facts_format_v2.html" %}</li>
+      <li>{% iflink "Report Wire Format - v3", "/puppetdb/2.0/api/wire_format/report_format_v3.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats - Deprecated</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format - v1", "/puppetdb/2.0/api/wire_format/catalog_format_v1.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v1", "/puppetdb/2.0/api/wire_format/facts_format_v1.html" %}</li>
+      <li>{% iflink "Report Wire Format - v1", "/puppetdb/2.0/api/wire_format/report_format_v1.html" %}</li>
+    </ul>
+  </li>
+</ul>

--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -66,7 +66,7 @@
       <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v4/metrics.html" %}</li>
       <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v4/reports.html" %}</li>
       <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v4/events.html" %}</li>
-      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v4/evenT-counts.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v4/event-counts.html" %}</li>
       <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v4/aggregate-event-counts.html" %}</li>
       <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v4/server-time.html" %}</li>
       <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v4/version.html" %}</li>
@@ -86,13 +86,13 @@
       <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v3/metrics.html" %}</li>
       <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v3/reports.html" %}</li>
       <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v3/events.html" %}</li>
-      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v3/evenT-counts.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v3/event-counts.html" %}</li>
       <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v3/aggregate-event-counts.html" %}</li>
       <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v3/server-time.html" %}</li>
       <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v3/version.html" %}</li>
     </ul>
   </li>
-  <li><strong>Query API Version 2</strong>
+  <li><strong>Query API Version 2 (Deprecated)</strong>
     <ul>
       <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v2/query.html" %}</li>
       <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v2/operators.html" %}</li>

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -29,4 +29,5 @@ Development and Pre-release Versions
 
 This version of the documentation represents a future feature or major release. This content only applies to the code available in the master branch of the PuppetDB git repository or a release candidate, so if you have downloaded a stable release you should consult the documentation above.
 
+* [PuppetDB 2.0](./2.0)
 * [PuppetDB (master)](./master)


### PR DESCRIPTION
This creates the new index for PuppetDB 2.0.0, it also fixes some
obvious typos with both this index and the master one and configures the
git download process to obtain the docs soure for 2.0.0 from the pdb
stable branch.

Signed-off-by: Ken Barber ken@bob.sh
