### PR TITLE
Razor documentation improvements

### DIFF
--- a/source/pe/3.2/razor_reference.markdown
+++ b/source/pe/3.2/razor_reference.markdown
@@ -52,7 +52,7 @@ Accepted on success. The `url` property of the response generally refers to
 an entity that is affected by the command and can be queried to determine
 when the command has finished.
 
-### Create new repo
+### Create new repo (`create-repo`)
 
 There are two flavors of repositories: ones where Razor unpacks ISO's for
 you and serves their contents, and ones that are somewhere else, for
@@ -66,7 +66,7 @@ ISO image into its file system:
     }
 
 The second form is created by providing a `url` property when you create
-the repository; this form is merely a pointer to a resource somehwere and
+the repository; this form is merely a pointer to a resource somewhere and
 nothing will be downloaded onto the Razor server:
 
     {
@@ -74,7 +74,7 @@ nothing will be downloaded onto the Razor server:
       "url": "http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/"
     }
 
-### Delete a repo
+### Delete a repo (`delete-repo`)
 
 The `delete-repo` command accepts a single repo name:
 
@@ -82,7 +82,7 @@ The `delete-repo` command accepts a single repo name:
       "name": "fedora16"
     }
 
-### Create task
+### Create task (`create-task`)
 
 Razor supports both tasks stored in the filesystem and tasks
 stored in the database; for development, it is highly recommended that you
@@ -117,7 +117,7 @@ description| Human-readable description
 boot_seq   | A hash mapping the boot counter or 'default' to a template
 templates  | A hash mapping template names to the actual ERB template text
 
-### Create broker
+### Create broker (`create-broker`)
 
 To create a broker, clients post the following to the `create-broker` URL:
 
@@ -136,7 +136,7 @@ The `broker-type` must correspond to a broker that is present on the
 The permissible settings for the `configuration` hash depend on the broker
 type and are declared in the broker type's `configuration.yaml`.
 
-### Delete broker
+### Delete broker (`delete-broker`)
 
 A broker can be deleted by posting its name to the `/spec/delete_broker`
 command:
@@ -148,7 +148,7 @@ command:
 If the broker is used by a policy, the attempt to delete the broker will
 fail.
 
-### Create tag
+### Create tag (`create-tag`)
 
 To create a tag, clients post the following to the `/spec/create_tag`
 command:
@@ -160,7 +160,7 @@ command:
 
 The `name` of the tag must be unique; the `rule` is a match expression.
 
-### Delete tag
+### Delete tag (`delete-tag`)
 
 A tag can be deleted by posting its name to the `/spec/delete_tag` command:
 
@@ -173,7 +173,7 @@ If the tag is used by a policy, the attempt to delete the tag will fail
 unless the optional parameter `force` is set to `true`; in that case the
 tag will be removed from all policies that use it and then deleted.
 
-### Update tag
+### Update tag (`update-tag`)
 
 The rule for a tag can be changed by posting the following to the
 `/spec/update_tag_rule` command:
@@ -193,7 +193,7 @@ If the tag is used by any policies, the update will only be performed if
 the optional parameter `force` is set to `true`. Otherwise, the command
 will return with status code 400.
 
-### Create policy
+### Create policy (`create-policy`)
 
     {
       "name": "a policy",
@@ -209,10 +209,10 @@ will return with status code 400.
                { "name": "new_tag", "rule": ["=", "dollar", "dollar"]}]
     }
 
-The overall list of policies is ordered, and polcies are considered in that
+The overall list of policies is ordered, and policies are considered in that
 order. When a new policy is created, the entry `before` or `after` can be
 used to put the new policy into the table before or after another
-policy. If neither `before` or `after` are specified, the policy is
+policy. If neither `before` nor `after` is specified, the policy is
 appended to the policy table.
 
 Tags, brokers, tasks and repos are referenced by their name. Tags can
@@ -230,10 +230,10 @@ positive integer to set an upper bound.
 
 The `node_metadata` allows a policy to apply metadata to a node when it
 binds.  This is NON AUTHORITATIVE in that it will not replace existing
-metadata on the node with the same keys, it will only add keys that are
+metadata on the node with the same keys; it will only add keys that are
 missing.
 
-### Move policy
+### Move policy (`move-policy`)
 
 This command makes it possible to change the order in which policies are
 considered when matching against nodes. To put an existing policy into a
@@ -248,7 +248,7 @@ body like:
 This will change the policy table so that `a policy` will appear before or
 after the policy `other policy`.
 
