### PR TITLE
Removed inaccurate statement about plugins in modules

### DIFF
--- a/source/guides/plugins_in_modules.markdown
+++ b/source/guides/plugins_in_modules.markdown
@@ -79,8 +79,7 @@ And so on.
 Most types and facts should be stored in which ever module they are related to;
 for example, a Bind fact might be distributed in your Bind module.  If you wish to centrally
 deploy types and facts you could create a separate module just for this purpose, for example
-one called `custom`.  This module needs to be a valid module (with the correct directory structure and
-an `init.pp` file).
+one called `custom`.  
 
 So, if we are using our custom module and our modulepath is
 /etc/puppet/modules then types and facts would be stored in the


### PR DESCRIPTION
The statement I removed is simply not accurate.

```
[root@pe-323-master test_module]# pwd
/etc/puppetlabs/puppet/modules/test_module
```

```
[root@pe-323-master test_module]# tree
.
├── lib
│   └── puppet
│       └── parser
│           └── functions
│               └── testfunction.rb
├── Modulefile
└── README
```

```
[root@pe-323-master test_module]# puppet agent --test
Info: Retrieving plugin
Notice: /File[/var/opt/lib/pe-puppet/lib/puppet/parser/functions/testfunction.rb]/ensure: defined content as '{md5}615757584098e8ab94b7e113926f7cbf'
...truncated for clarity...
Info: Applying configuration version '1400271142'
Notice: Finished catalog run in 12.07 seconds
```

No `init.pp`, no `manifests` directory, no problem.
