### PR TITLE
(maint) Add new fact-nodes endpoint to v4, and re-order sensibly

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -59,21 +59,22 @@
       <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v4/query.html" %}</li>
       <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v4/operators.html" %}</li>
       <li>{% iflink "Query Paging", "/puppetdb/master/api/query/v4/paging.html" %}</li>
-      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v4/facts.html" %}</li>
-      <li>{% iflink "Factsets Endpoint", "/puppetdb/master/api/query/v4/factsets.html" %}</li>
-      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v4/resources.html" %}</li>
       <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v4/nodes.html" %}</li>
-      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v4/catalogs.html" %}</li>
+      <li>{% iflink "Environments Endpoint", "/puppetdb/master/api/query/v4/environments.html" %}</li>
+      <li>{% iflink "Factsets Endpoint", "/puppetdb/master/api/query/v4/factsets.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v4/facts.html" %}</li>
       <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v4/fact-names.html" %}</li>
       <li>{% iflink "Fact-Paths Endpoint", "/puppetdb/master/api/query/v4/fact-paths.html" %}</li>
-      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v4/metrics.html" %}</li>
+      <li>{% iflink "Fact-Nodes Endpoint", "/puppetdb/master/api/query/v4/fact-nodes.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v4/catalogs.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v4/resources.html" %}</li>
       <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v4/reports.html" %}</li>
       <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v4/events.html" %}</li>
       <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v4/event-counts.html" %}</li>
       <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v4/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v4/metrics.html" %}</li>
       <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v4/server-time.html" %}</li>
       <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v4/version.html" %}</li>
-      <li>{% iflink "Environments Endpoint", "/puppetdb/master/api/query/v4/environments.html" %}</li>
     </ul>
   </li>
   <li><strong>Query API Version 3</strong>
@@ -81,16 +82,16 @@
       <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v3/query.html" %}</li>
       <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v3/operators.html" %}</li>
       <li>{% iflink "Query Paging", "/puppetdb/master/api/query/v3/paging.html" %}</li>
-      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v3/facts.html" %}</li>
-      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v3/resources.html" %}</li>
       <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v3/nodes.html" %}</li>
-      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v3/catalogs.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v3/facts.html" %}</li>
       <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v3/fact-names.html" %}</li>
-      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v3/metrics.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v3/catalogs.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v3/resources.html" %}</li>
       <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v3/reports.html" %}</li>
       <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v3/events.html" %}</li>
       <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v3/event-counts.html" %}</li>
       <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v3/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v3/metrics.html" %}</li>
       <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v3/server-time.html" %}</li>
       <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v3/version.html" %}</li>
     </ul>
@@ -99,10 +100,10 @@
     <ul>
       <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v2/query.html" %}</li>
       <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v2/operators.html" %}</li>
-      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v2/facts.html" %}</li>
-      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v2/resources.html" %}</li>
       <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v2/nodes.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v2/facts.html" %}</li>
       <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v2/fact-names.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v2/resources.html" %}</li>
       <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v2/metrics.html" %}</li>
     </ul>
   </li>


### PR DESCRIPTION
This adds the endpoint `fact-nodes` to the index for master, and re-orders the
indexes so that like components are next to each other.

Signed-off-by: Ken Barber ken@bob.sh
