### PR TITLE
Remove Debian "Sid" (aka unstable) from docs

### DIFF
--- a/source/_includes/platforms_debian_like.markdown
+++ b/source/_includes/platforms_debian_like.markdown
@@ -8,7 +8,6 @@ We publish official packages and run automated testing on the following versions
 
 We publish packages for the following versions, but do not run automated testing on them:
 
-* Debian "Sid" (current unstable distribution)
 * Ubuntu 13.10 "Saucy Salamander"
 
 [peinstall]: /pe/latest/install_basic.html


### PR DESCRIPTION
We are no longer building packages for sid/unstable. This is because
these package builds will often fail, and block successful build for
other platforms that we support. Additionally, this OS target is of
questionable value, given we already build against Debian testing.
