### PR TITLE
Minor typo fix in Puppet Style Guide

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -269,7 +269,7 @@ Within a manifest, resources should be grouped by logical relationship to each o
     }
 
     file { '/tmp/dir2':
-      ensure => directory,,
+      ensure => directory,
     }
 
     file { '/tmp/dir2/b':
@@ -285,7 +285,7 @@ Within a manifest, resources should be grouped by logical relationship to each o
     }
 
     file { '/tmp/dir2':
-      ensure => directory,,
+      ensure => directory,
     }
     
     file { ‘/tmp/dir/a’:


### PR DESCRIPTION
This commit removes an extraneous comma in the third resource in
both the good and bad examples of section 9.4 of the style guide.