### PR TITLE
Remove SMTP step from quick_start_install_mono

### DIFF
--- a/source/pe/3.7/quick_start_install_mono.markdown
+++ b/source/pe/3.7/quick_start_install_mono.markdown
@@ -2,23 +2,23 @@
 layout: default
 title: "PE 3.7 » Quick Start » Install PE (Monolithic)"
 subtitle: "PE Install Quick Start Guide"
-canonical: "/pe/latest/quick_start_install_mono.html" 
+canonical: "/pe/latest/quick_start_install_mono.html"
 ---
 
 
-### Overview 
+### Overview
 
 To get you started using Puppet Enterprise (PE) relatively quickly and efficiently, this guide walks you through the steps of a monolithic install. A monolithic deployment is best suited for users who want to evaluate PE, or for users managing a small number of puppet agent nodes (up to 500 nodes). For larger installations, you’ll need to perform a [split install](./install_pe_split.html).
 
-A monolithic PE deployment entails installing the puppet master, the PE console, and PuppetDB all on one node. Puppet agent nodes are installed later as part of the agent installation quick start guide [todo: link]. 
+A monolithic PE deployment entails installing the puppet master, the PE console, and PuppetDB all on one node. Puppet agent nodes are installed later as part of the agent installation quick start guide [todo: link].
 
-For more information about the components that make up your PE deployment, visit the [installation overview](./install_basic.html) in the PE docs. 
+For more information about the components that make up your PE deployment, visit the [installation overview](./install_basic.html) in the PE docs.
 
-Note: This guide assumes that you’ll install a monolithic PE deployment as `root`. 
+Note: This guide assumes that you’ll install a monolithic PE deployment as `root`.
 
 >#### General Prerequisites and Notes
 >
->- See the [system requirements](./install_system_requirements.html#monolithic-all-in-one-installation) to ensure your hardware needs are met. 
+>- See the [system requirements](./install_system_requirements.html#monolithic-all-in-one-installation) to ensure your hardware needs are met.
 >
 >- Make sure that DNS is properly configured on the machines you're installing PE on. All nodes must **know their own hostnames.** This can be done by properly configuring reverse DNS on your local DNS server, or by setting the hostname explicitly. Setting the hostname usually involves the `hostname` command and one or more configuration files, while the exact method varies by platform. In addition, all nodes must be able to **reach each other by name.** This can be done with a local DNS server, or by editing the `/etc/hosts` file on each node to point to the proper IP addresses.
 >
@@ -50,27 +50,25 @@ Note: This guide assumes that you’ll install a monolithic PE deployment as `ro
 9. Next, you'll be asked to choose your deployment type. Select **Monolithic**.
 10. Choose to install the Puppet master component on the server you're running the installer from.
 11. Provide the following information about the puppet master server:
-    
+
     a. **Puppet master FQDN**: provide the fully qualified domain name of the server you're installing PE on; for example, `master.example.com`.
-    
+
     b. **DNS aliases**: provide a comma-separated list of aliases agent nodes can use to reach to the master; for example `master`.
-   
+
 12. When prompted about database support, choose the default option **Install PostgreSQL for me**.
 
 13. Provide the following information about the PE console administrator user:
 
     **Console superuser password**: create a password for the console login; the password must be at least eight characters.
-    
+
     **Note**: the user name for the console administrator user is __admin__.
 
-14. For **SMTP Hostname** use `localhost`.
-
-15. Click **Submit**.
-16. On the confirm plan page, review the information you provided, and, if it looks correct, click **Continue**.
+14. Click **Submit**.
+15. On the confirm plan page, review the information you provided, and, if it looks correct, click **Continue**.
 
     If you need to make any changes, click **Go Back** and make whatever changes are required.
 
-17. On the validation page, the installer will verify various configuration elements (e.g., if SSH credentials are correct, if there is enough disk space, and if the OS is the same for the various components). If there aren't any outstanding issues, click **Deploy now**.
+16. On the validation page, the installer will verify various configuration elements (e.g., if SSH credentials are correct, if there is enough disk space, and if the OS is the same for the various components). If there aren't any outstanding issues, click **Deploy now**.
 
 The installer will then install and configure Puppet Enterprise. It may also need to install additional packages from your OS's repository. **This process may take up to 10-15 minutes.** When the installation is complete, the installer script that was running in the terminal will close itself.
 
@@ -88,5 +86,3 @@ To log in to the console, you can select the **Start Using Puppet Enterprise Now
 
 
 Next: Install Agents---[Windows](./quick_start_install_agents_windows.html) or [*nix](./quick_start_install_agents_nix.html)
-
-


### PR DESCRIPTION
There isn't a field for SMTP info in the GUI installer, anymore.

Atom apparently didn't like the EOL spaces or the trailing space at the end of the file. Does any of that actually change the generated page?
