### PR TITLE
Added license info to community guidelines doc page

### DIFF
--- a/source/community/community_guidelines.markdown
+++ b/source/community/community_guidelines.markdown
@@ -231,3 +231,8 @@ Credit to [01.org](https://01.org/community/participation-guidelines) and [meego
 
 The Event Code of Conduct is based on the [example policy from the Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment), created by the Ada Initiative and other volunteers. The [PyCon Code of Conduct](https://github.com/python/pycon-code-of-conduct) also served as inspiration.
 
+### License
+
+These documents belong to the community and are licensed under the Creative Commons. You can help improve them!
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-Share Alike 3.0 United States License</a>.


### PR DESCRIPTION
added explicit license info to bottom of doc to reduce the number of requests that we getto re-use content and questions about the license for people landing just on this page