-### Enable/disable policy
+### Enable/disable policy (`enable-policy`/`disable-policy`)
 
 Policies can be enabled or disabled. Only enabled policies are used when
 matching nodes against policies. There are two commands to toggle a
@@ -259,7 +259,7 @@ accept the same body, consisting of the name of the policy in question:
       "name": "a policy"
     }
 
-### Modify the max-count for a policy
+### Modify the max-count for a policy (`modify-policy-max-count`)
 
 The command `modify-policy-max-count` makes it possible to manipulate how
 many nodes can be bound to a specific policy at the most. The body of the
@@ -272,23 +272,36 @@ request should be of the form:
 
 The `new-count` can be an integer, which must be larger than the number of
 nodes that are currently bound to the policy, or `null` to make the policy
-unbounded
+unbounded.
 
-### Add/remove tags to/from Policy
+### Add tags to Policy (`add-policy-tag`)
 
-You can add or remove tags from policies with `add-policy-tag` and
- `remove-policy-tag` respectively.  In both cases supply the name of a
-policy and the name of the tag.  When adding a tag, you can specify an
-existing tag, or create a new one by supplying a name and rule for the
-new tag:
+To add tags to a policy, supply the name of a policy and the name of the tag:
 
     {
       "name": "a-policy-name",
       "tag" : "a-tag-name",
-      "rule": "new-match-expression" #Only for `add-policy-tag`
     }
 
-### Delete policy
+To create the tag in addition to adding it to the policy, supply the `rule`
+argument:
+
+    {
+      "name": "a-policy-name",
+      "tag" : "a-new-tag-name",
+      "rule": "new-match-expression"
+    }
+
+### Remove tags from Policy (`remove-policy-tag`)
+
+To remove tags from a policy, supply the name of a policy and the name of the tag.
+
+    {
+      "name": "a-policy-name",
+      "tag" : "a-tag-name",
+    }
+
+### Delete policy (`delete-policy`)
 
 Policies can be deleted with the `delete-policy` command.  It accepts the
 name of a single policy:
@@ -301,7 +314,7 @@ Note that this does not affect the `installed` status of a node, and
 therefore won't, by itself, cause a node to be bound to another policy upon
 reboot.
 
-### Delete node
+### Delete node (`delete-node`)
 
 A single node can be removed from the database with the `delete-node`
 command. It accepts the name of a single node:
@@ -313,7 +326,7 @@ command. It accepts the name of a single node:
 Of course, if that node boots again at some point, it will be automatically
 recreated.
 
-### Reinstall node
+### Reinstall node (`reinstall-node`)
 
 This command removes a node's association with any policy and clears its
 `installed` flag; once the node reboots, it will boot back into the
@@ -325,7 +338,7 @@ which node to unbind by sending the node's name in the body of the request
       "name": "node17"
     }
 
-### Set node IPMI credentials
+### Set node IPMI credentials (`set-node-ipmi-credentials`)
 
 Razor can store IPMI credentials on a per-node basis.  These are the hostname
 (or IP address), the username, and the password to use when contacting the
@@ -353,7 +366,7 @@ You *must* provide an IPMI hostname if you provide either a username or
 password, since we only support remote, not local, communication with the
 IPMI target.
 
-### Reboot node
+### Reboot node (`reboot-node`)
 
 Razor can request a node reboot through IPMI, if the node has IPMI credentials
 associated.  This only supports hard power cycle reboots.
@@ -389,7 +402,7 @@ The `node` field is the name of the node to operate on.
 The RBAC pattern for this command is: `reboot-node:${node}`
 
 
-### Set node desired power state
+### Set node desired power state (`set-node-desired-power-state`)
 
 In addition to monitoring power, Razor can enforce node power state.
 This command allows a desired power state to be set for a node, and if the
@@ -413,7 +426,7 @@ Power state is enforced every time it is observed; by default this happens
 on a scheduled basis in the background every few minutes.
 
 
-### Modify node metadata
+### Modify node metadata (`modify-node-metadata`)
 
 Node metadata is similar to a nodes facts except metadata is what the
 administrators tell Razor about the node rather than what the node tells
@@ -447,7 +460,7 @@ however, clear can only be done on its own (it doesnt make sense to
 update some details and then clear everything).  An error will also be
 returned if an attempt is made to update and remove the same key.
 
