### PR TITLE
(maint) Fix statement that says regular expressions cannot be assigned

### DIFF
--- a/source/puppet/3.7/reference/future_lang_variables.markdown
+++ b/source/puppet/3.7/reference/future_lang_variables.markdown
@@ -34,7 +34,7 @@ Syntax
 
 Variable names are prefixed with a `$` (dollar sign). Values are assigned to them with the `=` (equal sign) assignment operator.
 
-Any value of any of the normal (i.e. non-regex) [data types][datatype] can be assigned to a variable. Any statement that resolves to a normal value (including [expressions][], [functions][], and other variables) can be used in place of a literal value. The variable will contain the value that the statement resolves to, rather than a reference to the statement.
+Any value of any of the [data types][datatype] can be assigned to a variable. Any statement that resolves to a normal value (including [expressions][], [functions][], and other variables) can be used in place of a literal value. The variable will contain the value that the statement resolves to, rather than a reference to the statement.
 
 Variables can only be assigned using their [short name](#naming). That is, a given [scope][] cannot assign values to variables in a foreign scope.
 


### PR DESCRIPTION
It is possible to assign a regular expression to a variable and use it
later. e.g.

$a = /ana/
notice "banana"=~ $a

Which will notice true.