### PR TITLE
[DOC-1367] Update known issues to include a note about basemodulepath needing to be set in [main]

### DIFF
--- a/source/pe/3.7/install_upgrading_notes.markdown
+++ b/source/pe/3.7/install_upgrading_notes.markdown
@@ -13,7 +13,9 @@ PE 3.7.0 introduces the Puppet server, running the Puppet Master, which function
 
 Directory environments are enabled by default in PE 3.7.0. Before upgrading be sure to read [Important Information about Upgrades to PE 3.7 and Directory Environments](./install_upgrading_dir_env_notes.html).
 
->**Warning**: If you enabled directory environments in pe 3.3.x and are upgrading to pe 3.7.0, ensure there is no `default_manifest` parameter in `puppet.conf` **before** upgrading. Upgrades will fail if this change is not made.
+>**Warning**: If you enabled directory environments in PE 3.3.x and are upgrading to PE 3.7.0, ensure there is no `default_manifest` parameter in `puppet.conf` **before** upgrading. Upgrades will fail if this change is not made.
+
+>**Warning**: If you enabled directory environents in PE 3.3.x and are upgrading to PE 3.7.0, ensure that the `basemodulepath` parameter in `puppet.conf` is set in the `[main]` section and not in the `[master]` section **before** upgrading.  Upgrades will fail if this change is not made.
 
 ### Upgrading to the Node Classifier
 

--- a/source/pe/3.7/release_notes.markdown
+++ b/source/pe/3.7/release_notes.markdown
@@ -123,6 +123,10 @@ The following issues affect the currently shipped version of PE and all prior re
 
 ### Issues Related to Puppet Server
 
+#### Upgrading to PE 3.7.0 Will Fail If `basemodulepath` Is Not Set In `[main]` Section of `puppet.conf`.
+
+This only affects users who are upgradign from PE 3.3.x who have enabled directory environments.  If the `basemodulepath` is set in `[master]` then the parts of the upgrader that use `puppet apply` will fail due to not being able to find the PE specific modules. To prevent this, ensure that `basemodulepath` is set in the `[main]` section of `puppet.conf` prior to beginning the upgrade.
+
 #### SSL Termination Configuration Not Currently Supported
 
 Previous to PE 3.7.0, it was possible to configure your environment to handle SSL termination on a hardware load balancer. This situation was handled by supporting some custom HTTP headers where the client certificate information could be stored when the SSL was terminated, thus making it possible for Puppet to continue to perform authorization checks based on the client certificate data, even when communicating via HTTP instead of HTTPS. This configuration is not yet supported, but we intend to support it in a future release.


### PR DESCRIPTION
This patch adds a note to the known isseus page and the upgrade notes
page to inform people that `basemodulepath` needs to be in `[main]`,
and if it is just set in `[master]` it will cause the upgrader to fail

This PR also includes a fix for DOC-1368 as part of this patch