-### Update node metadata
+### Update node metadata (`update-node-metadata`)
 
 The `update-node-metadata` command is a shortcut to `modify-node-metadata`
 that allows for updating single keys on the command line or with a GET
@@ -460,7 +473,7 @@ request with a simple data structure that looks like.
         "no_replace": true       #Optional. Will not replace existing keys
     }
 
-### Remove Node Metadata
+### Remove Node Metadata (`remove-node-metadata`)
 
 The `remove-node-metadata` command is a shortcut to `modify-node-metadata`
 that allows for removing a single key OR all keys only on the command
@@ -529,7 +542,7 @@ identifier within the array.
 
 ## Other things
 
-### The default boostrap iPXE file
+### The default bootstrap iPXE file
 
 A GET request to `/api/microkernel/bootstrap` will return an iPXE script
 that can be used to bootstrap nodes that have just PXE booted (it

--- a/source/pe/3.3/razor_reference.markdown
+++ b/source/pe/3.3/razor_reference.markdown
@@ -47,12 +47,16 @@ a request to `GET /api` in the `commands` array. Clients can identify
 commands using the `rel` attribute of each entry in the array, and should
 make their POST requests to the URL given in the `url` attribute.
 
+Any command's help documentation can be queried via a GET (rather than POST
+which executes the command) on the command's endpoint, 
+e.g. `GET /api/commands/create-policy`.
+
 Commands are generally asynchronous and return a status code of 202
 Accepted on success. The `url` property of the response generally refers to
 an entity that is affected by the command and can be queried to determine
 when the command has finished.
 
-### Create new repo
+### Create new repo (`create-repo`)
 
 There are two flavors of repositories: ones where Razor unpacks ISO's for
 you and serves their contents, and ones that are somewhere else, for
@@ -62,19 +66,21 @@ ISO image into its file system:
 
     {
       "name": "fedora19",
-      "iso-url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
+      "iso-url": "file:///tmp/Fedora-19-x86_64-DVD.iso",
+      "task": "redhat"
     }
 
 The second form is created by providing a `url` property when you create
-the repository; this form is merely a pointer to a resource somehwere and
+the repository; this form is merely a pointer to a resource somewhere and
 nothing will be downloaded onto the Razor server:
 
     {
       "name": "fedora19",
-      "url": "http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/"
+      "url": "http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/",
+      "task": "redhat"
     }
 
-### Delete a repo
+### Delete a repo (`delete-repo`)
 
 The `delete-repo` command accepts a single repo name:
 
@@ -82,7 +88,7 @@ The `delete-repo` command accepts a single repo name:
       "name": "fedora16"
     }
 
-### Create task
+### Create task (`create-task`)
 
 Razor supports both tasks stored in the filesystem and tasks
 stored in the database; for development, it is highly recommended that you
