### PR TITLE
Pin PuppetDB 1.5.x docs to a tag

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -74,7 +74,7 @@ externalsources:
   puppetdb_1.5:
     url: /puppetdb/1.5
     repo: git://github.com/puppetlabs/puppetdb.git
-    commit: origin/1.5.x
+    commit: 1.5.x-docs
     subdirectory: documentation
   puppetdb_1.6:
     url: /puppetdb/1.6


### PR DESCRIPTION
In prepration to remove the 1.5.x branch, we need to ensure our docs are
pointing a tag instead.

Signed-off-by: Ken Barber ken@bob.sh
