### PR TITLE
Ubuntu 14.04 is the major release, not 14.

### DIFF
--- a/source/pe/3.3/release_notes.markdown
+++ b/source/pe/3.3/release_notes.markdown
@@ -119,7 +119,7 @@ Every node list view in the console now includes a link to export the table data
 
 This release provides full support for RHEL 7 for all applicable PE features and capabilities. For more information, see the [system requirements](./install_system_requirements.html).
 
-### Support for Ubuntu 14 LTS
+### Support for Ubuntu 14.04 LTS
 
 This release provides full support for Ubuntu 14.04 LTS for all applicable PE features and capabilities. For more information, see the [system requirements](./install_system_requirements.html).
 


### PR DESCRIPTION
There is no "Ubuntu 14" - each "Year.Month" is a major release.

Ubuntu 14.04 and 14.10 (which will be released in October) are not two
different versions of the same major release - they are both major
releases.