@@ -96,12 +102,10 @@ database. To create a task, clients post the following to the
     {
       "name": "redhat6",
       "os": "Red Hat Enterprise Linux",
-      "os_version": "6",
-      "description": "A basic installer for RHEL6",
       "boot_seq": {
         "1": "boot_install",
         "default": "boot_local"
-      }
+      },
       "templates": {
         "boot_install": " ... ERB template for an ipxe boot file ...",
         "installer": " ... another ERB template ..."
@@ -112,12 +116,10 @@ The possible properties in the request are:
 
 name       | The name of the task; must be unique
 os         | The name of the OS; mandatory
-os_version | The version of the operating system
-description| Human-readable description
 boot_seq   | A hash mapping the boot counter or 'default' to a template
 templates  | A hash mapping template names to the actual ERB template text
 
-### Create broker
+### Create broker (`create-broker`)
 
 To create a broker, clients post the following to the `create-broker` URL:
 
@@ -136,7 +138,7 @@ The `broker-type` must correspond to a broker that is present on the
 The permissible settings for the `configuration` hash depend on the broker
 type and are declared in the broker type's `configuration.yaml`.
 
-### Delete broker
+### Delete broker (`delete-broker`)
 
 A broker can be deleted by posting its name to the `/spec/delete_broker`
 command:
@@ -148,7 +150,7 @@ command:
 If the broker is used by a policy, the attempt to delete the broker will
 fail.
 
-### Create tag
+### Create tag (`create-tag`)
 
 To create a tag, clients post the following to the `/spec/create_tag`
 command:
@@ -160,7 +162,7 @@ command:
 
 The `name` of the tag must be unique; the `rule` is a match expression.
 
-### Delete tag
+### Delete tag (`delete-tag`)
 
 A tag can be deleted by posting its name to the `/spec/delete_tag` command:
 
@@ -173,7 +175,7 @@ If the tag is used by a policy, the attempt to delete the tag will fail
 unless the optional parameter `force` is set to `true`; in that case the
 tag will be removed from all policies that use it and then deleted.
 
-### Update tag
+### Update tag (`update-tag`)
 
 The rule for a tag can be changed by posting the following to the
 `/spec/update_tag_rule` command:
@@ -193,47 +195,44 @@ If the tag is used by any policies, the update will only be performed if
 the optional parameter `force` is set to `true`. Otherwise, the command
 will return with status code 400.
 
-### Create policy
+### Create policy (`create-policy`)
 
     {
       "name": "a policy",
-      "repo": { "name": "some_repo" },
-      "task": { "name": "redhat6" },
-      "broker": { "name": "puppet" },
+      "repo": "some_repo",
+      "task": "redhat6",
+      "broker": "puppet",
       "hostname": "host${id}.example.com",
-      "root_password": "secret",
-      "max_count": "20",
-      "before"|"after": { "name": "other policy" },
-      "node_metadata": { "key1": "value1", "key2": "value2" },
-      "tags": [{ "name": "existing_tag"},
-               { "name": "new_tag", "rule": ["=", "dollar", "dollar"]}]
+      "root-password": "secret",
+      "max-count": 20,
+      "before"|"after": "other policy",
+      "node-metadata": { "key1": "value1", "key2": "value2" },
+      "tags": ["existing_tag", "another_tag"]
     }
 
-The overall list of policies is ordered, and polcies are considered in that
+The overall list of policies is ordered, and policies are considered in that
 order. When a new policy is created, the entry `before` or `after` can be
 used to put the new policy into the table before or after another
-policy. If neither `before` or `after` are specified, the policy is
+policy. If neither `before` nor `after` is specified, the policy is
 appended to the policy table.
 
-Tags, brokers, tasks and repos are referenced by their name. Tags can
-also be created by providing a rule; if a tag with that name already
-exists, the rule must be equal to the rule of the existing tag.
+Tags, brokers, tasks and repos are referenced by their name.
 
 Hostname is a pattern for the host names of the nodes bound to the policy;
 eventually you'll be able to use facts and other fun stuff there. For now,
 you get to say ${id} and get the node's DB id.
 
-The `max_count` determines how many nodes can be bound at any given point
+The `max-count` determines how many nodes can be bound at any given point
 to this policy at the most. This can either be set to `nil`, indicating
 that an unbounded number of nodes can be bound to this policy, or a
 positive integer to set an upper bound.
 
-The `node_metadata` allows a policy to apply metadata to a node when it
+The `node-metadata` allows a policy to apply metadata to a node when it
 binds.  This is NON AUTHORITATIVE in that it will not replace existing
 metadata on the node with the same keys; it will only add keys that are
 missing.
 
-### Move policy
+### Move policy (`move-policy`)
 
 This command makes it possible to change the order in which policies are
 considered when matching against nodes. To put an existing policy into a
@@ -242,13 +241,13 @@ body like:
 
     {
       "name": "a policy",
-      "before"|"after": { "name": "other policy" }
+      "before"|"after": "other policy"
     }
 
 This will change the policy table so that `a policy` will appear before or
 after the policy `other policy`.
 
-### Enable/disable policy
+### Enable/disable policy (`enable-policy`/`disable-policy`)
 
 Policies can be enabled or disabled. Only enabled policies are used when
 matching nodes against policies. There are two commands to toggle a
@@ -259,7 +258,7 @@ accept the same body, consisting of the name of the policy in question:
       "name": "a policy"
     }
 
-### Modify the max-count for a policy
+### Modify the max-count for a policy (`modify-policy-max-count`)
 
 The command `modify-policy-max-count` makes it possible to manipulate how
 many nodes can be bound to a specific policy at the most. The body of the
@@ -272,23 +271,36 @@ request should be of the form:
 
 The `new-count` can be an integer, which must be larger than the number of
 nodes that are currently bound to the policy, or `null` to make the policy
-unbounded
+unbounded.
 
-### Add/remove tags to/from Policy
+### Add tags to Policy (`add-policy-tag`)
 
