### PR TITLE
(DOC-835) "How to change Console Port" lists steps no longer needed

### DIFF
--- a/source/pe/3.2/console_config.markdown
+++ b/source/pe/3.2/console_config.markdown
@@ -382,8 +382,6 @@ By default, a new installation of PE will serve the console on port 443. However
 
         $ sudo /etc/init.d/pe-httpd stop
 * Edit `/etc/puppetlabs/httpd/conf.d/puppetdashboard.conf` on the console server, and change the port number in the `Listen 443` and `<VirtualHost *:443>` directives. (These directives will contain the current port, which is not necessarily 443.)
-* Edit `/etc/puppetlabs/puppet/puppet.conf` on the puppet master server, and change the `reporturl` setting to use your preferred port.
-* Edit `/etc/puppetlabs/puppet-dashboard/external_node` on the puppet master server, and change the `ENC_BASE_URL` to use your preferred port.
 * Edit `/etc/puppetlabs/console-auth/config.yml ` on the puppet master server, and change the `cas_url` to use your preferred port.
 * Edit `/etc/puppetlabs/rubycas-server/config.yml ` on the puppet master server, and change the `console_base_url` to use your preferred port.
 * Make sure to allow access to the new port in your system's firewall rules.


### PR DESCRIPTION
This patch removes two entries from the steps for changing the
Console's port.  These two steps reference items that are no longer
valid for PE 3.2+.

The first item was a reference to `reporturl` in `puppet.conf`. This
is only needed if the `http` report processor is used. The console now
uses a report handler named `console`.

The second item refers to the old ENC script, which no longer exists
and has been replaced with a new node terminus type.
