### PR TITLE
(PDB-486) puppetdb.conf page lives in PuppetDB docs now

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -29,6 +29,7 @@
   <li><strong>Configuration</strong>
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/configure.html">Configuring PuppetDB</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/puppetdb_connection.html">puppetdb.conf: Configuring a Puppet/PuppetDB Connection</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/postgres_ssl.html">Setting Up SSL for PostgreSQL</a></li>
     </ul>
   <li><strong>Usage/Admin</strong>

--- a/source/puppet/3.7/reference/config_file_puppetdb.markdown
+++ b/source/puppet/3.7/reference/config_file_puppetdb.markdown
@@ -4,11 +4,20 @@ title: "Config Files: puppetdb.conf"
 canonical: "/puppet/latest/reference/config_file_puppetdb.html"
 ---
 
+[puppetdb_connection]: /puppetdb/master/puppetdb_connection.html
 
 
-The `puppetdb.conf` file contains the hostname and port of the [PuppetDB](/puppetdb/latest/) server. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
+The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/puppetdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
 
-## Location
+## PuppetDB Documentation
+
+If you're using PuppetDB 3.0 or higher (unreleased as of this writing), [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
+
+## PuppetDB 2.2 and Earlier
+
+The following description does **not** apply to PuppetDB 3.0 and later. If you're using a newer version, see [the PuppetDB docs][puppetdb_connection] instead, as the file format has changed.
+
+### Location
 
 The `puppetdb.conf` file is always located at `$confdir/puppetdb.conf`. Its location is **not** configurable.
 
@@ -16,13 +25,13 @@ The location of the `confdir` varies; it depends on the OS, Puppet distribution,
 
 [confdir]: ./dirs_confdir.html
 
-## Example
+### Example
 
     [main]
     server = puppetdb.example.com
     port = 8081
 
-## Format
+### Format
 
 The `puppetdb.conf` file uses the same INI-like format as `puppet.conf`, but only uses a `[main]` section and only has two settings:
 


### PR DESCRIPTION
This commit updates the Puppet reference manual page about that file, and adds
that page to the master version of the PuppetDB docs index.