### PR TITLE
Removed an extra "$" from a command

### DIFF
--- a/source/pe/3.7/razor_install.markdown
+++ b/source/pe/3.7/razor_install.markdown
@@ -71,7 +71,7 @@ Razor provides a specific iPXE boot image to ensure you're using a compatible ve
 		
 ###Verify the Razor Server 
 
-Test the new Razor configuration: `wget http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out`.
+Test the new Razor configuration: `wget http://${RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out`.
 	
 The command should execute successfully, and the output JSON file `test.out` should contain a list of available Razor commands.
 


### PR DESCRIPTION
The command provided under "Verify the Razor Server" is as follows:

'''
wget http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out
'''

The output from that is as follows:

'''
-bash: http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api: bad substitution
'''

I changed it to the following, and it seemed to work:

'''
wget http://${RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out
'''
