### PR TITLE
(docs) Add a comma after the operatingsystem_support node in the metadat...

### DIFF
--- a/source/puppet/3.7/reference/modules_publishing.markdown
+++ b/source/puppet/3.7/reference/modules_publishing.markdown
@@ -118,7 +118,7 @@ Your metadata.json will look something like
         "operatingsystem": "Ubuntu",
         "operatingsystemrelease": [ "12.04", "10.04" ]
         }
-       ]
+       ],
       "dependencies": [
         { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
         { "name": "puppetlabs/firewall", "version_requirement": ">= 0.0.4" },


### PR DESCRIPTION
...a.json example in source/puppet/3.7/reference/modules_publishing.markdown

The json is currently invalid.
