### PR TITLE
Updates modules_publishing and modules_installing for PE 3.3.1 release

### DIFF
--- a/source/_includes/pe33.html
+++ b/source/_includes/pe33.html
@@ -71,6 +71,8 @@
       <li><a href="./puppet_data_library.html">Puppet Data Library</a></li>
       <li><a href="./puppet_references.html">References</a></li>
       <li><a href="./puppet_config.html">Configuring Puppet Core</a></li>
+      <li><a href="./modules_installing.html">Installing, Upgrading, & Uninstalling Modules</a></li>
+      <li><a href="./modules_publishing.html">Publishing Modules</a></li>
     </ul>
   </li>
   <li><strong>Orchestration</strong>

--- a/source/pe/3.3/modules_installing.markdown
+++ b/source/pe/3.3/modules_installing.markdown
@@ -1,0 +1,207 @@
+---
+layout: default
+title: "Installing Modules"
+canonical: "/puppet/latest/reference/modules_installing.html"
+---
+
+[forge]: http://forge.puppetlabs.com
+[module_man]: /references/3.6.latest/man/module.html
+[modulepath]: /references/stable/configuration.html#modulepath
+
+[publishing]: ./modules_publishing.html
+[fundamentals]: ./modules_fundamentals.html
+[plugins]: /guides/plugins_in_modules.html
+[documentation]: ./modules_documentation.html
+
+Installing Modules
+=====
+
+
+![Windows note](/images/windows-logo-small.jpg)
+
+* Windows nodes that pull configurations from a Linux or Unix puppet master can use any Forge modules installed on the master. Continue reading to learn how to use the module tool on your puppet master.
+* On Windows nodes which compile their own catalogs, you can install a Forge module by downloading and extracting the module's release tarball from the module's page on the Forge (you will also need to download each module listed in the Dependencies tab). Then run the following command in PowerShell or Command Prompt: `puppet module install <path to tarball> --ignore-dependencies`.
+
+**Solaris Note**
+To use the puppet module tool on Solaris systems, you must first install gtar.
+
+The [Puppet Forge][forge] is a **repository of pre-existing modules,** written and contributed by users. These modules solve a wide variety of problems so using them can save you time and effort.
+
+The `puppet module` subcommand, which ships with Puppet, is a tool for finding and managing new modules from the Forge. Its interface is similar to several common package managers, and makes it easy to **search for and install new modules from the command line.**
+
+* Continue reading to learn how to install and manage modules from the Puppet Forge.
+* [See "Module Fundamentals"][fundamentals] to learn how to use and write Puppet modules.
+* [See "Publishing Modules"][publishing] to learn how to contribute your own modules to the Forge, including information about the puppet module tool's `build` and `generate` actions.
+* [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
+* [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
+
+
+Using the Module Tool
+-----
+
+The `puppet module` subcommand has several **actions.** The main actions used for managing modules are:
+
+`install`
+: Install a module from the Forge or a release archive.
+
+      # puppet module install puppetlabs-apache --version 0.0.2
+
+`list`
+: List installed modules.
+
+      # puppet module list
+
+`search`
+: Search the Forge for a module.
+
+      # puppet module search apache
+
+`uninstall`
+: Uninstall a puppet module.
+
+      # puppet module uninstall puppetlabs-apache
+
+`upgrade`
+: Upgrade a puppet module.
+
+      # puppet module upgrade puppetlabs-apache --version 0.0.3
+
+If you have used a command line package manager tool (like `gem`, `apt-get`, or `yum`) before, these actions will generally do what you expect. You can view a full description of each action with `puppet man module` or by [viewing the man page here][module_man].
+
+###Using the Module Tool Behind a Proxy
+
+In order to use the puppet module tool behind a proxy, you need to set the following:
+
+	export http_proxy=http://10.187.255.9:8080 
+	export https_proxy=http://10.187.255.9:8080
+	
+Alternatively, you can set these two proxy settings inside the `user` config section in the `puppet.conf` file: `http_proxy_host` and `http_proxy_port`. For more information, see [Configuration Reference](/references/latest/configuration.html).
+
+**Note:** Make sure to set these two proxy settings in the `user` section only. Otherwise, there can be adverse effects. 
+
+
+Installing Modules
+-----
+
+The `puppet module install` action will install a module and all of its dependencies. By default, **it will install into the first directory in Puppet's modulepath.**
+
+* Use the `--version` option to specify a version. You can use an exact version or a requirement string like `>=1.0.3`.
+* Use the `--force` option to forcibly install a module or re-install an existing module.
+* Use the `--environment` option to install into a different environment.
+* Use the `--modulepath` option to manually specify which directory to install into. Note: To avoid duplicating modules installed as dependencies, you may need to specify the modulepath as a list of directories; see [the documentation for setting the modulepath][modulepath] for details.
+* Use the `--ignore-dependencies` option to skip installing any modules required by this module.
+* Use the `--debug` option to see additional information about what the puppet module tool is doing.
+
+<!-- TODO: change this if the behavior of --dir/--target-dir changes; for now, we aren't mentioning it -->
+
+### Installing From the Puppet Forge
+
+To install a module from the Puppet Forge, simply identify the desired module by its full name. **The full name of a Forge module is formatted as "username-modulename."**
+
+    # puppet module install puppetlabs-apache
+
+### Installing From Another Module Repository
+
+The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/latest/configuration.html#modulerepository) setting in [`puppet.conf`](/puppet/3.6/reference/config_file_main.html) or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `http://forge.puppetlabs.com`.
+
+After setting the repository, follow the instructions above for installing from the Forge.
+
+    # puppet module install --module_repository http://dev-forge.example.com puppetlabs-apache
+
+### Installing From a Release Tarball
+
+To install a module from a release tarball, specify the path to the tarball instead of the module name.
+
+Make sure to use the `--ignore-dependencies` flag if you cannot currently reach the Puppet Forge or are installing modules that have not yet been published to the Forge. This flag will tell the puppet module tool not to try to resolve dependencies by connecting to the Forge. Be aware that in this case you must manually install any dependencies.
+
+    # puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependencies
+
+### Installing PE Supported Modules
+
+PE 3.2 introduced [supported modules](http://forge.puppetlabs.com/supported), which  includes an additional field in the modules' metadata.json files to indicate compatibility with PE versions. The puppet module tool (PMT) has been updated to look for PE version requirements in the metadata. 
+
+If you are running PE 3.2 or greater, please note that if a version of the module matches the installed version of PE, non-matching versions will be filtered out. The `--force` flag will prevent this filtering, and will either install the most recent version of the module if no version is specified or install the specified version. Note that the `--force` flag will ignore dependencies and checksums, as well as overwrite installed modules with the same modulename. The `--debug` flag will show whether a module is being filtered or not. If no PE version metadata is present in any version, all available versions of the module will be displayed.
+
+*Note:*
+It is possible that some community modules may also include this `requirements` metadata. **We stongly reccomend against including the `requirements` field in modules that are not Puppet Labs supported modules.**
+
+Finding Modules
+-----
+
+Modules can be found by browsing the Forge's [web interface][forge] or by using the module tool's **`search` action.** The search action accepts a single search term and returns a list of modules whose names, descriptions, or keywords match the search term.
+
+    $ puppet module search apache
+    Searching http://forge.puppetlabs.com ...
+    NAME                           DESCRIPTION            AUTHOR          KEYWORDS
+    puppetlabs-apache              This is a generic ...  @puppetlabs     apache web
+    puppetlabs-passenger           Module to manage P...  @puppetlabs     apache
+    DavidSchmitt-apache            Manages apache, mo...  @DavidSchmitt   apache
+    jamtur01-httpauth              Puppet HTTP Authen...  @jamtur01       apache
+    jamtur01-apachemodules         Puppet Apache Modu...  @jamtur01       apache
+    adobe-hadoop                   Puppet module to d...  @adobe          apache
+    adobe-hbase                    Puppet module to d...  @adobe          apache
+    adobe-zookeeper                Puppet module to d...  @adobe          apache
+    adobe-highavailability         Puppet module to c...  @adobe          apache mon
+    adobe-mon                      Puppet module to d...  @adobe          apache mon
+    puppetmanaged-webserver        Apache webserver m...  @puppetmanaged  apache
+    ghoneycutt-apache              Manages apache ser...  @ghoneycutt     apache web
+    ghoneycutt-sites               This module manage...  @ghoneycutt     apache web
+    fliplap-apache_modules_sles11  Exactly the same a...  @fliplap
+    mstanislav-puppet_yum          Puppet 2.              @mstanislav     apache
+    mstanislav-apache_yum          Puppet 2.              @mstanislav     apache
+    jonhadfield-wordpress          Puppet module to s...  @jonhadfield    apache php
+    saz-php                        Manage cli, apache...  @saz            apache php
+    pmtacceptance-apache           This is a dummy ap...  @pmtacceptance  apache php
+    pmtacceptance-php              This is a dummy ph...  @pmtacceptance  apache php
+
+Once you've identified the module you need, you can install it by name as described above.
+
+
+Managing Modules
+-----
+
+### Listing Installed Modules
+
+Use the module tool's **`list` action** to see which modules you have installed (and which directory they're installed in).
+
+* Use the `--tree` option to view the modules arranged by dependency instead of by location on disk.
+
+### Upgrading Modules
+
+Use the module tool's **`upgrade` action** to upgrade an installed module to the latest version. The target module must be identified by its full name.
+
+* Use the `--version` option to specify a version.
+* Use the `--ignore-changes` option to upgrade the module while ignoring and overwriting any local changes that may have been made.
+* Use the `--ignore-dependencies` option to skip upgrading any modules required by this module.
+
+### Uninstalling Modules
+
+Use the module tool's **`uninstall` action** to remove an installed module. The target module must be identified by its full name:
+
+    # puppet module uninstall apache
+    Error: Could not uninstall module 'apache':
+      Module 'apache' is not installed
+          You may have meant `puppet module uninstall puppetlabs-apache`
+    # puppet module uninstall puppetlabs-apache
+    Removed /etc/puppet/modules/apache (v0.0.3)
+
+By default, the tool won't uninstall a module which other modules depend on or whose files have been edited since it was installed.
+
+* Use the `--force` option to uninstall even if the module is depended on or has been manually edited.
+* Use the `--ignore-changes` option to upgrade the module while ignoring and overwriting any local changes that may have been made.
+
+### Errors
+
+The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/latest/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+
+If you see an error similiar to the following when upgrading or uninstalling,
+
+~~~
+Notice: Preparing to upgrade 'puppetlabs-motd' ...
+Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/puppet/modules ...
+Error: Could not upgrade module 'puppetlabs-motd' (v1.0.0 -> latest)
+  Installed module has had changes made locally
+~~~
+
+you can workaround it by upgrading or uninstalling using the `--ignore-changes` option.
+

--- a/source/pe/3.3/modules_publishing.markdown
+++ b/source/pe/3.3/modules_publishing.markdown
@@ -1,0 +1,292 @@
+---
+layout: default
+title: "Publishing Modules on the Puppet Forge"
+canonical: "/puppet/latest/reference/modules_publishing.html"
+---
+
+
+[installing]: ./modules_installing.html
+[fundamentals]: ./modules_fundamentals.html
+[plugins]: /guides/plugins_in_modules.html
+[forge]: https://forge.puppetlabs.com/
+[rspec]: http://rspec-puppet.com/
+[signup]: ./images/forge_signup.png
+[publishmodule]: ./images/forge_publish_module.png
+[uploadtarball]: ./images/forge_upload_tarball.png
+[uploadtarball2]: ./images/forge_upload_tarball2.png
+[forgenewrelease]: ./images/forge_new_release.png
+[documentation]: ./modules_documentation.html
+[errors]: ./modules_installing.html#errors
+
+Publishing Modules on the Puppet Forge
+=====
+
+The Puppet Forge is a community repository of modules, written and contributed by  Puppet Open Source and Puppet Enterprise users. Using the Puppet Forge is a great way to build on the work others have done and get updates and expansions on your own module work. This document describes how to publish your own modules to the Puppet Forge so that other users can [install][installing] them.
+
+
+* Continue reading to learn how to publish your modules to the Puppet Forge.
+* [See "Module Fundamentals"][fundamentals] for how to write and use your own Puppet modules.
+* [See "Installing Modules"][installing] for how to install pre-built modules from the Puppet Forge.
+* [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
+* [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
+
+>**DEPRECATION WARNING** As of Puppet 3.6 the Modulefile has been deprecated in favor of the metadata.json file. We strongly suggest that you use `puppet module generate` to create new modules, as it now includes a dialog for creating your metadata.json. You can read more about how to [deal with your Modulefile](#build-your-modulefile) below.
+
+
+Overview
+-----
+
+This guide assumes that you have already [written a useful Puppet module][fundamentals]. To publish your module, you will need to:
+
+1. Create a Puppet Forge account, if you don't already have one.
+2. Prepare your module.
+3. Write a metadata.json file with the required metadata.
+4. Build an uploadable tarball of your module.
+5. Upload your module using the Puppet Forge's web interface.
+
+> ###A Note on Module Names
+>
+> Because many users have published their own versions of modules with common names ("mysql," "bacula," etc.), the Puppet Forge requires module names to have a username prefix. That is, if a user named "puppetlabs" maintained a "mysql" module, it would be known to the Puppet Forge as `puppetlabs-mysql`.
+>
+> **Be sure to use this long name in your module's [metadata.json file](#write-a-metadatajson-file).** However, you do not have to rename the module's directory, and can leave the module in your active modulepath --- the build action will do the right thing as long as the metadata.json is correct.
+
+> ###Another Note on Module Names
+>
+> Although the Puppet Forge expects to receive modules named `username-module`, its web interface presents them as `username/module`. There isn't a good reason for this, and we are working on reconciling the two; in the meantime, be sure to always use the `username-module` style in your metadata files and when issuing commands.
+
+Create a Puppet Forge Account
+--------
+
+Before you begin, you should create a user account on the Puppet Forge. You will need to know your username when preparing to publish any of your modules.
+
+1. Start by navigating to the [Puppet Forge website][forge] and clicking the "Sign Up" link in the sidebar:
+
+![The "sign up" link in the Puppet Forge sidebar][signup]
+
+2. Fill in your details. After you finish, you will be asked to verify your email address via a verification email. Once you have done so, you can publish modules to the Puppet Forge.
+
+Prepare the Module
+-----
+
+If you already have a Puppet module with the [correct directory layout][fundamentals], you may continue to the next step.
+
+Alternately, you can use the `puppet module generate` action to generate a template layout. Generating a module will provide you with a sample README and a copy of the `spec_helper` tool for writing [rspec-puppet][rspec] tests. It will also launch a series of questions that will create your metadata.json file. If you decided to construct a module on your own first, you will need to manually copy that module's files into the generated module.
+
+To generate a new module, run `puppet module generate <USERNAME>-<MODULE NAME>`. For example:
+
+    # puppet module generate examplecorp-mymodule
+    Generating module at /Users/Pat/Development/examplecorp-mymodule
+    examplecorp-mymodule
+    examplecorp-mymodule/manifests
+    examplecorp-mymodule/manifests/init.pp
+    examplecorp-mymodule/metadata.json
+    examplecorp-mymodule/Rakefile
+    examplecorp-mymodule/README.md
+    examplecorp-mymodule/spec
+    examplecorp-mymodule/spec/classes
+    examplecorp-mymodule/spec/classes/init_spec.rb
+    examplecorp-mymodule/spec/spec_helper.rb
+    examplecorp-mymodule/tests
+    examplecorp-mymodule/tests/init.pp
+    
+
+Write a metadata.json File
+-----
+
+If you generated your module using the `puppet module generate` command, you'll already have a metadata.json file. If you put your module together without using the `puppet module generate` command, you must make sure that you have a metadata.json file in your module's main directory. 
+
+The metadata.json is a JSON-formatted file containing information about your module, such as its name, version, and dependencies.
+
+Your metadata.json will look something like
+
+    {
+      "name": "examplecorp-mymodule",
+      "version": "0.0.1",
+      "author": "Pat",
+      "license": "Licensed under (Apache 2.0)",
+      "summary": "A module for a thing",
+      "source": "https://github.com/examplecorp/examplecorp-mymodule",
+      "project_page": "(https://forge.puppetlabs.com/examplecorp/mymodule)",
+      "issues_url": "",
+      "tags": ["things", "stuff"],
+      "operatingsystem_support": [
+        {
+        "operatingsystem":"RedHat",
+        "operatingsystemrelease":[ "5.0", "6.0" ]
+        },
+        {
+        "operatingsystem": "Ubuntu",
+        "operatingsystemrelease": [ "12.04", "10.04" ]
+        }
+       ]
+      "dependencies": [
+        { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
+        { "name": "puppetlabs/firewall", "version_requirement": ">= 0.0.4" },
+      ] 
+    }
+
+###Fields in metadata.json 
+
+* `name` --- REQUIRED. The **full name** of your module, including the username (e.g. "username-module" --- [see note above](#a-note-on-module-names)).
+* `version` --- REQUIRED. The current version of your module. This should be a [semantic version](http://semver.org/).
+* `author` --- REQUIRED. The person who gets credit for creating the module. If not provided, this field will default to the username portion of the `name` field.
+* `license` --- REQUIRED. The license under which your module is made available.
+* `summary` --- REQUIRED. A one-line description of your module.
+* `source` --- REQUIRED. The source repository for your module.
+* `dependencies` --- REQUIRED. A list of the other modules that your module depends on to function. See [Dependencies in metadata.json](#dependencies-in-metadatajson) below for more details.
+* `project_page` --- A link to your module's website. This will typically be the Puppet Forge.
+* `issues_url` --- A link to your module's issue tracker.
+* `operatingsystem_support` --- A list of operating system compatibility for your module. See [Operating system compatibility in metadata.json](#operating-system-compatibility-in-metadatajson) below for more details.
+* `tags` --- A list of key words that will help others find your module (not case sensitive)(e.g. [“msyql”, “database”, “monitoring”]). Tags cannot contain whitespace. We recommend using four to six tags. 
+
+#####DEPRECATED
+
+* `types` --- Resource type documentation generated by the puppet module tool as part of `puppet module build`. **You must [remove this field](#migrate-from-modulefile-to-metadatajson) from your metadata.json or else your module will break.**
+* `checksums`--- File checksums generated by the puppet module tool as part of `puppet module build`. **You must [remove this field](#migrate-from-modulefile-to-metadatajson) from your metadata.json or else your module will break.**
+
+###Dependencies in metadata.json
+
+If your module's functionality depends upon functionality in another module, you can express this in the `dependencies` field of your metadata.json file. The `dependencies` field accepts an array of hashes. Here's an example from the [puppetlabs-postgresql](https://forge.puppetlabs.com/puppetlabs/postgresql) module:
+
+    "dependencies": [
+      { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
+      { "name": "puppetlabs/firewall", "version_requirement": ">= 0.0.4" },
+      { "name": "puppetlabs/apt", "version_requirement": ">=1.1.0 <2.0.0" },      
+      { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <2.0.0" }
+    ]
+
+
+**Note:** Once you've generated your module and gone through the metadata.json dialog, you must manually edit the metadata.json file to include the dependency information. 
+
+> **Warning:** The full name in a dependency **must** use a slash between the username and module name. **This is different from the name format used elsewhere in metadata.json.** This is a legacy architecture problem with the Puppet Forge, and we apologize for the inconvenience. We are working on a solution.
+
+The version requirement in a dependency isn't limited to a single version; you can use several operators for version comparisons. 
+
+* `1.2.3` --- A specific version.
+* `>1.2.3` --- Greater than a specific version.
+* `<1.2.3` --- Less than a specific version.
+* `>=1.2.3` --- Greater than or equal to a specific version.
+* `<=1.2.3` --- Less than or equal to a specific version.
+* `>=1.0.0 <2.0.0` --- Range of versions; both conditions must be satisfied. (This example would match 1.0.1 but not 2.0.1)
+* `1.x` --- A semantic major version. (This example would match 1.0.1 but not 2.0.1, and is shorthand for `>=1.0.0 <2.0.0`.)
+* `1.2.x` --- A semantic major and minor version. (This example would match 1.2.3 but not 1.3.0, and is shorthand for `>=1.2.0 <1.3.0`.)
+
+**Note:** You cannot mix semantic versioning shorthand (.x) with greater/less than versioning syntax. The following would be incorrect.
+
+* `>= 3.2.x`
+* `< 4.x`
+
+###Operating system compatibility in metadata.json
+
+If you are publishing your module to the Puppet Forge, we highly recommend that you include `operatingsystem_support` in your metadata.json. Even if you do not intend to publish your module, including this information can be helpful for tracking your work. 
+
+You can express this field through an array of hashes, classified under `operatingsystem` or `operatingsystemrelease`. `operatingsystem` will be used with Forge search filters, and `operatingsystemrelease` will be treated as strings on module pages. You can format it in either way shown below:
+
+    "operatingsystem_support": [
+      {
+      "operatingsystem":"RedHat",
+      "operatingsystemrelease":[ "5.0", "6.0" ]
+      },
+      {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "10.04"
+        ]
+      }
+    ]
+
+> ###A Note on Semantic Versioning
+>
+> When writing your metadata.json file, you're setting a version for your own module and optionally expressing dependencies on others' module versions. We strongly recommend following the [Semantic Versioning](http://semver.org/spec/v1.0.0.html) specification. Doing so allows others to rely on your modules without unexpected change.
+>
+> Many other users already use semantic versioning, and you can take advantage of this in your modules' dependencies. For example, if you depend on puppetlabs/stdlib and want to allow updates while avoiding breaking changes, you could write the following line in your metadata.json (assuming a current stdlib version of 4.2.1):
+>
+>     "dependencies": [
+>       { "name": "puppetlabs/stdlib", "version_requirement": "4.x" },
+>     ]
+
+Build Your Module
+------
+
+With Puppet 3.6's updates to the puppet module tool (PMT), the process for  building your module will be slightly different based on the files in your module's directory. 
+
+* [I generated a new module using `puppet module generate`](#brand-new-module)
+* [I have a Modulefile and no metadata.json](#modulefile-no-metadatajson)
+* [I have a Modulefile and a metadata.json](#modulefile-and-metadatajson)
+* [I have a metadata.json and no Modulefile](#metadatajson-no-modulefile)
+
+In order for your module to be successfully uploaded to and displayed on the Forge, your metadata.json file will need to have the following [fields](#fields-in-metadatajson): name, version, author, license, summary, source, dependencies, project_page, operatingsystem_support, and tags.
+
+###Brand new module
+
+If you used Puppet 3.6 to run `puppet module generate` to create your module, your metadata.json file was created for you! To build your module:
+
+1. Run `# puppet module build <MODULE DIRECTORY>`. A .tar.gz package will be generated and saved in the module's pkg/ subdirectory. For example:
+
+~~~
+    # puppet module build /etc/puppetlabs/puppet/modules/mymodule
+    Building /etc/puppetlabs/puppet/modules/mymodule for release
+    /etc/puppetlabs/puppet/modules/mymodule/pkg/examplecorp-mymodule-0.0.1.tar.gz
+~~~
+
+###Modulefile, no metadata.json
+
+1. Run `# puppet module build <MODULE DIRECTORY>`. 
+2. If you have a Modulefile but no metadata.json file, you will receive a deprecation warning when you run the build command. The PMT will build you a complete metadata.json file using the information in your Modulefile, and will place the metadata.json in both your build directory and root module directory. 
+3. In your module's root directory, delete your Modulefile.
+
+###Modulefile and metadata.json
+
+1. Run `# puppet module build <MODULE DIRECTORY>`. The PMT will merge your Modulefile and metadata.json files and issue a deprecation warning. 
+2. In your module's root directory, delete your Modulefile.
+
+###metadata.json, no Modulefile
+
+1. Make sure, before you build, that your metadata.json contains all of the [fields](#fields-in-metadatajson) required for publishing to the Forge.
+2. Run `# puppet module build <MODULE DIRECTORY>`. A .tar.gz package will be generated and saved in the module's pkg/ subdirectory. 
+
+Upload to the Puppet Forge
+------
+
+Now that you have a compiled `tar.gz` package, you can upload it to the Puppet Forge. *Note:* Your tarball must be 10MB or less. There is currently no command line tool for publishing; you must use the Puppet Forge's web interface.
+
+In your web browser, navigate [to the Puppet Forge][forge] and log in.
+
+###Create a Module Page
+
+If you have never published this module before, you must create a new page for it. 
+
+1. Click the "Publish a Module" in the sidebar:
+
+![the "publish a module"" link in the Forge's sidebar][publishmodule]
+
+2. Fill in the module form that opens. Only the "Module Name" field is required. **Use the module's short name, not the long `username-module` name.**
+
+3. Click the "Publish Module" button at the bottom of the form. Doing so automatically takes you to the new module page.
+
+###Create a Release
+
+1. Navigate to the module's page if you are not already there, and click the "Click here to upload your tarball" link:
+
+![the "upload a tarball" link on a module's page][uploadtarball]
+
+This will bring you to the upload form:
+
+![the upload form for a new release of a module][uploadtarball2]
+
+2. Click "Choose File" and use the file browser to locate and select the release tarball you created with the `puppet module build` action. Then click the "Upload Release" link.
+
+Your module has now been published to the Puppet Forge. The Forge will pull your README, Changelog, and License files from your tarball to display on your module's page. To confirm that it was published correctly, you can [install it][installing] on a new system using the `puppet module install` action.
+
+
+Release a New Version
+-----
+
+1. To release a new version of an already published module, make any necessary edits to your module, and then increment the `version` field in the metadata.json file (ensuring you use a valid [semantic version](http://semver.org/)).
+
+2. When you're ready to publish your new version, navigate [to the Puppet Forge][forge] and log in if necessary. Click the "Upload a New Release" link:
+
+![the upload a new release link][forgenewrelease]
+
+This will bring you to the upload form as mentioned in [Create a Release](#create-a-release) above, where you can select the new release tarball and upload the release.


### PR DESCRIPTION
PMT bug (JIRA PE-5074 and PE-5120) has been fixed. Remove publisher workaround steps. Update upgrading/uninstalling sections with --ignore-changes flag. Add pages specifically to PE docs. Add sidebar navigation for these pages.
