### PR TITLE
Make 10.2 example comply with own rules and 10.7

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -427,30 +427,28 @@ We recommend that the last two items -- declared resources and declared relation
 The following example follows the recommended style:
 
 ~~~
+    # init.pp
     class myservice (
-      $service_ensure = 'running',
-      $package_list   = undef,
-    ) {
+      $service_ensure     = $myservice::params::service_ensure,
+      $package_list       = $myservice::params::package_list,
+      $tempfile_contents  = $myservice::params::tempfile_contents,
+    ) inherits myservice::params {
 
-      if $service_ensure in [ 'running', 'stopped' ] {
-        $_ensure = $service_ensure
-      } else {
+      if !($service_ensure in [ 'running', 'stopped' ]) {
         fail('ensure parameter must be running or stopped')
       }
 
-      if $package_list {
-        $_package_list = $package_list
-       } else {
-        case $::operatingsystem {
-          'centos': {
-            $_package_list = 'myservice-centos-package'
-          }
-          'solaris': {
-            $_package_list = [ 'myservice-solaris-package1', 'myservice-solaris-package2' ]
-          }
-          default: {
-            fail("Module ${module_name} does not support ${::operatingsystem}")
-          }
+      if !$package_list {
+        fail("Module ${module_name} does not support ${::operatingsystem}")
+      }
+
+      # temp file contents cannot contain numbers
+      case $tempfile_contents {
+        /\d/: {
+          $_tempfile_contents = regsubst($tempfile_contents, '\d', '', 'G')
+        }
+        default: {
+          $_tempfile_contents = $tempfile_contents
         }
       }
 
@@ -458,21 +456,41 @@ The following example follows the recommended style:
 
       Package { ensure => present, }
 
-      File { 
+      File {
         owner => '0',
         group => '0',
         mode  => '0644',
      }
 
-      package { $_package_list: }
+      package { $package_list: }
 
       file { "/tmp/${variable}":
-        ensure => present,
+        ensure   => present,
+        contents => $_tempfile_contents,
       }
 
       service { 'myservice':
-        ensure    => $_service_ensure,
+        ensure    => $service_ensure,
         hasstatus => true,
+      }
+
+      Package[$package_list] -> Service['myservice']
+    }
+
+    # params.pp
+    class myservice::params {
+      $service_ensure = 'running'
+
+      case $::operatingsystem {
+        'centos': {
+          $package_list = 'myservice-centos-package'
+        }
+        'solaris': {
+          $package_list = [ 'myservice-solaris-package1', 'myservice-solaris-package2' ]
+        }
+        default: {
+          $package_list = undef
+        }
       }
     }
 ~~~


### PR DESCRIPTION
The example in 10.2 violated 10.7 by specifying parameter defaults inside the class. Additionally, it did not adequately demonstrate 10.2.4 or 10.2.8.