-You can add or remove tags from policies with `add-policy-tag` and
- `remove-policy-tag` respectively.  In both cases supply the name of a
-policy and the name of the tag.  When adding a tag, you can specify an
-existing tag, or create a new one by supplying a name and rule for the
-new tag:
+To add tags to a policy, supply the name of a policy and the name of the tag:
 
     {
       "name": "a-policy-name",
       "tag" : "a-tag-name",
-      "rule": "new-match-expression" #Only for `add-policy-tag`
     }
 
-### Delete policy
+To create the tag in addition to adding it to the policy, supply the `rule`
+argument:
+
+    {
+      "name": "a-policy-name",
+      "tag" : "a-new-tag-name",
+      "rule": "new-match-expression"
+    }
+
+### Remove tags from Policy (`remove-policy-tag`)
+
+To remove tags from a policy, supply the name of a policy and the name of the tag.
+
+    {
+      "name": "a-policy-name",
+      "tag" : "a-tag-name",
+    }
+
+### Delete policy (`delete-policy`)
 
 Policies can be deleted with the `delete-policy` command.  It accepts the
 name of a single policy:
@@ -301,7 +313,7 @@ Note that this does not affect the `installed` status of a node, and
 therefore won't, by itself, cause a node to be bound to another policy upon
 reboot.
 
-### Delete node
+### Delete node (`delete-node`)
 
 A single node can be removed from the database with the `delete-node`
 command. It accepts the name of a single node:
@@ -313,7 +325,7 @@ command. It accepts the name of a single node:
 Of course, if that node boots again at some point, it will be automatically
 recreated.
 
-### Reinstall node
+### Reinstall node (`reinstall-node`)
 
 This command removes a node's association with any policy and clears its
 `installed` flag; once the node reboots, it will boot back into the
@@ -325,7 +337,7 @@ which node to unbind by sending the node's name in the body of the request
       "name": "node17"
     }
 
-### Set node IPMI credentials
+### Set node IPMI credentials (`set-node-ipmi-credentials`)
 
 Razor can store IPMI credentials on a per-node basis.  These are the hostname
 (or IP address), the username, and the password to use when contacting the
@@ -353,7 +365,7 @@ You *must* provide an IPMI hostname if you provide either a username or
 password, since we only support remote, not local, communication with the
 IPMI target.
 
-### Reboot node
+### Reboot node (`reboot-node`)
 
 Razor can request a node reboot through IPMI, if the node has IPMI credentials
 associated.  This only supports hard power cycle reboots.
@@ -389,7 +401,7 @@ The `node` field is the name of the node to operate on.
 The RBAC pattern for this command is: `reboot-node:${node}`
 
 
-### Set node desired power state
+### Set node desired power state (`set-node-desired-power-state`)
 
 In addition to monitoring power, Razor can enforce node power state.
 This command allows a desired power state to be set for a node, and if the
@@ -413,7 +425,7 @@ Power state is enforced every time it is observed; by default this happens
 on a scheduled basis in the background every few minutes.
 
 
-### Modify node metadata
+### Modify node metadata (`modify-node-metadata`)
 
 Node metadata is similar to a nodes facts except metadata is what the
 administrators tell Razor about the node rather than what the node tells
@@ -447,7 +459,7 @@ however, clear can only be done on its own (it doesnt make sense to
 update some details and then clear everything).  An error will also be
 returned if an attempt is made to update and remove the same key.
 
-### Update node metadata
+### Update node metadata (`update-node-metadata`)
 
 The `update-node-metadata` command is a shortcut to `modify-node-metadata`
 that allows for updating single keys on the command line or with a GET
@@ -460,7 +472,7 @@ request with a simple data structure that looks like.
         "no_replace": true       #Optional. Will not replace existing keys
     }
 
-### Remove Node Metadata
+### Remove Node Metadata (`remove-node-metadata`)
 
 The `remove-node-metadata` command is a shortcut to `modify-node-metadata`
 that allows for removing a single key OR all keys only on the command
@@ -529,7 +541,7 @@ identifier within the array.
 
 ## Other things
 
