### PR TITLE
(PDB-486) Added link for the new terminus failover docs

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -29,6 +29,7 @@
   <li><strong>Configuration</strong>
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/configure.html">Configuring PuppetDB</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/puppetdb_connection.html">Configuring PuppetDB Connection</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/postgres_ssl.html">Setting Up SSL for PostgreSQL</a></li>
     </ul>
   <li><strong>Usage/Admin</strong>


### PR DESCRIPTION
This is needed in connection with this pr: https://github.com/puppetlabs/puppetdb/pull/1212 