### PR TITLE
(PDB-551) Index for versioning policy

### DIFF
--- a/source/_includes/puppetdb2.0.html
+++ b/source/_includes/puppetdb2.0.html
@@ -5,7 +5,8 @@
     <ul>
       <li>{% iflink "Overview & Requirements", "/puppetdb/2.0/index.html" %}</li>
       <li>{% iflink "Frequently Asked Questions", "/puppetdb/2.0/puppetdb-faq.html" %}</li>
-      <li>{% iflink "Release Notes", "/puppetdb/master/release_notes.html" %}</li>
+      <li>{% iflink "Release Notes", "/puppetdb/2.0/release_notes.html" %}</li>
+      <li>{% iflink "Versioning Policy", "/puppetdb/2.0/versioning_policy.html" %}</li>
       <li>{% iflink "Known Issues", "/puppetdb/2.0/known_issues.html" %}</li>
       <li>{% iflink "Community Add-ons", "/puppetdb/2.0/community_add_ons.html" %}</li>
     </ul>

--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -8,6 +8,7 @@
       <li>{% iflink "Overview & Requirements", "/puppetdb/master/index.html" %}</li>
       <li>{% iflink "Frequently Asked Questions", "/puppetdb/master/puppetdb-faq.html" %}</li>
       <li>{% iflink "Release Notes", "/puppetdb/master/release_notes.html" %}</li>
+      <li>{% iflink "Versioning Policy", "/puppetdb/master/versioning_policy.html" %}</li>
       <li>{% iflink "Known Issues", "/puppetdb/master/known_issues.html" %}</li>
       <li>{% iflink "Community Add-ons", "/puppetdb/master/community_add_ons.html" %}</li>
     </ul>


### PR DESCRIPTION
We've added a short note about versioning to our docs, this adds a link to the
doc in our index for both 2.0 and master.

I've also corrected a small typo, whereby our release notes were pointing at
the master version instead of 2.0.

Signed-off-by: Ken Barber ken@bob.sh
