### PR TITLE
(DOC-847) Deployment Guide has inappropriate example

### DIFF
--- a/source/guides/deployment_guide/dg_define_infrastructure.markdown
+++ b/source/guides/deployment_guide/dg_define_infrastructure.markdown
@@ -11,7 +11,7 @@ How Can Puppet Enterprise Help You?
 
 The particulars of every infrastructure will vary, but all sysadmins have some needs in common. They want to be more productive and agile, they want to spend less time fixing recurring problems, and they want keen, timely insight into their infrastructure. In this chapter, we identify some specific needs and provide examples of ways to meet them by using [Puppet Enterprise][pe_dl] (PE) to automate stuff. If you've been an admin for any period of time, these wants should be all too familiar:
 
-- I want to learn how to use a tool that will make me a more efficient sysadmin, so I can go home earlier (or get to the pub, or my kids' soccer game, or the weekly gaming session, dragon boat race, naked knitting club meeting, etc.). If you're reading this, it's safe to assume the tool you want to learn is PE.
+- I want to learn how to use a tool that will make me a more efficient sysadmin, so I can go home earlier (or get to the pub, or my kids' soccer game, or the weekly gaming session, dragon boat race, etc.). If you're reading this, it's safe to assume the tool you want to learn is PE.
 
 - I want to know beyond a shadow of a doubt that I can always securely access any machine in my infrastructure to fix things, perform maintenance, or reconfigure something. I don't want to spend much time on this. I just want it to work.
 


### PR DESCRIPTION
This patch removes an inappropriate and potentially offensive example
from the "How Can Puppet Enterprise Help You?" section of the
Deployment Guide.
