### PR TITLE
DOC-1349

### DIFF
--- a/source/puppet/3.7/reference/modules_publishing.markdown
+++ b/source/puppet/3.7/reference/modules_publishing.markdown
@@ -122,7 +122,7 @@ Your metadata.json will look something like
       "summary": "A module for a thing",
       "source": "https://github.com/examplecorp/examplecorp-mymodule",
       "project_page": "https://forge.puppetlabs.com/examplecorp/mymodule",
-      "issues_url": "",
+      "issues_url": "https://github.com/examplecorp/examplecorp-mymodule/issues",
       "tags": ["things", "stuff"],
       "operatingsystem_support": [
         {


### PR DESCRIPTION
Two commits fix the example metadata.json in the modules_publishing page. project_url was invalid if someone published with the parenthesis which we came across last week. The second commit adds a simple issues_url example. 

https://tickets.puppetlabs.com/browse/DOC-1349
