### PR TITLE
(DOC-1035) Notes for enabling profiling output

### DIFF
--- a/source/pe/3.3/trouble_puppet.markdown
+++ b/source/pe/3.3/trouble_puppet.markdown
@@ -16,9 +16,9 @@ PE 3 uses an updated version of Ruby, 1.9, that is much stricter about character
 
 You can get the puppet master to log additional debug-level messages about how much time each step of its catalog compilation takes by setting `profile` to `true` in an agent's puppet.conf file (or specify `--profile` on the CLI). 
 
-If you’re trying to profile, be sure to check the `--logdest` and `--debug` options on the master — debug must be on, and messages will go to the log destination, which defaults to syslog. If you’re running via Passenger or another Rack server, these options will be set in the config.ru file.
+If you're trying to profile, be sure to check the `--logdest` and `--debug` command-line options on the master --- debug must be on, and messages will go to the log destination, which defaults to syslog. If you're running via Passenger or another Rack server, these options must be set as command-line arguments in the config.ru file and not as settings in puppet.conf. The config.ru file for Puppet Enterprise, located at `/var/opt/lib/pe-puppetmaster/config.ru`, contains a commented set of example arguments that enable profiling.
 
-To find the messages, look for the string PROFILE in the master’s logs — each catalog request will get a unique ID, so you can tell which messages are for which request.
+To find the messages, look for the string `PROFILE` in the master's logs --- each catalog request will get a unique ID, so you can tell which messages are for which request. Ensure syslog is configured to record messages logged at debug priority when used as the log destination.
 
 ### Increase `PassengerMaxPoolSize` to Decrease Response Times on Node Requests
 

--- a/source/puppet/3/reference/release_notes.markdown
+++ b/source/puppet/3/reference/release_notes.markdown
@@ -934,9 +934,9 @@ The new [`%` modulo operator][32modulo_operator] will return the remainder of di
 
 If you set [the `profile` setting][32profiling_setting] to `true` in  an agent node's puppet.conf (or specify `--profile` on the command line), the puppet master will log additional debug-level messages about how much time each step of its catalog compilation takes.
 
-If you're trying to profile, be sure to check the `--logdest` and `--debug` command-line options on the master --- debug must be on, and messages will go to the log destination, which defaults to syslog. If you're running via Passenger or another Rack server, these options will be set in the config.ru file.
+If you're trying to profile, be sure to check the `--logdest` and `--debug` command-line options on the master --- debug must be on, and messages will go to the log destination, which defaults to syslog. If you're running via Passenger or another Rack server, these options must be set as command-line arguments in the config.ru file and not as settings in puppet.conf.
 
-To find the messages, look for the string `PROFILE` in the master's logs --- each catalog request will get a unique ID, so you can tell which messages are for which request.
+To find the messages, look for the string `PROFILE` in the master's logs --- each catalog request will get a unique ID, so you can tell which messages are for which request. Ensure syslog is configured to record messages logged at debug priority when used as the log destination.
 
 (Issue [17190][])
 


### PR DESCRIPTION
Added some additional information to the notes on enabling profile output for
Puppet Masters. Notably:
- Log destination and level _absolutely must_ be specified as command line
  arguments and not setting in `puppet.conf`. This requires editing
  `config.ru` when Puppet is running under Passenger.
- Added a pointer to the PE `config.ru` file used by the Puppet Master.
- Added a note concerning `syslog` priority levels. Some systems, such as
  Enterprise Linux, don't record messages sent to syslog at debug priority
  unless the configuration is changed.
