### PR TITLE
(DOC-842) Confusing language around a code sample

### DIFF
--- a/source/pe/3.0/orchestration_puppet.markdown
+++ b/source/pe/3.0/orchestration_puppet.markdown
@@ -199,7 +199,7 @@ While logged in as a [read/write or admin user][console_user], navigate to the [
 
 While [logged in to the puppet master server as `peadmin`][peadmin], run `mco service pe-puppet stop` or `mco service pe-puppet start` with or without a filter.
 
-To prepare all web servers for a manifest update and no-op run:
+**Example:** To prepare all web servers for a manifest update and no-op run:
 
     $ mco service pe-puppet stop -C /apache/
 

--- a/source/pe/3.1/orchestration_puppet.markdown
+++ b/source/pe/3.1/orchestration_puppet.markdown
@@ -199,7 +199,7 @@ While logged in as a [read/write or admin user][console_user], navigate to the [
 
 While [logged in to the puppet master server as `peadmin`][peadmin], run `mco service pe-puppet stop` or `mco service pe-puppet start` with or without a filter.
 
-To prepare all web servers for a manifest update and no-op run:
+**Example:** To prepare all web servers for a manifest update and no-op run:
 
     $ mco service pe-puppet stop -C /apache/
 

--- a/source/pe/3.2/orchestration_puppet.markdown
+++ b/source/pe/3.2/orchestration_puppet.markdown
@@ -199,7 +199,7 @@ While logged in as a [read/write or admin user][console_user], navigate to the [
 
 While [logged in to the puppet master server as `peadmin`][peadmin], run `mco service pe-puppet stop` or `mco service pe-puppet start` with or without a filter.
 
-To prepare all web servers for a manifest update and no-op run:
+**Example:** To prepare all web servers for a manifest update and no-op run:
 
     $ mco service pe-puppet stop -C /apache/
 


### PR DESCRIPTION
This patch rewords the language around the code sample in the "On the
Command Line" section of the "Enable and Disable Puppet Agent" section
of the PE 3.x Orchestration documentation. It also adds a bit of
markup and the word "Example" to make it more consistent with other
examples on this page.
