### PR TITLE
(DOCUMENT-258) Facter online doc : broken link

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -148,7 +148,7 @@ version_notes:
   # Default notes for upstreams. Tweak these whenever latest de-syncs or re-syncs with PE!
   /puppet/: '<p class="noisy">This page is about an old version of Puppet. If you use the current version of Puppet or of Puppet Enterprise, see <a href="/puppet/latest/index.html">the current Puppet docs.</a></p>'
   /puppetdb/: '<p class="noisy">This page is about an old version of PuppetDB. If you use the current version of PuppetDB or of Puppet Enterprise, see <a href="/puppetdb/latest">the current PuppetDB docs.</a></p>'
-  /facter/: '<p class="noisy">This page is about an old version of Facter. If you use the current version of Facter, see <a href="/puppet/latest">the latest version of the docs.</a> If you use Puppet Enterprise 3.7, see <a href="/facter/2.2">the Facter 2.2 docs.</a></p>'
+  /facter/: '<p class="noisy">This page is about an old version of Facter. If you use the current version of Facter, see <a href="/facter/latest">the latest version of the docs.</a> If you use Puppet Enterprise 3.7, see <a href="/facter/2.2">the Facter 2.2 docs.</a></p>'
   # Version-specific notes:
   /puppet/3.7: "Applies to Puppet Enterprise 3.7"
   /puppetdb/2.2: "Applies to Puppet Enterprise 3.7"


### PR DESCRIPTION
This patch corrects a broken link in the facter 2.0 docs related to the latest version of the documentation.