### PR TITLE
Clarify explanation of resources containment in classes.

### DIFF
--- a/source/puppet/3.7/reference/lang_containment.markdown
+++ b/source/puppet/3.7/reference/lang_containment.markdown
@@ -38,7 +38,7 @@ This effectively means that if any resource or class forms a [relationship][] wi
     }
 {% endhighlight %}
 
-In this example, `Exec['/usr/local/bin/update_custom_timestamps.sh']` would happen after _every_ resource in the ntp class, including the package, the file, and the service.
+In this example, `Exec['/usr/local/bin/update_custom_timestamps.sh']` would happen after _every_ resource in the ntp class has been fulfilled, including the package, the file, and the service.
 
 This feature also allows you to [notify and subscribe to][notify] classes and defined resource types as though they were a single resource.
 


### PR DESCRIPTION
The documentation explaining the containment behaviour of a resource dependent on a class is unclear. It reads as though the dependent resource will be executed after each resource declared in the class has been fulfilled, which is incorrect.