### PR TITLE
Add a note that you may not have a class named foo::init.

### DIFF
--- a/source/puppet/3.6/reference/modules_fundamentals.markdown
+++ b/source/puppet/3.6/reference/modules_fundamentals.markdown
@@ -109,7 +109,7 @@ Each of the module's subdirectories has a specific function, as follows.
 
 **Each manifest in a module's `manifests` folder should contain one class or defined type.** The file names of manifests **map predictably** to the names of the classes and defined types they contain.
 
-`init.pp` is special and **always contains a class with the same name as the module.**
+`init.pp` is special and **always contains a class with the same name as the module. You may not have a class named init.**
 
 Every other manifest contains a class or defined type named as follows:
 


### PR DESCRIPTION
When migrating from puppet 2.7 to 3.6, I banged my head on a desk for a bit wondering why Puppet was telling me it could not find a class we had named foo::init inside of foo/manifests/init.pp. The class was there. It worked in 2.7. Turns out init is a reserved word and can't be used for class names (wish the error had been more helpful, instead of 'not found.').
