### PR TITLE
Prepare release for PuppetDB 2.2

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -36,6 +36,7 @@ defaultnav:
   /puppetdb/1.6: puppetdb1.6.html
   /puppetdb/2.0: puppetdb2.0.html
   /puppetdb/2.1: puppetdb2.1.html
+  /puppetdb/2.2: puppetdb2.2.html
   /puppetdb/master: puppetdb_master.html
   /puppet/0.24/reference: puppet_0_24.html
   /puppet/0.25/reference: puppet_0_25.html
@@ -55,8 +56,8 @@ url: "http://docs.puppetlabs.com"
 #    commit: origin/master # a git treeish (in a form acceptable to `git checkout`) that the external source should track. This should almost always be either a tag, which will never update, or an upstream tracking branch on the default "origin" remote (origin/<branch>), which will update every time someone builds the site.
 #    subdirectory: website # A subdirectory within the remote repository that contains the documentation files that we'll build and mount at the specified url.
 externalsources:
-  # Both 1.1 and 1.2 are now 'legacy' and so we can clear the branch, we are
-  # referencing a sha1 directly instead.
+  # Older versions of PuppetDB are now 'legacy' and so we can clear the branch, we are
+  # referencing a tag instead.
   puppetdb_1.1:
     url: /puppetdb/1.1
     repo: git://github.com/puppetlabs/puppetdb.git
@@ -94,6 +95,11 @@ externalsources:
     subdirectory: documentation
   puppetdb_2.1:
     url: /puppetdb/2.1
+    repo: git://github.com/puppetlabs/puppetdb.git
+    commit: origin/2.1.x
+    subdirectory: documentation
+  puppetdb_2.2:
+    url: /puppetdb/2.2
     repo: git://github.com/puppetlabs/puppetdb.git
     commit: origin/stable
     subdirectory: documentation

