### PR TITLE
puppetdb_master.html: remove retired APIs and wire formats

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -80,50 +80,11 @@
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/version.html">Version Endpoint</a></li>
     </ul>
   </li>
-  <li><strong>Query API Version 3</strong>
-    <ul>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/query.html">Query Structure</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/operators.html">Available Operators</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/paging.html">Query Paging</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/nodes.html">Nodes Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/facts.html">Facts Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/fact-names.html">Fact-Names Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/catalogs.html">Catalogs Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/resources.html">Resources Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/reports.html">Reports Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/events.html">Events Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/event-counts.html">Event Counts Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/aggregate-event-counts.html">Aggregate Event Counts Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/metrics.html">Metrics Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/server-time.html">Server Time Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v3/version.html">Version Endpoint</a></li>
-    </ul>
-  </li>
-  <li><strong>Query API Version 2 (Deprecated)</strong>
-    <ul>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/query.html">Query Structure</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/operators.html">Available Operators</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/nodes.html">Nodes Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/facts.html">Facts Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/fact-names.html">Fact-Names Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/resources.html">Resources Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v2/metrics.html">Metrics Endpoint</a></li>
-    </ul>
-  </li>
   <li><strong>Wire Formats</strong>
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v5.html">Catalog Wire Format - v5</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v3.html">Facts Wire Format - v3</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v3.html">Report Wire Format - v3</a></li>
-    </ul>
-  </li>
-  <li><strong>Wire Formats - Deprecated</strong>
-    <ul>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v4.html">Catalog Wire Format - v4</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v1.html">Catalog Wire Format - v1</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v2.html">Facts Wire Format - v2</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v1.html">Facts Wire Format - v1</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v1.html">Report Wire Format - v1</a></li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
All APIs except v4 have been removed from PuppetDB master, so remove
them from the documentation sidebar too.