-### The default boostrap iPXE file
+### The default bootstrap iPXE file
 
 A GET request to `/api/microkernel/bootstrap` will return an iPXE script
 that can be used to bootstrap nodes that have just PXE booted (it

--- a/source/pe/3.3/razor_tasks.markdown
+++ b/source/pe/3.3/razor_tasks.markdown
@@ -13,7 +13,7 @@ Tasks are stored in the file system. The configuration setting `task_path` deter
 
 ## Task Metadata
 
-Tasks can include the following metadata in the task's YAML file. This file is called  `NAME.yaml` where `NAME` is the task name.
+Tasks can include the following metadata in the task's YAML file. This file is called  `metadata.yaml` and exists in `tasks/NAME.task` where `NAME` is the task name.
 
     ---
     description: HUMAN READABLE DESCRIPTION
@@ -33,11 +33,9 @@ The `boot_sequence` hash indicates which templates to use when a node using this
 
 Task templates are ERB templates and are searched in all the directories given in the `task_path` configuration setting. Templates are searched in the subdirectories in this order: 
 
-1. `name/os_version`
-2. `name`
+1. `name.task`
+2. `base.task` # If the task has a base task.
 3. `common` 
-
-If the task has a base task, the base task's template directories are searched just before the `common` directory.
 
 ####Template Helpers
 Templates can use the following helpers to generate URLs that point back to the server; all of the URLs respond to a `GET` request, even the ones that make changes on the server:

--- a/source/pe/3.3/razor_using.markdown
+++ b/source/pe/3.3/razor_using.markdown
@@ -21,11 +21,11 @@ Include Repos
 
 A repo contains all of the actual bits used when installing a node with Razor. The repo is identified by a unique name, such as 'centos-6.4'. The instructions for an installation are contained in *tasks*, which are described below.
 
-To load a repo onto the server, you use: `razor create-repo --name=<repo name> --iso-url <URL>`.
+To load a repo onto the server, you use: `razor create-repo --name=<repo name> --iso-url <URL> --task <task name>`.
 	
-For example: `razor create-repo --name=centos-6.4 --iso-url http://mirrors.usc.edu/pub/linux/distributions/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso`.
+For example: `razor create-repo --name=centos-6.4 --iso-url http://mirrors.usc.edu/pub/linux/distributions/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso --task centos`.
 
-**Note**: Creating the repo can take five or so minutes, plus however long it takes to download the ISO and unpack the contents. Currently, the best way to find out the status is to check the log file.
+**Note**: Creating the repo can take five or so minutes, plus however long it takes to download the ISO and unpack the contents. Currently, the best way to find out the status is to check the status of the job: `razor commands` then `razor commands <command number>` using the command number from the list. If there are errors in the job, they will be present in `razor commands <command number> errors`.
 
 
 Include Brokers
@@ -72,14 +72,14 @@ Because policies contain a good deal of information, it's handy to save them in 
 
 	{
 		"name": "centos-for-small",
-		"repo": { "name": "centos-6.4" },
-		"task": { "name": "centos" },
-		"broker": { "name": "noop" },
+		"repo": "centos-6.4",
+		"task": "centos",
+		"broker": "noop",
 		"enabled": true,
 		"hostname": "host${id}.example.com",
 		"root_password": "secret",
-		"max_count": "20",
-		"tags": [{ "name": "small", "rule": ["<=", ["num", ["fact", "processorcount"]], 2]}]
+		"max_count": 20,
+		"tags": ["small"]
 	}
 
 **Policy Tables**
@@ -96,14 +96,14 @@ See [Razor Command Reference](./razor_reference.html) for more information.
 
 		{	
   		"name": "test_<NODE_ID>",
-  		"repo": { "name": "<OS>" },
-  		"task": { "name": "<INSTALLER>" },
-  		"broker": { "name": "pe" },
+  		"repo": "<OS>",
+  		"task": "<INSTALLER>",
+  		"broker": "pe",
   		"enabled": true,
   		"hostname": "node${id}.vm",
   		"root_password": "puppet",
-  		"max_count": "20",
-  		"tags": [{ "name": "<TAG_NAME>", "rule": ["in",["fact", "macaddress"],"<NODE_MAC_ADDRESS>"]}]
+  		"max_count": 20,
+  		"tags": ["<TAG_NAME>"]
   		}
 
 2. Edit the options in the `policy.json` template with information specific to  your environment. 


### PR DESCRIPTION
This makes several changes for PE 3.3's Razor documentation, primarily centered
around consistency (factual and formatting):
- How to query help documentation for each command
- Tasks have a new format [name.task + metadata.yaml]
- `create-task` has no `description` or `os_version` arguments
- Including `task` argument in `create-repo`
- Using just the name, rather than a hash, in object references (preferred)
- `create-policy` cannot create tags
- `create-policy`'s max_count should be an integer
- Adding the real command name after the summary/title (included in 3.2 too)
- Typos/grammar fixes (included in 3.2 too)
- Separating `add-policy-tag` and `remove-policy-tag` (included in 3.2 too)