--- a/source/_includes/puppetdb2.2.html
+++ b/source/_includes/puppetdb2.2.html
@@ -1,0 +1,126 @@
+<h2 id="puppetdb">PuppetDB 2.2</h2>
+
+<p class="versionnote">This documentation is for an unreleased version of PuppetDB! Please see the documentation for the <a href="/puppetdb/2.1/">latest official release</a>.</p>
+
+<ul>
+  <li><strong>General Information</strong>
+    <ul>
+      <li>{% iflink "Overview & Requirements", "/puppetdb/master/index.html" %}</li>
+      <li>{% iflink "Frequently Asked Questions", "/puppetdb/master/puppetdb-faq.html" %}</li>
+      <li>{% iflink "Release Notes", "/puppetdb/master/release_notes.html" %}</li>
+      <li>{% iflink "Versioning Policy", "/puppetdb/master/versioning_policy.html" %}</li>
+      <li>{% iflink "Known Issues", "/puppetdb/master/known_issues.html" %}</li>
+      <li>{% iflink "Community Add-ons", "/puppetdb/master/community_add_ons.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Installation</strong>
+    <ul>
+      <li>{% iflink "Migrating Existing Data", "/puppetdb/master/migrate.html" %}</li>
+      <li>{% iflink "Installing via Puppet Module", "/puppetdb/master/install_via_module.html" %}</li>
+      <li>{% iflink "Installing From Packages", "/puppetdb/master/install_from_packages.html" %}</li>
+      <li>{% iflink "Installing from Source", "/puppetdb/master/install_from_source.html" %}</li>
+      <li>{% iflink "Upgrading PuppetDB", "/puppetdb/master/upgrade.html" %}</li>
+      <li>{% iflink "Connecting Puppet Masters", "/puppetdb/master/connect_puppet_master.html" %}</li>
+      <li>{% iflink "Connecting Standalone Puppet", "/puppetdb/master/connect_puppet_apply.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Configuration</strong>
+    <ul>
+      <li>{% iflink "Configuring PuppetDB", "/puppetdb/master/configure.html" %}</li>
+      <li>{% iflink "Setting Up SSL for PostgreSQL", "/puppetdb/master/postgres_ssl.html" %}</li>
+    </ul>
+  <li><strong>Usage/Admin</strong>
+    <ul>
+      <li>{% iflink "Using PuppetDB", "/puppetdb/master/using.html" %}</li>
+      <li>{% iflink "Maintaining and Tuning", "/puppetdb/master/maintain_and_tune.html" %}</li>
+      <li>{% iflink "Migrating Data", "/puppetdb/master/migrate.html" %}</li>
+      <li>{% iflink "Anonymizing Data", "/puppetdb/master/anonymization.html" %}</li>
+      <li>{% iflink "Scaling Recommendations", "/puppetdb/master/scaling_recommendations.html" %}</li>
+      <li>{% iflink "Debugging with Remote REPL", "/puppetdb/master/repl.html" %}</li>
+      <li>{% iflink "Load Testing", "/puppetdb/master/load_testing_tool.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Troubleshooting</strong>
+    <ul>
+      <li>{% iflink "KahaDB Corruption", "/puppetdb/master/trouble_kahadb_corruption.html" %}</li>
+      <li>{% iflink "Low Catalog Duplication", "/puppetdb/master/trouble_low_catalog_duplication.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>API</strong>
+    <ul>
+      <li>{% iflink "Overview", "/puppetdb/master/api/index.html" %}</li>
+      <li>{% iflink "Query Tutorial", "/puppetdb/master/api/query/tutorial.html" %}</li>
+      <li>{% iflink "Curl Tips", "/puppetdb/master/api/query/curl.html" %}</li>
+      <li>{% iflink "Command API", "/puppetdb/master/api/commands.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 4 (experimental)</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v4/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v4/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/master/api/query/v4/paging.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v4/nodes.html" %}</li>
+      <li>{% iflink "Environments Endpoint", "/puppetdb/master/api/query/v4/environments.html" %}</li>
+      <li>{% iflink "Factsets Endpoint", "/puppetdb/master/api/query/v4/factsets.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v4/facts.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v4/fact-names.html" %}</li>
+      <li>{% iflink "Fact-Paths Endpoint", "/puppetdb/master/api/query/v4/fact-paths.html" %}</li>
+      <li>{% iflink "Fact-Contents Endpoint", "/puppetdb/master/api/query/v4/fact-contents.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v4/catalogs.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v4/resources.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v4/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v4/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v4/event-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v4/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v4/metrics.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v4/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v4/version.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 3</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v3/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v3/operators.html" %}</li>
+      <li>{% iflink "Query Paging", "/puppetdb/master/api/query/v3/paging.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v3/nodes.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v3/facts.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v3/fact-names.html" %}</li>
+      <li>{% iflink "Catalogs Endpoint", "/puppetdb/master/api/query/v3/catalogs.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v3/resources.html" %}</li>
+      <li>{% iflink "Reports Endpoint", "/puppetdb/master/api/query/v3/reports.html" %}</li>
+      <li>{% iflink "Events Endpoint", "/puppetdb/master/api/query/v3/events.html" %}</li>
+      <li>{% iflink "Event Counts Endpoint", "/puppetdb/master/api/query/v3/event-counts.html" %}</li>
+      <li>{% iflink "Aggregate Event Counts Endpoint", "/puppetdb/master/api/query/v3/aggregate-event-counts.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v3/metrics.html" %}</li>
+      <li>{% iflink "Server Time Endpoint", "/puppetdb/master/api/query/v3/server-time.html" %}</li>
+      <li>{% iflink "Version Endpoint", "/puppetdb/master/api/query/v3/version.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 2 (Deprecated)</strong>
+    <ul>
+      <li>{% iflink "Query Structure", "/puppetdb/master/api/query/v2/query.html" %}</li>
+      <li>{% iflink "Available Operators", "/puppetdb/master/api/query/v2/operators.html" %}</li>
+      <li>{% iflink "Nodes Endpoint", "/puppetdb/master/api/query/v2/nodes.html" %}</li>
+      <li>{% iflink "Facts Endpoint", "/puppetdb/master/api/query/v2/facts.html" %}</li>
+      <li>{% iflink "Fact-Names Endpoint", "/puppetdb/master/api/query/v2/fact-names.html" %}</li>
+      <li>{% iflink "Resources Endpoint", "/puppetdb/master/api/query/v2/resources.html" %}</li>
+      <li>{% iflink "Metrics Endpoint", "/puppetdb/master/api/query/v2/metrics.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format - v5", "/puppetdb/master/api/wire_format/catalog_format_v5.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v3", "/puppetdb/master/api/wire_format/facts_format_v3.html" %}</li>
+      <li>{% iflink "Report Wire Format - v3", "/puppetdb/master/api/wire_format/report_format_v3.html" %}</li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats - Deprecated</strong>
+    <ul>
+      <li>{% iflink "Catalog Wire Format - v4", "/puppetdb/master/api/wire_format/catalog_format_v4.html" %}</li>
+      <li>{% iflink "Catalog Wire Format - v1", "/puppetdb/master/api/wire_format/catalog_format_v1.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v2", "/puppetdb/master/api/wire_format/facts_format_v2.html" %}</li>
+      <li>{% iflink "Facts Wire Format - v1", "/puppetdb/master/api/wire_format/facts_format_v1.html" %}</li>
+      <li>{% iflink "Report Wire Format - v1", "/puppetdb/master/api/wire_format/report_format_v1.html" %}</li>
+    </ul>
+  </li>
+</ul>

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -17,10 +17,10 @@ Stable Community Versions
 
 * [PuppetDB 2.1](./2.1)
 
-Legacy Versions
+Legacy Community Versions
 -----
 
-The following documentation links are no longer actively maintained. You should upgrade to the latest revision of PuppetDB to benefit from the latest bug fixes, features and documentation.
+The following community versions are no longer actively maintained. You should upgrade to the latest revision of PuppetDB to benefit from the latest bug fixes, features and documentation.
 
 * [PuppetDB 2.0](./2.0)
 * [PuppetDB 1.6](./1.6)
@@ -37,4 +37,5 @@ Development and Pre-release Versions
 
 This version of the documentation represents a future feature or major release. This content only applies to the code available in the master branch of the PuppetDB git repository or a release candidate, so if you have downloaded a stable release you should consult the documentation above.
 
+* [PuppetDB 2.2](./2.2)
 * [PuppetDB (master)](./master)


### PR DESCRIPTION
This prepares the indexes and source code retrieval for version 2.2. It bumps
2.1 to use a new 2.1.x branch as well. Since we haven't released yet, we still
need to leave the docs as 'pending release' for now.

Signed-off-by: Ken Barber ken@bob.sh
