### PR TITLE
Removed another extra "$" from another command

### DIFF
--- a/source/pe/3.7/razor_install.markdown
+++ b/source/pe/3.7/razor_install.markdown
@@ -87,7 +87,7 @@ The Razor client is installed as a Ruby gem.
 		
 2. You can verify that the Razor client is installed by printing Razor help:
 
-		razor -u http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api
+		razor -u http://${RAZOR_HOSTNAME}:${RAZOR_PORT}/api
 
 3. You'll likely get this warning message about JSON: "MultiJson is using the default adapter (ok_json). We recommend loading a different JSON library to improve performance."  This message is harmless, but you can disble it with this command:
 


### PR DESCRIPTION
The command provided under "Verify the Razor Server" is as follows:

```
wget http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out
```

The output from that is as follows:

```
-bash: http://${$RAZOR_HOSTNAME}:${RAZOR_PORT}/api: bad substitution
```

I changed it to the following, and it seemed to work:

```
wget http://${RAZOR_HOSTNAME}:${RAZOR_PORT}/api -O test.out
```
