### PR TITLE
(DOCUMENT-126) Qualify variable as used in hierarchy

### DIFF
--- a/source/hiera/1/complete_example.markdown
+++ b/source/hiera/1/complete_example.markdown
@@ -392,7 +392,7 @@ Once you've got all that configured, go ahead and test with the Hiera command li
 	$ hiera vmwaretools::version
 	8.6.5-621624
 
-	$ hiera classes virtual=vmware
+	$ hiera classes ::virtual=vmware
 	vmwaretools
 
 If everything worked, great. If not, [consult the checklist we provided earlier](#something-went-wrong) and give it another shot.


### PR DESCRIPTION
When hiera recieves values from the command line, they are just the
literal name that it will look up internally. The :: doesn't mean
anything special to hiera. What this means is that when a variable is
referenced as ::foo, then the value provided on the command line needs
to use ::foo.

There may have been a hiera version in the past that allowed the
documented version to work, but it doesn't do that anymore. :(
