### PR TITLE
Add notes to modules_installing/publishing re new PE pages.

### DIFF
--- a/source/puppet/3.6/reference/modules_installing.markdown
+++ b/source/puppet/3.6/reference/modules_installing.markdown
@@ -16,6 +16,8 @@ canonical: "/puppet/latest/reference/modules_installing.html"
 Installing Modules
 =====
 
+>**A Note for Puppet Enterprise 3.3.1 users**
+>A bug present in Puppet 3.6 was fixed in PE's 3.3.1 release. Please go to the [PE-specific](https://docs.puppetlabs.com/pe/3.3/modules_installing.html) page for an updated workflow. 
 
 ![Windows note](/images/windows-logo-small.jpg)
 

--- a/source/puppet/3.6/reference/modules_publishing.markdown
+++ b/source/puppet/3.6/reference/modules_publishing.markdown
@@ -21,6 +21,9 @@ canonical: "/puppet/latest/reference/modules_publishing.html"
 Publishing Modules on the Puppet Forge
 =====
 
+>**A Note for Puppet Enterprise 3.3.1 users**
+>A bug present in Puppet 3.6 was fixed in PE's 3.3.1 release. Please go to the [PE-specific](https://docs.puppetlabs.com/pe/3.3/modules_publishing.html) page for an updated workflow.
+
 The Puppet Forge is a community repository of modules, written and contributed by  Puppet Open Source and Puppet Enterprise users. Using the Puppet Forge is a great way to build on the work others have done and get updates and expansions on your own module work. This document describes how to publish your own modules to the Puppet Forge so that other users can [install][installing] them.
 
 


### PR DESCRIPTION
Due to the PE 3.3.1 release fixing a PMT bug, the workflow for PE 3.3.1 users has diverged from Puppet 3.6 users. New pages have already been added to PE-specific docs. This adds notes pointing to those docs.
