### PR TITLE
Updates Publishing and Installing to address PMT bug

### DIFF
--- a/source/puppet/3.6/reference/modules_installing.markdown
+++ b/source/puppet/3.6/reference/modules_installing.markdown
@@ -187,3 +187,25 @@ Use the module tool's **`uninstall` action** to remove an installed module. The 
 By default, the tool won't uninstall a module which other modules depend on or whose files have been edited since it was installed.
 
 * Use the `--force` option to uninstall even if the module is depended on or has been manually edited.
+
+### Errors
+
+The PMT from Puppet 3.6. has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](http://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+
+To determine if a module you're using has this issue, run `puppet module changes <path to module>`. If your module has this checksum issue, you will see that the metadata.json has been modified. If you try to upgrade or uninstall a module with this issue, your action will fail and you will receive warning similar to that below.
+
+~~~
+Notice: Preparing to upgrade 'puppetlabs-motd' ...
+Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/puppet/modules ...
+Error: Could not upgrade module 'puppetlabs-motd' (v1.0.0 -> latest)
+  Installed module has had changes made locally
+~~~
+
+The workaround for this issue is:
+ 
+1. Navigate to the module. 
+2. Open the checksums.json file in your editor if it is present and delete the line: "metadata.json": [some checksum here]
+3. If there is no checksums.json, open the metadata.json file in your editor and delete the entire 'checksums' field.
+4. Run `puppet module changes <path to module>` to determine whether the fix was successful. A successful fix will return: `Notice: No modified files`. An unsuccessful fix will show modified files.
+5. Retry your upgrade/uninstall action. 
+

--- a/source/puppet/3.6/reference/modules_publishing.markdown
+++ b/source/puppet/3.6/reference/modules_publishing.markdown
@@ -16,6 +16,7 @@ canonical: "/puppet/latest/reference/modules_publishing.html"
 [uploadtarball2]: ./images/forge_upload_tarball2.png
 [forgenewrelease]: ./images/forge_new_release.png
 [documentation]: ./modules_documentation.html
+[errors]: ./modules_installing.html#errors
 
 Publishing Modules on the Puppet Forge
 =====
@@ -213,41 +214,57 @@ With Puppet 3.6's updates to the puppet module tool (PMT), the process for  buil
 * [I generated a new module using `puppet module generate`](#brand-new-module)
 * [I have a Modulefile and no metadata.json](#modulefile-no-metadatajson)
 * [I have a Modulefile and a metadata.json](#modulefile-and-metadatajson)
+* [I have a metadata.json and no Modulefile](#metadatajson-no-modulefile)
 
 In order for your module to be successfully uploaded to and displayed on the Forge, your metadata.json file will need to have the following [fields](#fields-in-metadatajson): name, version, author, license, summary, source, dependencies, project_page, operatingsystem_support, and tags.
 
 ###Brand new module
 
-If you used `puppet module generate` to create your module *and* you're using Puppet 3.6, your metadata.json file was created for you! All you need to do is build  a package of your module by running the following command:
+If you used Puppet 3.6 to run `puppet module generate` to create your module, your metadata.json file was created for you! To build your module:
 
-    # puppet module build <MODULE DIRECTORY>
+1. Run `# puppet module build <MODULE DIRECTORY>`. A .tar.gz package will be generated and saved in the module's pkg/ subdirectory. For example:
 
-This generates a `.tar.gz` package, which is saved in the module's `pkg/` subdirectory.
-
-For example:
-
+~~~
     # puppet module build /etc/puppetlabs/puppet/modules/mymodule
     Building /etc/puppetlabs/puppet/modules/mymodule for release
     /etc/puppetlabs/puppet/modules/mymodule/pkg/examplecorp-mymodule-0.0.1.tar.gz
+~~~
+
+2. Navigate to your module in the pkg/ subdirectory, `#cd <username-modulename>/pkg/<username-modulename-version>`.
+3. Copy the metadata.json file to the root of your module.
+4. Navigate out of the pkg/ subdirectory to your module's root directory. Run `# puppet module build <MODULE DIRECTORY>` again. (If you do not rebuild your module before publishing, you will cause users of your module to face [errors][errors]).
+5. Run `puppet module changes pkg/<username-modulename-version>` to determine whether your build was successful. A successful build will return: `Notice: No modified files`. An unsuccessful build will show modified files, which means you must start the process again.
 
 ###Modulefile, no metadata.json
 
-If you have a Modulefile but no metadata.json file, you will receive a deprecation warning when you build a package of your module. The PMT will build you a complete metadata.json file using the information in your Modulefile, and will place the metadata.json in both your build directory and root module directory. You must then perform [migration steps](#migrate-from-modulefile-to-metadatajson).
+1. Run `# puppet module build <MODULE DIRECTORY>`. 
+2. If you have a Modulefile but no metadata.json file, you will receive a deprecation warning when you run the build command. The PMT will build you a complete metadata.json file using the information in your Modulefile, and will place the metadata.json in both your build directory and root module directory. 
+3. Navigate to your module in the pkg/ subdirectory, `#cd <username-modulename>/pkg/<username-modulename-version>`.
+4. Copy the metadata.json file to the root of your module.
+5. Navigate out of the pkg/ subdirectory to your module's root directory. Delete your Modulefile.
+6. Run `puppet module build <MODULE DIRECTORY>` again. (If you do not rebuild your module before publishing, you will cause users of your module to face [errors][errors]).
+7. Run `puppet module changes pkg/<username-modulename-version>` to determine whether your build was successful. A successful build will return: `Notice: No modified files`. An unsuccessful build will show modified files, which means you must start the process again.
 
 ###Modulefile and metadata.json
 
-If you have a complete metadata.json, the PMT will merge your Modulefile and metadata.json files and issue a deprecation warning when you build a package of your module. You must then go through the [migration steps](#migrate-from-modulefile-to-metadatajson). 
+1. Open the metadata.json file in your editor and remove the `types` and `checksums` fields entirely, if present.
+2. Make sure your dependencies are expressed in the metadata.json and **NOT** in the Modulefile.
+3. Run `# puppet module build <MODULE DIRECTORY>`. The PMT will merge your Modulefile and metadata.json files and issue a deprecation warning. 
+4. Navigate to your module in the pkg/ subdirectory, `#cd <username-modulename>/pkg/<username-modulename-version>`.
+5. Copy the metadata.json file to the root of your module.
+6. Navigate out of the pkg/ subdirectory to your module's root directory. Delete your Modulefile.
+7. Run `# puppet module build <MODULE DIRECTORY>` again. (If you do not rebuild your module before publishing, you will cause users of your module to face [errors][errors]). 
+8. Run `puppet module changes pkg/<username-modulename-version>` to determine whether your build was successful. A successful build will return: `Notice: No modified files`. An unsuccessful build will show modified files, which means you must start the process again.
 
-###Migrate from Modulefile to metadata.json
+###metadata.json, no Modulefile
 
-To migrate from Modulefile to metadata.json:
+1. Open the metadata.json file in your editor and remove the `types` and `checksums` fields entirely, if present.
+2. Run `# puppet module build <MODULE DIRECTORY>`.
+3. Navigate to your module in the pkg/ subdirectory, `#cd <username-modulename>/pkg/<username-modulename-version>`.
+4. Copy the metadata.json file to the root of your module.
+5. Navigate out of the pkg/ subdirectory to your module's root directory. Run `# puppet module build <MODULE DIRECTORY>` again. (If you do not rebuild your module before publishing, you will cause users of your module to face [errors][errors]).
+6. Run `puppet module changes pkg/<username-modulename-version>` to determine whether your build was successful. A successful build will return: `Notice: No modified files`. An unsuccessful build will show modified files, which means you must start the process again.
 
-1. Run `puppet module build` as normal.
-2. Navigate to the current version of your module in the pkg/ subdirectory.
-3. Copy the metadata.json file to the root of your module.
-4. Delete the `types` and `checksums` fields, if present.
-5. Delete the Modulefile.
-  
 Upload to the Puppet Forge
 ------
 


### PR DESCRIPTION
Updates PMT build steps for 4 separate workflows to workaround PMT checksums bug. Updates Installing's Upgrading/Uninstalling section to include Errors section detailing workaround for the PMT bug for module consumers.
