### PR TITLE
Update minimum system level for Mac OS X

### DIFF
--- a/source/puppet/3.6/reference/system_requirements.markdown
+++ b/source/puppet/3.6/reference/system_requirements.markdown
@@ -43,7 +43,7 @@ Puppet 3.6 and all of its prerequisites will run on the following platforms, and
 
 Although we publish packages for Mac OS X, we do not run automated testing on it.
 
-- Mac OS X, version 10.6 (Snow Leopard) and higher
+- Mac OS X, version 10.9 (Mavericks) and higher
 
 Platforms Without Packages
 -----


### PR DESCRIPTION
Since Puppet 3.5 we require json, which isn't provided by
system ruby in Mac OS X before Mavericks. (PUP-2697)
