### PR TITLE
Review and fix future parser doc 3_7

### DIFF
--- a/source/guides/language_history.markdown
+++ b/source/guides/language_history.markdown
@@ -36,6 +36,33 @@ Iteration over arrays and hashes                                                
 [The modulo (`%`) operator][modulo]                                              |        |            |        |                             |                    |     | X                     | X
 [`$trusted` hash][trusted]                                                       |        |            |        |                             |                    |     |                       | X
 
+<!-- TODO: There are *many* new features in 4.0.0 / future parser that are not in the table. Maybe add a new table that stats with 3x (all blank), 3.7.x future parser, then 4.0.
+ Typesystem
+ Numeric data type
+ Local resource defaults
+ Resource attributes hash
+ Dynamic reference to resource type in resource expression
+ Code blocks /iteration
+ Data in modules and environments
+ heredoc
+ epp
+ namespaced functions
+ optionally typed parameters in classes and defines
+ regular expression as a data type
+ array concat with +
+ hash merge with +
+ array delete with -
+ match type with =~
+ type in case options and selector options
+ type in 'in' search
+ substrings of strings
+ 'in' operator search of substring in string
+ arithmetic only on numeric, not on strings
+ empty string is truthy
+ 
+ etc.
+ -->
+
 \* In Puppet 2.7.20+ and 3.0.2+, hyphens in variable names can be reenabled with [the `allow_variables_with_dashes` setting][hv_pref]. This should only be used as a temporary measure while renaming variables.
 
 \*\* Until Puppet 2.6.7, hashes could not be nested and hash members could not be used in selectors.

--- a/source/puppet/3.7/reference/future_lang_classes.markdown
+++ b/source/puppet/3.7/reference/future_lang_classes.markdown
@@ -133,9 +133,9 @@ Classes should be stored in their module's `manifests/` directory as one class p
 >
 > Most users should **only** load classes from modules. However, you can also put classes in the following additional locations:
 >
-> * [The main manifest][sitedotpp]. If you do so, they may be placed anywhere in the file and are not parse-order dependent.
-> * [Imported manifests][import]. If you do so, you must [import][] the file containing the class before you may declare it.
-> * Other class definitions. This puts the interior class under the exterior class's [namespace][], causing its real name to be something other than the name with which it was defined. It does not cause the interior class to be automatically declared along with the exterior class. Nested classes cannot be autoloaded; in order for the interior class to be visible to Puppet, the manifest containing it must have been forcibly loaded, either by autoloading the outermost class, using an [import][] statement, or placing the entire nested structure in the site manifest. Although nesting classes is not yet formally deprecated, it is **very much** not recommended.
+> * [The main manifest][sitedotpp], or a main directory of manifests. If you do so, they may be placed anywhere in the file (or directory structure) and are not evaluation-order dependent.
+> * [Imported manifests][import] has been discontinued in favor of a directory of manifests.
+> * Other class definitions. This puts the interior class under the exterior class's [namespace][], causing its real name to be the parents name concatenated with '::' and the name with which it was defined. It does not cause the interior class to be automatically declared along with the exterior class. Nested classes cannot be autoloaded without also causing the containing class to be autoloaded; puppet attempts to load a manifest for each part of the class' namespaces and stops when a matching manifest is found - e.g if including `mymodule::outer::nested`, puppet will try to load `mymodule/outer/nested.pp`, then `mymodule/outer.pp`. Puppet gives up if the first found manifest does not define the class. Alternatively, the nested class becomes visible if its outer class is directly autoloaded, or if its parent is in the main manifest (or directory of manifests). Although it is possible to nest classes and play tricks with loading and naming, it is **very much** not recommended.
 
 ### Containment
 
@@ -147,17 +147,22 @@ Classes can also contain other classes, but _you must manually specify that a cl
 
 Every resource in a class gets automatically [tagged][tags] with the class's name (and each of its [namespace segments][namespace]).
 
+Every class gets automatically [tagged][tags] with its container's name (typically the name of
+a node.
+
 ### Inheritance
 
 Classes can be derived from other classes using the `inherits` keyword. This allows you to make special-case classes that extend the functionality of a more general "base" class.
 
-> Note: This version of Puppet does not support using parameterized classes for inheritable base classes. The base class **must** have no parameters.
+> Note: This version of Puppet does not support using parameterized classes for inheritable base classes. The base class **must** have no parameters, or parameters must be set by default, or
+> by data binding.
 
 Inheritance causes three things to happen:
 
-* When a derived class is declared, its base class is automatically declared **first** (if it wasn't already declared elsewhere).
+* When a derived class is defined, its base class is automatically defined **first** (if it wasn't already defined elsewhere).
 * The base class becomes the [parent scope][parent_scope] of the derived class, so that the new class receives a copy of all of the base class's variables and resource defaults.
 * Code in the derived class is given special permission to override any resource attributes that were set in the base class.
+* Blocks further inheritance of the base class, since it can only be included once.
 
 > #### Aside: When to Inherit
 >
@@ -170,7 +175,7 @@ Inheritance causes three things to happen:
 >
 >   This pattern works by guaranteeing that the params class is evaluated before Puppet attempts to evaluate the main class's parameter list. It is especially useful when you want your default values to change based on system facts and other data, since it lets you isolate and encapsulate all that conditional logic.
 >
-> **In nearly all other cases, inheritance is unnecessary complexity.** If you need some class's resources declared before proceeding further, you can [include](#using-include) it inside another class's definition. If you need to read internal data from another class, you should generally use [qualified variable names][qualified_var] instead of assigning parent scopes. If you need to use an "anti-class" pattern (e.g. to disable a service that is normally enabled), you can use a class parameter to override the standard behavior.
+> **In nearly all other cases, inheritance is unnecessary complexity.** If you need some class's resources defined before proceeding further, you can [include](#using-include) it inside another class's definition. If you need to read internal data from another class, you should generally use [qualified variable names][qualified_var] instead of assigning parent scopes. If you need to use an "anti-class" pattern (e.g. to disable a service that is normally enabled), you can use a class parameter to override the standard behavior.
 >
 > Note also that you can [use resource collectors to override resource attributes][collector_override] in unrelated classes, although this feature should be handled with care.
 
@@ -203,7 +208,7 @@ You can remove an attribute's previous value without setting a new one by overri
 
 This causes the attribute to be unmanaged by Puppet.
 
-> **Note:** If a base class declares other classes with the resource-like syntax, a class derived from it cannot override the class parameters of those inner classes. This is a known bug.
+> **Note:** If a base class defines other classes with the resource-like syntax, a class derived from it cannot override the class parameters of those inner classes. This is a known bug.
 
 #### Appending to Resource Attributes
 
@@ -228,16 +233,16 @@ Some resource attributes (such as the [relationship metaparameters][relationship
 
 
 
-Declaring Classes
+Including Classes
 -----
 
-**Declaring** a class in a Puppet manifest adds all of its resources to the catalog. You can declare classes in [node definitions][node], at top scope in the [site manifest][sitedotpp], and in other classes or [defined types][definedtype]. Declaring classes isn't the only way to add them to the catalog; you can also [assign classes to nodes with an ENC](#assigning-classes-from-an-enc).
+**Including** a class in a Puppet manifest adds all of its resources to the catalog. You can include classes in [node definitions][node], at top scope in the [site manifest][sitedotpp], and in other classes or [defined types][definedtype]. Using `include` to include classes isn't the only way to add them to the catalog; you can also [assign classes to nodes with an ENC](#assigning-classes-from-an-enc).
 
 Classes are singletons --- although a given class may have very different behavior depending on how its parameters are set, the resources in it will only be evaluated **once per compilation.**
 
 ### Include-Like vs. Resource-Like
 
-Puppet has two main ways to declare classes: include-like and resource-like.
+Puppet has two main ways to including classes: include-like and resource-like.
 
 > **Note:** These two behaviors **should not be mixed** for a given class. Puppet's behavior when declaring or assigning a class with both styles is undefined, and will sometimes work and sometimes cause compilation failures.
 
@@ -245,9 +250,9 @@ Puppet has two main ways to declare classes: include-like and resource-like.
 
 [include-like]: #include-like-behavior
 
-The `include`, `require`, `contain`, and `hiera_include` functions let you safely declare a class **multiple times;** no matter how many times you declare it, a class will only be added to the catalog once. This can allow classes or defined types to manage their own dependencies, and lets you create overlapping "role" classes where a given node may have more than one role.
+The `include`, `require`, `contain`, and `hiera_include` functions let you safely include a class **multiple times;** no matter how many times you include it, a class will only be added to the catalog once. This can allow classes or defined types to manage their own dependencies, and lets you create overlapping "role" classes where a given node may have more than one role.
 
-Include-like behavior relies on [external data][external_data] and defaults for class parameter values, which allows the external data source to act like cascading configuration files for all of your classes. When a class is declared, Puppet will try the following for each of its parameters:
+Include-like behavior relies on [external data][external_data] and defaults for class parameter values, which allows the external data source to act like cascading configuration files for all of your classes. When a class is included, Puppet will try the following for each of its parameters:
 
 1. Request a value from [the external data source][external_data], using the key `<class name>::<parameter name>`. (For example, to get the `apache` class's `version` parameter, Puppet would search for `apache::version`.)
 2. Use the default value.
@@ -255,7 +260,7 @@ Include-like behavior relies on [external data][external_data] and defaults for 
 
 > **Aside: Best Practices**
 >
-> **Most** users in **most** situations should use include-like declarations and set parameter values in their external data. However, compatibility with earlier versions of Puppet may require compromises. See [Aside: Writing for Multiple Puppet Versions][aside_history] below for details.
+> **Most** users in **most** situations should use include-like statements and set parameter values in their external data. However, compatibility with earlier versions of Puppet may require compromises. See [Aside: Writing for Multiple Puppet Versions][aside_history] below for details.
 
 > **Version Note:** Automatic external parameter lookup was a new feature in Puppet 3. Puppet 2.7 and earlier could only use default values or override values from resource-like declarations. [See below for more details.][aside_history]
 
@@ -263,7 +268,7 @@ Include-like behavior relies on [external data][external_data] and defaults for 
 
 [resource-like]: #resource-like-behavior
 
-Resource-like class declarations require that you **only declare a given class once.** They allow you to override class parameters at compile time, and will fall back to [external data][external_data] for any parameters you don't override.  When a class is declared, Puppet will try the following for each of its parameters:
+Resource-like class inclusion require that you **only declare a given class once.** They allow you to override class parameters at compile time, and will fall back to [external data][external_data] for any parameters you don't override.  When a class is included this way, Puppet will try the following for each of its parameters:
 
 1. Use the override value from the declaration, if present.
 2. Request a value from [the external data source][external_data], using the key `<class name>::<parameter name>`. (For example, to get the `apache` class's `version` parameter, Puppet would search for `apache::version`.)
@@ -272,18 +277,19 @@ Resource-like class declarations require that you **only declare a given class o
 
 > **Aside: Why Do Resource-Like Declarations Have to Be Unique?**
 >
-> This is necessary to avoid paradoxical or conflicting parameter values. Since overridden values from the class declaration always win, are computed at compile-time, and do not have a built-in hierarchy for resolving conflicts, allowing repeated overrides would cause catalog compilation to be unreliable and parse-order dependent.
+> This is necessary to avoid paradoxical or conflicting parameter values. Since overridden values from the class inclusion always win, are computed at compile-time, and do not have a built-in hierarchy for resolving conflicts, allowing repeated overrides would cause catalog compilation to be unreliable and evaluation-order dependent.
 >
-> This was the original reason for adding external data bindings to include-like declarations: since external data is set **before** compile-time and has a **fixed hierarchy,** the compiler can safely rely on it without risk of conflicts.
+> This was the original reason for adding external data bindings to include-like statements: since external data is set **before** compile-time and has a **fixed hierarchy,** the compiler can safely rely on it without risk of conflicts.
 
 
 ### Using `include`
 
-The `include` [function][] is the standard way to declare classes.
+The `include` [function][] is the standard way to include classes (add them and their contents to
+the catalog).
 
 {% highlight ruby %}
     include base::linux
-    include base::linux # no additional effect; the class is only declared once
+    include base::linux # no additional effect; the class is only added once
 
     include base::linux, apache # including a list
 
@@ -293,9 +299,9 @@ The `include` [function][] is the standard way to declare classes.
 
 The `include` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It can accept:
 
-* A single class
-* A comma-separated list of classes
-* An array of classes
+* A single class name or class reference
+* A comma-separated list of class names or class references
+* An array of class names or class references
 
 ### Using `require`
 
@@ -312,13 +318,13 @@ In the above example, Puppet will ensure that every resource in the `apache` cla
 
 The `require` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It can accept:
 
-* A single class
-* A comma-separated list of classes
-* An array of classes
+* A single class name or class reference
+* A comma-separated list of class names or class references
+* An array of class names or class references
 
 ### Using `contain`
 
-The `contain` function is meant to be used _inside another class definition._ It declares one or more classes, then causes them to become [contained][contains] by the surrounding class. For details, [see the "Containing Classes" section of the Containment page.][contain_classes]
+The `contain` function is meant to be used _inside another class definition._ It includes one or more classes, then causes them to become [contained][contains] by the surrounding class. For details, [see the "Containing Classes" section of the Containment page.][contain_classes]
 
 {% highlight ruby %}
     class ntp {
@@ -338,19 +344,13 @@ In the above example, any resource that forms a `before` or `require` relationsh
 
 The `contain` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It can accept:
 
-* A single class
-* A comma-separated list of classes
-* An array of classes
-
-> **Bug note:** In this version of Puppet, some uses of the `contain` function are affected by bug [PUP-1597](https://tickets.puppetlabs.com/browse/PUP-1597). This bug prevents `contain` from accepting class names with an absolute `::` prefix (for example, `::ntp::service`).
->
-> This bug can also cause `Error: undefined method 'ref' for nil:NilClass` errors. These occur when `contain` is given a class name that would  have been affected by [accidental relative name lookup.](./future_lang_namespaces.html#relative-name-lookup-and-incorrect-name-resolution)
->
-> [PUP-1597](https://tickets.puppetlabs.com/browse/PUP-1597) will be fixed in Puppet 3.7.
+* A single class name or class reference
+* A comma-separated list of class names or class references
+* An array of class names or class references
 
 ### Using `hiera_include`
 
-The `hiera_include` function requests a list of class names from [Hiera][], then declares all of them. Since it uses the [array resolution type][array_search], it will get a combined list that includes classes from **every level** of the [hierarchy][hiera_hierarchy]. This allows you to abandon [node definitions][node] and use Hiera like a lightweight ENC.
+The `hiera_include` function requests a list of class names from [Hiera][], then includes all of them. Since it uses the [array resolution type][array_search], it will get a combined list that includes classes from **every level** of the [hierarchy][hiera_hierarchy]. This allows you to abandon [node definitions][node] and use Hiera like a lightweight ENC.
 
     # /etc/puppetlabs/puppet/hiera.yaml
     ...
@@ -375,24 +375,24 @@ The `hiera_include` function requests a list of class names from [Hiera][], then
     hiera_include(classes)
 {% endhighlight %}
 
-On the node `web01.example.com`, the example above would declare the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only declare `base::linux`.
+On the node `web01.example.com`, the example above would include the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only include `base::linux`.
 
 The `hiera_include` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It accepts a single lookup key.
 
 ### Using Resource-Like Declarations
 
-Resource-like declarations look like [normal resource declarations][resource_declaration], using the special `class` pseudo-resource type.
+Resource-like catalog inclusion look like [normal resource declarations][resource_declaration], using the special `class` pseudo-resource type.
 
 {% highlight ruby %}
     # Overriding a parameter:
     class {'apache':
       version => '2.2.21',
     }
-    # Declaring a class with no parameters:
+    # Including a class with no parameters:
     class {'base::linux':}
 {% endhighlight %}
 
-Resource-like declarations use [resource-like behavior][resource-like]. (Multiple declarations prohibited; parameters may be overridden at compile-time.) You can provide a value for any class parameter by specifying it as resource attribute; any parameters not specified will follow the normal external/default/fail lookup path.
+Resource-like catalog inclusions use [resource-like behavior][resource-like]. (Multiple inclusion prohibited; parameters may be overridden at compile-time.) You can provide a value for any class parameter by specifying it as resource attribute; any parameters not specified will follow the normal external/default/fail lookup path.
 
 In addition to class-specific parameters, you can also specify a value for any [metaparameter][metaparameters]. In such cases, every resource contained in the class will also have that metaparameter:
 
@@ -413,7 +413,7 @@ However, note that:
 Assigning Classes From an ENC
 -----
 
-Classes can also be assigned to nodes by [external node classifiers][enc] and [LDAP node data][ldap_nodes]. Note that most ENCs assign classes with include-like behavior, and some ENCs assign them with resource-like behaior. See the [documentation of the ENC interface][enc] or the documentation of your specific ENC for complete details.
+Classes can also be assigned to nodes by [external node classifiers][enc] and [LDAP node data][ldap_nodes]. Note that most ENCs assign classes with include-like behavior, and some ENCs assign them with resource-like behavior. See the [documentation of the ENC interface][enc] or the documentation of your specific ENC for complete details.
 
 
 
@@ -455,7 +455,7 @@ This design pattern can make for significantly cleaner code while enabling some 
     }
 {% endhighlight %}
 
-To summarize what's happening here: When a class inherits from another class, it implicitly declares the base class. Since the base class's local scope already exists before the new class's parameters get declared, those parameters can be set based on information in the base class.
+To summarize what's happening here: When a class inherits from another class, it implicitly includes the base class. Since the base class's local scope already exists before the new class's parameters get declared, those parameters can be set based on information in the base class.
 
 This is functionally equivalent to doing the following:
 
@@ -497,3 +497,32 @@ This is functionally equivalent to doing the following:
 {% endhighlight %}
 
 ... but it's a significant readability win, especially if the amount of logic or the number of parameters gets any higher than what's shown in the example.
+
+You can also take advantage of Puppet's type system to avoid having to use the string `'UNSET'` to
+indicate that a default value should be used. At the same we also add that a package name
+may not be an empty string.
+
+{% highlight ruby %}
+    # /etc/puppet/modules/webserver/manifests/init.pp
+
+    class webserver(
+      Variant[String[1], Default] $packages = default,
+      Variant[String[1], Default] $vhost_dir = default ) {
+
+     if $packages == default {
+       $real_packages = ...
+     }
+     else {
+      ...
+     }
+
+     if $vhost_dir == default {
+        ...
+       }
+     }
+     else {
+       ...
+    }
+    ...
+    }
+{% endhighlight %}

--- a/source/puppet/3.7/reference/future_lang_collectors.markdown
+++ b/source/puppet/3.7/reference/future_lang_collectors.markdown
@@ -22,7 +22,7 @@ canonical: "/puppet/latest/reference/future_lang_collectors.html"
 [catalog]: ./future_lang_summary.html#compilation-and-catalogs
 
 
-Resource collectors (AKA the spaceship operator) select a group of resources by searching the attributes of every resource in the [catalog][]. This search is parse-order independent (that is, it even includes resources which haven't yet been declared at the time the collector is written). Collectors realize [virtual resources][virtual], can be used in [chaining statements][chaining], and can override resource attributes.
+Resource collectors (AKA the spaceship operator) select a group of resources by searching the attributes of every resource in the [catalog][]. This search is evaluation-order independent (that is, it even includes resources which haven't yet been declared at the time the collector is written). Collectors realize [virtual resources][virtual], can be used in [chaining statements][chaining], and can override resource attributes.
 
 Collectors have an irregular syntax that lets them function as both a statement and a value.
 
@@ -52,7 +52,7 @@ Collectors can search the values of resource titles and attributes using a speci
 
 A collector with an empty search expression will match **every** resource of the specified type.
 
-Parentheses may be used to improve readability. You can create arbitrarily complex expressions using the following four operators:
+Parentheses may be used to improve readability and to modify the priority/grouping of `and`/`or`. You can create arbitrarily complex expressions using the following four operators:
 
 - [`==`](#equality-search)
 - [`!=`](#non-equality-search)
@@ -85,11 +85,15 @@ Both operands must be valid search expressions.
 
 For a given resource, this operator will **match** if **both** of the operands would match for that resource.
 
+This operator has higher priority than `or`.
+
 #### `or`
 
 Both operands must be valid search expressions.
 
 For a given resource, this operator will **match** if **either** of the operands would match for that resource.
+
+This operator has lower priority than `and`.
 
 Location
 -----
@@ -100,8 +104,8 @@ Notably, collectors **cannot** be used in the following contexts:
 
 - as the value of a resource attribute
 - as the argument of a function
-- within an array
-- as the operand of an expression.
+- within an array or hash
+- as the operand of an expression (other than relationship expressions).
 
 
 Behavior
@@ -141,4 +145,7 @@ The general form of an exported resource collector is:
 Exported resource collectors exist only to import resources that were published by other nodes. To use them, you need to have catalog storage and searching (storeconfigs) enabled. See [Exported Resources][exported] for more details. To enable exported resources, follow the [installation instructions][puppetdb_install] and [Puppet configuration instructions][puppetdb_connect] in [the PuppetDB manual][puppetdb].
 
 Like normal collectors, exported resource collectors can be used with attribute blocks and chaining statements.
+
+Note that the search for exported resources also searches the catalog being compiled to avoid having
+to perform an additional run before finding them in the store of exported resources.
 

--- a/source/puppet/3.7/reference/future_lang_defined_types.markdown
+++ b/source/puppet/3.7/reference/future_lang_defined_types.markdown
@@ -87,6 +87,11 @@ To declare a resource of the `apache::vhost` type from the example above:
     }
 {% endhighlight %}
 
+<!-- TODO: * => and using a title of default:  -->
+<!-- TODO: resource declaration is a r-value, a Resource reference, and can be
+     placed in an array etc. One reference is produced per title. -->
+<!-- TODO: Dynamic Reference to Resource type e.g. Resource[$type] { } -->
+
 Behavior
 -----
 

--- a/source/puppet/3.7/reference/future_lang_exported.markdown
+++ b/source/puppet/3.7/reference/future_lang_exported.markdown
@@ -30,6 +30,7 @@ canonical: "/puppet/latest/reference/future_lang_exported.html"
 >
 > (Exported resources can also be enabled by the [deprecated `active_record` storeconfigs][ar_storeconfigs] backend. However, all new users should avoid that and use PuppetDB instead.)
 
+<!-- TODO: active record storeconfigs are removed in puppet 4.0.0 -->
 
 An **exported resource declaration** specifies a desired state for a resource, **does not** manage the resource on the target system, and publishes the resource for use by **other nodes.** Any node (including the node that exported it) can then **collect** the exported resource and manage its own copy of it.
 

--- a/source/puppet/3.7/reference/future_lang_expressions.markdown
+++ b/source/puppet/3.7/reference/future_lang_expressions.markdown
@@ -21,14 +21,12 @@ canonical: "/puppet/latest/reference/future_lang_expressions.html"
 [variables]: ./future_lang_variables.html
 
 
-**Expressions** resolve to values and can be used in **most** of the places where values of the [standard data types][datatypes] are required.  Expressions can be compounded with other expressions and the entire combined expression will resolve to a single value.
-
-Most expressions resolve to [boolean][] values. They are particularly useful as conditions in [conditional statements][conditional].
+**Expressions** resolve to values and can be used almost everywhere values of the [standard data types][datatypes] are required.  Expressions can be compounded with other expressions and the entire combined expression will resolve to a single value.
 
 Location
 -----
 
-Expressions can be used in the following places:
+Expressions can be used almost everywhere:
 
 * The operand of another expression
 * The condition of an [if statement][if]
@@ -36,23 +34,31 @@ Expressions can be used in the following places:
 * The assignment value of a variable
 * The value of a resource attribute
 * The argument(s) of a [function][] call
+* As the title of a resource
+* As an entry in an array or hash (key or value)
 
-They cannot be used as resource titles.
+Expressions cannot be used:
+
+* Where a literal name of a class or define is expected (e.g. in `class` or `define` statements)
+* As the name of a variable (the name of the variable must be a literal name)
 
 Syntax
 -----
 
 Operator expressions take two basic forms:
 
-* **infix operators** appear between two operands: `$a = 1`, `5 < 9`, `$operatingsystem != 'Solaris'`, etc.
-* **prefix operators** appear immediately before a single operand: `*$interfaces`, `!$is_virtual`, etc.
+* **infix operators** appear between operands: `$a = 1`, `5 < 9`, `$operatingsystem != 'Solaris'`, etc. Operators that operate on two operands are said to be *binary* operators.
+* **prefix operators** appear immediately before a single operand: `*$interfaces`, `!$is_virtual`, etc. Prefix operators are also called *unary* operators.
 
-The vast majority of operators are infixes. Expressions may optionally be surrounded by parentheses, which can help
+More complex expressions involve multiple operators, punctuation (such as commas), and/or
+keywords: `$a ? { 0 => false, 1 => true }`, `if $a == 1 { 'red' } else { 'blue'}`, etc.
+
+The vast majority of operators are infixes. Expressions may optionally be surrounded by parentheses to alter the order of evaluation: `10+10/5` is 12, and `(10+10)/5` is 4. Parentheses can help
 make your code clearer: `($operatingsystem == 'Solaris') or ($virtual == 'LXC')`.
 
 ### Operands
 
-Operands in an expression may be:
+Operands in an expression may be any other expression:
 
 * Literal values
 * [Variables][]
@@ -61,7 +67,7 @@ Operands in an expression may be:
 
 The [data type][datatypes] of each operand is dictated by the operator. See the list of operators below for details.
 
-When creating compound expressions by using other expressions as operands, you should use parentheses for clarity:
+When creating compound expressions by using other expressions as operands, you may use parentheses for clarity:
 
 {% highlight ruby %}
     (90 < 7) and ('Solaris' == 'Solaris') # resolves to false
@@ -87,9 +93,9 @@ The precedence of operators, from highest to lowest:
 2. `-` (unary: numeric negation)
 3. `*` (unary: array splat)
 4. `in`
-5. `=~` and `!~` (regex matches and non-match)
+5. `=~` and `!~` (regex or type matches and non-match)
 6. `*`, `/`, and `%` (multiplication, division, and modulo)
-7. `+` and `-` (subtraction and addition/concatenation)
+7. `+` and `-` (addition/concatenation and subtraction/deletion)
 8. `<<` and `>>` (left shift/append and right shift)
 9. `==` and `!=` (equal and not equal)
 10. `>=`, `<=`, `>`, and `<` (greater or equal, less or equal, greater than, and less than)
@@ -106,6 +112,13 @@ Comparison operators have the following traits:
 * They take operands of **several data types**
 * They resolve to [**boolean**][boolean] values
 
+Comparisons of [numbers][numbers] automatically converts between floating point and integral
+values such that `1.0 == 1` is true. Note that calculated floating point values are inexact in that two mathematically equal values may have fractional differences when encoded as a floating point values.
+
+Comparisons of [string][strings] values are case independent for characters in the US ASCII range. Characters outside this range are case sensitive. Characters are compared based on their encoding. This means that for characters in US ASCII range, punctuation comes before digits, digits are in the order 0, 1, 2, ... 9, and letters are in alphabetical order. For characters outside the range the order is defined by their UTF-8 character code which may not always place them in alphabetical order in a given international locale.
+
+It is never an error to compare two values with equals (`==`) or not equals (`!=`), but only strings and numbers can be compared with operators that require values to have a defined order.
+ 
 ### `==` (equality)
 
 Resolves to `true` if the operands are equal. Accepts the following types of operands:
@@ -115,61 +128,70 @@ Resolves to `true` if the operands are equal. Accepts the following types of ope
 * [Arrays][] and [hashes][] --- Tests whether two arrays or hashes are identical.
 * [Booleans][boolean] --- Tests whether two booleans are the same value.
 
+Values are only considered equal if they have the same data type. Notably, this means that
+`1 == "1"` is false, and `"true" == true` is false.
+
 ### `!=` (non-equality)
 
-Resolves to `false` if the operands are equal. Behaves similarly to `==`.
+Resolves to `false` if the operands are equal. Note that `$x != $y` is the same as `!($x == $y)`.
+For details about equality see `==`.
 
 ### `<` (less than)
 
-Resolves to `true` if the left operand is smaller than the right operand. Accepts [numbers][].
-
-The behavior of this operator when used with strings is undefined.
+Resolves to `true` if the left operand is smaller than the right operand. Accepts [numbers][] and [strings][].
 
 ### `>` (greater than)
 
-Resolves to `true` if the left operand is bigger than the right operand. Accepts [numbers][].
-
-The behavior of this operator when used with strings is undefined.
+Resolves to `true` if the left operand is bigger than the right operand. Accepts [numbers][] and [strings][].
 
 ### `<=` (less than or equal to)
 
-Resolves to `true` if the left operand is smaller than or equal to the right operand. Accepts [numbers][].
-
-The behavior of this operator when used with strings is undefined.
+Resolves to `true` if the left operand is smaller than or equal to the right operand. Accepts [numbers][] and [strings][].
 
 ### `>=` (greater than or equal to)
 
-Resolves to `true` if the left operand is bigger than or equal to the right operand. Accepts [numbers][].
-
-The behavior of this operator when used with strings is undefined.
+Resolves to `true` if the left operand is bigger than or equal to the right operand. Accepts [numbers][] and [strings][].
 
 ### `=~` (regex match)
 
-This operator is **non-transitive** with regard to data types: it accepts a [string][strings] as the left operand and a [regular expression][regex] as the right operand.
+<!-- TODO: (regex match) should be changed, it is not only for regular expressions.
+     suggestion: (matches operator) -->
 
-Resolves to `true` if the left operand [matches][regex_match] the regular expression.
+This operator is **non-transitive** with regard to data types: it accepts different types of values as operands depending on the type of the right operand, which is one of the following types:
+
+* [Literal Regexp][regex] --- a literal regular expression e.g. `/abc.*/`. The left operand
+  must be of string value.
+* [Regexp in String form][regex] --- a string value expression resulting in a regular expression
+  in string form e.g. `$x =~ "abc.*"`. The left operand must be of string value.
+* A Type --- matches if the left operand is an instance of the given type - e.g. `5 =~ 
+  Integer[1,10]` is true.
+
+Resolves to `true` if the left operand [matches][regex_match] the right operand.
 
 ### `!~` (regex non-match)
+<!-- TODO: (regex non-match) should be changed, it is not only for regular expressions. 
+     suggestion: (not-matches operator) -->
 
-This operator is **non-transitive** with regard to data types: it accepts a [string][strings] as the left operand and a [regular expression][regex] as the right operand.
-
-Resolves to `false` if the left operand [matches][regex_match] the regular expression.
+Resolves to `false` if the left operand [matches][regex_match] the right operand. Note that `$x !~ $y` is the same as `!($x =~ $y)`. For details about matching see the [matches][regex_match] operator.
 
 ### `in`
 
-Resolves to `true` if the right operand contains the left operand. The exact definition of "contains" here depends on the data type of the right operand.
+Resolves to `true` if the right operand contains the left operand. The exact definition of "contains" here depends on the data type of the right operand. This operator is **non-transitive** with regard to data types.
 
-This operator is **non-transitive** with regard to data types: it accepts a [string][strings] as the left operand, and the following types of right operands:
+| left      | right  | Description
+| --        | --     |
+| String    | String | true if left is a substring of right using == to compare substrings
+| Regexp    | String | true if the string matches the regexp
+| *any other* | String | false
+| 
+| Type      | Array | true if there is an element in the array of the given type
+| Regexp    | Array | true if there is an array element that matches the regexp (non string elements are skipped).
+| *any other* | Array | true if there is an array element that is equal to the left value
+| 
+| Any       | Hash | true if left is `in` the array of hash keys
+| 
+| Any       | *any other* | false
 
-* [Strings][] --- Tests whether the left operand is a substring of the right, ignoring case.
-* [Arrays][] --- Tests whether one of the members of the array is identical to the left operand (case-sensitive).
-* [Hashes][] --- Tests whether the hash has a **key** identical to the left operand (case-sensitive).
-
-The future parser also supports using a [regular expression][regex] for the left operand, with slightly different behavior depending on the right operand:
-
-* [Strings][] --- Tests whether the right operand matches the regular expression.
-* [Arrays][] --- Tests whether one of the members of the array matches the regular expression.
-* [Hashes][] --- Tests whether the hash has a **key** that matches the regular expression.
 
 Examples:
 
@@ -180,7 +202,7 @@ Examples:
 
     # Right hand operand is an array:
     'eat' in ['eat', 'ate', 'eating'] # resolves to true
-    'Eat' in ['eat', 'ate', 'eating'] # resolves to false
+    'Eat' in ['eat', 'ate', 'eating'] # resolves to true
 
     # Right hand operand is a hash:
     'eat' in { 'eat' => 'present tense', 'ate' => 'past tense'} # resolves to true
@@ -188,6 +210,11 @@ Examples:
 
     # Left hand operand is a regular expression (with the case-insensitive option "?i")
     /(?i:EAT)/ in ['eat', 'ate', 'eating'] # resolves to true
+    
+    # left hand is a type (an integer between 100-199)
+    Integer[100, 199] in [1, 2, 125] # resolves to true
+    Integer[100, 199] in [1, 2, 25]  # resolves to false
+    
 {% endhighlight %}
 
 Boolean Operators
@@ -261,7 +288,7 @@ Array Operations
 
 ### `*` (splat)
 
-"Unfolds" an array into a series of function arguments. For example:
+"Unfolds" an array into a series of individual arguments to a function or case options. For example:
 
 {% highlight ruby %}
     $a = ['vim', 'emacs']
@@ -269,14 +296,38 @@ Array Operations
     myfunc(*$a)   # calls myfunc with two arguments: 'vim' and 'emacs'
 {% endhighlight %}
 
+{% highlight ruby %}
+    $a = ['vim', 'emacs']
+    $x = 'vim'
+    notice case $x {
+      $a      : { 'an array with both vim and emacs' }
+      *$a     : { 'vim or emacs'}
+      default : { 'no match' }
+    }
+{% endhighlight %}
+
+
 ### `+` (concatenation)
 
-Resolves to an array containing the elements in the left operand and the elements in the right operand. One or both operands must be an array, or the result will be the arithmetical sum. This operation **does not change** the operands.
+Resolves to an array containing the elements in the left operand and the elements in the right operand. Left or both operands must be an array, or the result will be the arithmetical sum. This operation **does not change** the operands.
 
 ### `-` (removal)
 
 Resolves to an array containing the elements in the left operand without the elements in the right operand. The left operand must be an array, but the right
 operand may be any data type. This operation **does not change** the operands.
+
+{% highlight ruby %}
+    $a = ['vim', 'emacs', 'geppetto']
+    notice( $a - 'vim') # resolves to ['emacs', 'geppetto']
+{% endhighlight %}
+
+If the right operand is an array, each of its entries are removed from the left. Thus, to remove array entries from the left, wrap the array in another array.
+
+{% highlight ruby %}
+    $a = [1, 2, 3, [1, 2]]
+    notice( $a - [1, 2])   # resolves to [3, [1, 2]]
+    notice( $a - [[1, 2]]) # resolves to [1, 2, 3]
+{% endhighlight %}
 
 
 Assignment Operations
@@ -290,6 +341,19 @@ Note that variables can only be set once, after which any attempt to set the var
 
 Backus-Naur Form
 -----
+<!-- TODO: This grammar is quite INCOMPLETE and has errors. 
+     += and -= are removed
+     % is missing
+     in, ? {} is missing
+     splat is missing
+     names of operators are misleading since their meaning depend on data type
+     (e.g. + is concat, - is delete as well as being arithmetic operators).
+     the matchop does not require a right regexp (can be string or a Type).
+     there are other constructs that are also right values
+     heredoc is missing
+     
+     Suggest referring the user to the specification instead (at least initially).
+-->
 
 With the exception of the `in` operator, the available operators in Backus-Naur Form are:
 

--- a/source/puppet/3.7/reference/future_lang_expressions.markdown
+++ b/source/puppet/3.7/reference/future_lang_expressions.markdown
@@ -253,6 +253,8 @@ Arithmetic Operators
 Arithmetic Operators have the following traits:
 
 * They take two [**numeric**][numbers] operands
+  * if an operand is a string it will be converted to numeric form
+  * the operation fails if a string can't be converted
 * They resolve to [**numeric**][numbers] values
 
 ### `+` (addition)

--- a/source/puppet/3.7/reference/future_lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/3.7/reference/future_lang_facts_and_builtin_vars.markdown
@@ -136,10 +136,10 @@ Several variables are set by the puppet master. These are most useful when manag
 * `$serverversion` --- the current version of puppet on the puppet master.
 * `$settings::<name of setting>` --- the value of any of the master's [settings](/guides/configuring.html). This is implemented as a special namespace and these variables must be referred to by their qualified names. Note that, other than `$environment` and `$clientnoop`, the agent node's settings are **not** available in manifests. If you wish to expose them to the master in this version of Puppet, you will have to create a custom fact.
 
-Variables Set by the Parser
+Variables Set by the Compiler
 -----
 
-These variables are set in every [local scope][scope] by the parser during compilation. These are mostly useful when implementing complex [defined types][definedtype].
+These variables are set in every [local scope][scope] by the compiler during compilation. These are mostly useful when implementing complex [defined types][definedtype].
 
 * `$module_name` --- the name of the module that contains the current class or defined type.
 * `$caller_module_name` --- the name of the module in which the **specific instance** of the surrounding defined type was declared. This is only useful when creating versatile defined types which will be re-used by several modules.

--- a/source/puppet/3.7/reference/future_lang_functions.markdown
+++ b/source/puppet/3.7/reference/future_lang_functions.markdown
@@ -45,9 +45,98 @@ In the examples above, `template`, `include`, and `str2bool` are all functions. 
 The general form of a function call is:
 
 * The name of the function, as a bare word
-* An opening parenthesis, which is optional for statements but mandatory for rvalues
+* An opening parenthesis
+  * always required if no arguments are to be given to the function
+  * is optional for built in statements but mandatory for rvalues
 * Any number of **arguments,** separated with commas; the number and type of arguments are controlled by the function
 * A closing parenthesis, if an open parenthesis was used
+* An optional parameterized code block (lambda) if the function supports this
+
+Note that the new function API allows functions to have qualified names and these must be
+called using the full name. As an example, if there is a function named `mymodule::foo` in `mymodule`, it is called like this:
+
+{% highlight ruby %}
+    mymodule::foo()
+{% endhighlight %}
+
+### Chained calls
+
+Puppet supports an alternative infix notation for chained calls. This is mostly useful for chaining
+iterative functions (e.g. `each`, `map`, `filter`, but may be used to call any function. The syntax for this type of call is:
+
+* Any expression (which becomes the first argument to the function)
+* A period (.)
+* The name of the function as a bare word
+* An opening parenthesis
+  * optional if no *additional* arguments are passed
+* Any number of additional **arguments,** separated with commas; the number and type of arguments are controlled by the function
+* A closing parenthesis, if an open parenthesis was used
+* An optional parameterized code block (lambda) if the function supports this
+
+As an example, the stdlib function `uniq` removes duplicate entries from an array, and
+the function `flatten` makes a single flat array out of an array with nested arrays. To perform both operations on the same array (first `flatten`, then `uniq`)- they would be called like this without chaining:
+
+{% highlight ruby %}
+
+    $the_array = [1, 2, 3, 1, [1, 2]]
+    uniq(flatten($the_array)) # resolves to [1,2,3]
+{% endhighlight %}
+
+And called like this with chained infix notation:
+
+{% highlight ruby %}
+
+    $the_array = [1, 2, 3, 1, [1, 2]]
+    $the_array.flatten.uniq # resolves to [1,2,3]
+{% endhighlight %}
+
+With this notation, the left hand side value always becomes the first argument to the function.
+Thus, when chained, the *result* of the first call (`uniq`) becomes the first argument in the second call (`flatten`), etc.
+
+While the readability of the two examples above is more or less the same, when writing more advanced calls using code blocks, it is easier to read the logic from top to bottom/left to right than when calls are written in traditional nested fashion.
+
+The examples below turns a list of user names given as first name, last name in a string (e.g. 'Fozzie Bear') into short form user names using a policy that (up to) two characters from the first name, and (up to) seven characters from the last name forms the user name to use on a system. Thus 'Fozzie Bear' becomes 'fobear'. (The examples use the `split` function from stdlib which splits
+a string into an array of strings (in the example the string is split into first name, and last name), and the iterative function reduce that takes multiple elements and transforms them into one).
+
+First, **using chained call notation**:
+
+{% highlight ruby %}
+
+    $users = ['Fozzie Bear', 'Miss Piggy', 'Bunsen Honeydew']
+    $users.map |$name| {
+      $name
+        .downcase
+        .split(/ /)
+        .reduce |$first, $second| {
+          # up to two letters from first name, and up to 7 from last
+          "${first[0,2]}${second[0,7]}"
+        }
+      }.each |$name| {
+        notice $name
+   }
+{% endhighlight %}
+
+As you can see, it is possible to break up sequences like `$name.downcase.split(/ /)` on
+multiple lines. When reading this to yourself, you can read "take $name", "then downcase", "then split", "then reduce".
+
+
+Secondly, **using nested calls notation** (here it takes a bit more effort to mentally associate
+the last block with the correct function call (`each`) since it is now the outermost
+call in the "chain" of calls:
+
+{% highlight ruby %}
+
+    $users = ['Fozzie Bear', 'Miss Piggy', 'Bunsen Honeydew']
+    each(map($users) |$name| {
+      reduce(split(downcase($name), / /)) |$first, $second| {
+        # up to two letters from first name, and up to 7 from last
+        "${first[0,2]}${second[0,7]}"
+      }}) |$name| {
+      notice $name
+    }
+
+{% endhighlight %}
+
 
 Behavior
 -----
@@ -55,23 +144,63 @@ Behavior
 There are two types of Puppet functions:
 
 * **Rvalues** return values and can be used anywhere a normal value is expected. (This includes resource attributes, variable assignments, conditions, selector values, the arguments of other functions, etc.) These values can come from a variety of places; the `template` function reads and evaluates a template to return a string, and stdlib's `str2bool` and `num2bool` functions convert values from one [data type][datatype] to another.
-* **Statements** should stand alone and do some form of work, which can be anything from logging a message (like `notice`), to modifying the catalog in progress (like `include`), to causing the entire compilation to fail (`fail`). Statements do not return usable values.
+* **Statements** stands alone and do some form of work, which can be anything from logging a message (like `notice`), to modifying the catalog in progress (like `include`), to causing the entire compilation to fail (`fail`). Statements always returns `undef`. The set of statement functions are limited to a set of functions built in to puppet:
+
+| Statement Function | Description
+| ---                | ---
+| require  | includes given class(es) in the catalog and adds them as a dependency
+| realize  | makes a virtual object real
+| include  | includes given class(es) in catalog
+| contain  | contains one or more classes in the current class
+| tag      | adds the specified tag(s) to the containing class or definition
+|
+| debug    | logs message at debug level
+| info     | logs message at info level
+| notice   | logs message at notice level
+| warning  | logs message at warning level
+| error    | logs message at error level
+|
+| fail     | logs error message and aborts compilation
+
 
 All functions run during [compilation][catalog], which means they can only access the commands and data available on the puppet master. To perform tasks on, or collect data from, an agent node, you must use a [resource][] or a [custom fact][custom_facts].
 
 ### Arguments
 
-Each function defines how many arguments it takes and what [data types][datatype] it expects those arguments to be. These should be documented in the function's `:doc` string, which can be extracted and included in the [function reference][func_ref].
+Each function defines how many arguments it takes and what [data types][datatype] it expects those arguments to be. When writing a 3x function these should be documented in the function's `:doc` string, which can be extracted and included in the [function reference][func_ref]. When writing a function using the 4x function API, parameters are typed the same way as for parameters to defines and classes (using the Puppet Type System). The Puppet PDoc tool can extract these 4x type declarations and include them in the produced [function reference][func_ref].
+
+<!-- TODO: Reference to Puppet Type System, and to docs for 3x and 4x functions in text above -->
 
 Functions may accept any of Puppet's standard [data types][datatype]. The values passed to the function's Ruby code will be converted to Ruby objects as follows:
 
-Puppet type        | Ruby type
--------------------|----------
-boolean            | boolean
-undef              | the empty string
-string             | string
-resource reference | `Puppet::Resource`
-number             | string
-array              | array
-hash               | hash
+In Ruby code implementing a function using the 3x API:
 
+Puppet type          | Ruby type
+-------------------  |----------
+`Boolean`            | `Boolean`
+`Undef`              | '' (empty `String`), but not in nested constructs where it is `NilClass`
+`String`             | `String`
+Resource reference   | `Puppet::Resource`
+`Numeric`            | subtype of `Numeric`
+`Array`              | `Array`
+`Hash`               | `Hash`
+`Default`            | `Symbol` (value `:default`)
+`Regexp`             | `Regexp`
+code block           | `Puppet::Pops::Evaluator::Closure`
+types                | type class in `Puppet::Pops::Types` e.g. `PIntegerType`
+
+In Ruby code implementing a function using the 4x API:
+
+Puppet type          | Ruby type
+-------------------  |----------
+`Boolean`            | `Boolean`
+`Undef`              | `NilClass`
+String               | `String`
+Resource reference   | `Puppet::Pops::Types::PResourceType`, or `Puppet::Pops::Types::PHostClassType`
+`Numeric`            | subtype of `Numeric`
+`Array`              | `Array`
+`Hash`               | `Hash`
+`Default`            | `Symbol` (value `:default`)
+`Regexp`             | `Regexp`
+code block           | `Puppet::Pops::Evaluator::Closure`
+types                | type class in `Puppet::Pops::Types` e.g. `PIntegerType`

--- a/source/puppet/3.7/reference/future_lang_import.markdown
+++ b/source/puppet/3.7/reference/future_lang_import.markdown
@@ -1,0 +1,27 @@
+---
+layout: default
+title: "Future Parser: Import"
+canonical: "/puppet/latest/reference/future_lang_import.html"
+---
+
+[enc]: /guides/external_nodes.html
+
+Import
+---
+The use of the `import` keyword to import arbitrary manifests into the catalog compilation
+has been discontinued and has been replaced by the ability to "import" a set of manifests in
+a directory structure by referencing the root of the directory structure instead of a single
+`site.pp` manifest.
+
+All manifests (`.pp` files) in the referenced directory and all subdirectories (recursively)
+are imported in ascending alphabetical order.
+
+The result is the same as if all the `.pp` files in the directory structure had been concatenated
+into a single `site.pp` manifest.
+
+The ability to use a directory structure is typically used to keep instructions per node
+in separate files, and the ability to use nested directories is typically used to group files
+in order to make it easier to name and find them.
+
+An alternative to using a directory structure to assign classes and parameters to nodes
+is to use the [ENC][enc].

--- a/source/puppet/3.7/reference/future_lang_namespaces.markdown
+++ b/source/puppet/3.7/reference/future_lang_namespaces.markdown
@@ -38,8 +38,13 @@ Autoloader Behavior
 When a class or defined resource is declared, Puppet will use its full name to find the class or defined type in your modules. Names are interpreted as follows:
 
 * The first segment in a name (excluding the empty "top" namespace) identifies the [module][]. Every class and defined type should be in its own file in the module's `manifests` directory, and each file should have the `.pp` file extension.
-* If there are **no** additional namespaces, Puppet will look for the class or defined type in the module's `init.pp` file.
-* Otherwise, Puppet will treat the final segment as the file name and any interior segments as a series of subdirectories under the `manifests` directory.
+* When resolving a name to a loadable file, the autoloader searches by shortening the name one segment at a time until only the module name remains.
+  * For each searched name, the final segment is used as the file name, and any interior segments
+    are used as a series of subdirectories under the manifests `directory`.
+  * When only the module name remains, the module's init.pp file is used.
+  * The first found existing file will be loaded, and if this file does not contain the expected
+    loaded object an error is raised.
+
 
 Thus, every class or defined type name maps directly to a file path within Puppet's [`modulepath`][modulepath]:
 
@@ -50,3 +55,25 @@ name                     | file path
 `apache::mod::passenger` | `<modulepath>/apache/manifests/mod/passenger.pp`
 
 Note again that `init.pp` always contains a class or defined type named after the module, and any other `.pp` file contains a class or type with at least two namespace segments. (That is, `apache.pp` would contain a class named `apache::apache`.)
+
+Nested Namespaces
+---
+
+While it is recommended that each class or define is written in a separate file using fully qualified names, it is also possible to define multiple objects in the same file, or nest classes and definitions inside of other classes. When doing so, the namespace of the outer class is prepended to the the given name of a nested class or define.
+
+{% highlight ruby %}
+
+    class apache {
+      class mod {
+        class passenger { ... }
+      }
+      define vhost { ... }
+    }
+{% endhighlight %}
+
+This creates the classes and defines:
+
+* class apache
+* class apache::mod
+* class apache::mod::passenger
+* define apache::vhost

--- a/source/puppet/3.7/reference/future_lang_reserved.markdown
+++ b/source/puppet/3.7/reference/future_lang_reserved.markdown
@@ -55,7 +55,7 @@ The following words are reserved:
 * `undef` --- special value
 * `unless` --- language keyword
 
-Additionally, you cannot use the name of any existing [resource type][type_ref] or [function][func_ref] as the name of a function, and you cannot use the name of any existing [resource type][type_ref] as the name of a defined type.
+Additionally, you cannot use the name of any existing [resource type][type_ref] or [function][func_ref] as the name of a function, and you cannot use the name of any existing [resource type][type_ref] as the name of a defined type. You should not use the name of any existing data type (e.g. integer) as the name of a user defined type as they cannot be directly referenced with only their upper cased name (e.g. `Resource[integer, title]` must then be used to reference such resources instead of just `Integer[title]`).
 
 Reserved Class Names
 -----
@@ -73,7 +73,7 @@ Additionally, the names of data types can't be used as class names:
 * `catalogentry`, `catalogEntry, CatalogEntry`
 * `class`, `Class`
 * `collection`, `Collection`
-* `data`, `Data`
+* `callable`, `Callable`
 * `data`, `Data`
 * `default`, `Default`
 * `enum`, `Enum`
@@ -93,12 +93,13 @@ Additionally, the names of data types can't be used as class names:
 * `undef`, `Undef`
 * `variant`, `Variant`
 
+
 Reserved Variable Names
 -----
 
 The following variable names are reserved, and you **must not** assign values to them:
 
-* Every variable name consisting only of numbers, starting with `$0` --- These [regex capture variables][capture] are automatically set by regular expressions used in [conditional statements][conditional], and their values do not persist outside their associated code block or selector value. Puppet's behavior when these variables are directly assigned a value is undefined.
+* Every variable name consisting only of numbers, starting with `$0` --- These [regex capture variables][capture] are automatically set by regular expressions used in [conditional statements][conditional], and their values do not persist outside their associated code block or selector value. An error is raised if an attempt is made to assign to these variables.
 * Puppet's [built-in variables][built_in] and [facts][facts] are reserved at [top scope][topscope], but can be safely re-used at node or local scope.
 * If [enabled][trusted_on], the `$trusted` and `$facts` variables are reserved for facts and cannot be reassigned at local scopes.
 
@@ -166,7 +167,7 @@ Note that [some class names are reserved](#reserved-class-names), and [reserved 
 Module names obey the same rules as individual class/type namespace segments. That is, they **must begin with a lowercase letter** and can include:
 
 * Lowercase letters
-* Numbers
+* Digits
 * Underscores
 
 Module names should match the following regular expression:
@@ -180,7 +181,7 @@ Note that [reserved words](#reserved-words) and [reserved class names](#reserved
 Class and defined type parameters begin with a `$` (dollar sign), and their first non-`$` character **must be a lowercase letter.** They can include:
 
 * Lowercase letters
-* Numbers
+* Digits
 * Underscores
 
 Parameter names should match the following regular expression:
@@ -192,7 +193,7 @@ Parameter names should match the following regular expression:
 [Tags][] must begin with a lowercase letter, number, or underscore, and can include:
 
 * Lowercase letters
-* Numbers
+* Digits
 * Underscores
 * Colons
 * Periods

--- a/source/puppet/3.7/reference/future_lang_summary.markdown
+++ b/source/puppet/3.7/reference/future_lang_summary.markdown
@@ -47,15 +47,15 @@ Nodes that serve different roles will generally get different sets of classes. T
 Ordering
 -----
 
-Puppet's language is mostly **declarative:** Rather than listing a series of steps to carry out, a Puppet manifest describes a desired final state.
+Puppet's language is mostly **declarative:** Rather than listing a series of steps to carry out on a node, a Puppet manifest describes a desired final state.
 
 The resources in a manifest can be freely ordered --- they will not necessarily be applied to the system in the order they are written. This is because Puppet assumes most resources aren't related to each other. If one resource depends on another, [you must say so explicitly][relationships]. (If you want a short section of code to get applied in the order written, you can use [chaining arrows][chaining].)
 
-Although resources can be freely ordered, several parts of the language do depend on parse order. The most notable of these are variables, which must be set before they are referenced.
+Although resources can be freely ordered, several parts of the language do depend on evaluation order. The most notable of these are variables, which must be set before they are referenced.
 
 ### Configurable Ordering
 
-The [ordering setting][ordering] allows you to configure how resources are ordered when relationships are not present.
+The [ordering setting][ordering] allows you to configure the application order of resources when relationships are not present.
 
 By default, the order of unrelated resources is effectively random. If you set `ordering = manifest` in `puppet.conf`, Puppet will apply unrelated resources in the order in which they appear in the manifest.
 

--- a/source/puppet/3.7/reference/future_lang_variables.markdown
+++ b/source/puppet/3.7/reference/future_lang_variables.markdown
@@ -109,18 +109,17 @@ Unlike most other languages, Puppet only allows a given variable to be assigned 
 
 In the example above, `$myvar` has several different values, but only one value will apply to any given scope.
 
-### Parse-Order Dependence
+### Evaluation-Order Dependence
 
-Unlike [resource declarations][resource], variable assignments are parse-order dependent. This means you cannot resolve a variable before it has been assigned.
-
-This is the main way in which the Puppet language fails to be fully declarative.
-
+Unlike [resource declarations][resource], variable assignments are evaluation-order dependent. This means you cannot resolve a variable before it has been assigned.
 
 
 Naming
 -----
 
-Variable names are case-sensitive and can include alphanumeric characters and underscores.
+Variable names are case-sensitive and can include alphanumeric characters and underscores. A variable that starts with an underscore cannot be references with a qualified name from another scope. A variable may not start with an upper case letter.
+
+<!--TODO: isn't this defined elsewhere in greater detail? -->
 
 Qualified variable names are prefixed with the name of their scope and the `::` (double colon) namespace separator. (For example, the `$vhostdir` variable from the `apache::params` class would be `$apache::params::vhostdir`.)
 

--- a/source/puppet/3.7/reference/future_lang_virtual.markdown
+++ b/source/puppet/3.7/reference/future_lang_virtual.markdown
@@ -105,9 +105,9 @@ Behavior
 
 By itself, a virtual resource declaration will not add any resources to the catalog. Instead, it makes the virtual resource available to the compiler, which may or may not realize it. A matching resource collector or a call to the `realize` function will cause the compiler to add the resource to the catalog.
 
-### Parse-Order Independence
+### Evaluation-Order Independence
 
-Virtual resources do not depend on parse order. You may realize a virtual resource before the resource has been declared.
+Virtual resources do not depend on evaluation order. You may realize a virtual resource before the resource has been declared.
 
 ### Collectors vs. the `realize` Function
 

--- a/source/puppet/3.7/reference/future_modules_fundamentals.markdown
+++ b/source/puppet/3.7/reference/future_modules_fundamentals.markdown
@@ -1,0 +1,287 @@
+---
+layout: default
+title: "Future Module Fundamentals"
+canonical: "/puppet/latest/reference/future_modules_fundamentals.html"
+---
+
+[modulepath]: ./dirs_modulepath.html
+[installing]: ./modules_installing.html
+[publishing]: ./modules_publishing.html
+<!-- {% comment %} The below needs to be forked to a future version since documentation
+process and tags has changed with the introduction of Puppet Strings {% endcomment %} -->
+[documentation]: ./modules_documentation.html
+<!-- {% comment %} The one below will get renamed to "using plugins" when we revise and move it into place. {% endcomment %} -->
+[plugins]: /guides/plugins_in_modules.html
+
+[external facts]: /facter/latest/custom_facts.html#external-facts
+[custom facts]: /facter/latest/custom_facts.html
+[classes]: ./lang_classes.html
+[defined_types]: ./lang_defined_types.html
+[enc]: /guides/external_nodes.html
+[environment]: ./environments.html
+[templates]: /guides/templating.html
+[forge]: http://forge.puppetlabs.com
+[file_function]: /references/3.7.latest/function.html#file
+
+Puppet Modules
+=====
+
+**Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from [the Puppet Forge][forge].
+
+**Nearly all Puppet manifests belong in modules.** The sole exception is the main `site.pp` manifest, which contains site-wide and node-specific code.
+
+**Every Puppet user should expect to write at least some of their own modules.**
+
+* Continue reading to learn how to write and use Puppet modules.
+* [See "Installing Modules"][installing] for how to install pre-built modules from [the Puppet Forge][forge].
+* [See "Publishing Modules"][publishing] for how to publish your modules to the Puppet Forge.
+* [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
+* [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
+
+Using Modules
+-----
+
+**Modules are how Puppet finds the classes and types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or types can be declared by name:
+
+{% highlight ruby %}
+    # /etc/puppetlabs/puppet/site.pp
+
+    node default {
+      include apache
+
+      class {'ntp':
+        enable => false;
+      }
+
+      apache::vhost {'personal_site':
+        port    => 80,
+        docroot => '/var/www/personal',
+        options => 'Indexes MultiViews',
+      }
+    }
+{% endhighlight %}
+
+Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
+
+To make a module available to Puppet, **place it in one of the directories in Puppet's [modulepath][].**
+
+You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
+
+
+Module Layout
+-----
+
+On disk, a module is simply **a directory tree with a specific, predictable structure:**
+
+* `<MODULE NAME>`
+    * `manifests`
+    * `files`
+    * `templates`
+    * `lib`
+    * `facts.d`
+    * `tests`
+    * `spec`
+
+
+### Example
+
+This example module, named "`my_module`," shows the standard module layout in more detail:
+
+* `my_module` --- This outermost directory's name matches the name of the module.
+    * `manifests/` --- Contains all of the manifests in the module.
+        * `init.pp` --- Contains a class definition. **This class's name must match the module's name.**
+        * `other_class.pp` --- Contains a class named **`my_module::other_class`.**
+        * `my_defined_type.pp` --- Contains a defined type named **`my_module::my_defined_type`.**
+        * `implementation/` --- This directory's name affects the class names beneath it.
+            * `foo.pp` --- Contains a class named **`my_module::implementation::foo`.**
+            * `bar.pp` --- Contains a class named **`my_module::implementation::bar`.**
+    * `files/` --- Contains static files, which managed nodes can download.
+        * `service.conf` --- This file's `source =>` URL would be **`puppet:///modules/my_module/service.conf`.** Its contents can also be accessed with the `file` function, like `content => file('my_module/service.conf')`.
+    * `lib/` --- Contains plugins, like [custom facts][] and custom resource types. These will be used by both the puppet master server and the puppet agent service, and they'll be synced to all agent nodes whenever they request their configurations. See ["Using Plugins"][plugins] for more details.
+    * `facts.d/` --- Contains [external facts][], which are an alternative to Ruby-based [custom facts][]. These will be synced to all agent nodes, so they can submit values for those facts to the puppet master. (Requires Facter 2.0.1 or later.)
+    * `templates/` --- Contains templates, which the module's manifests can use. See ["Templates"][templates] for more details.
+        * `component.erb` --- A manifest can render this template with `template('my_module/component.erb')`.
+        * `component.epp` --- A manifest can render this template with `epp('my_module/component.epp')`.
+
+    * `tests/` --- Contains examples showing how to declare the module's classes and defined types.
+        * `init.pp`
+        * `other_class.pp` --- Each class or type should have an example in the tests directory.
+    * `spec/` --- Contains spec tests for any plugins in the lib directory.
+
+Each of the module's subdirectories has a specific function, as follows.
+
+### Manifests
+
+**Each manifest in a module's `manifests` folder should contain one class or defined type.** The file names of manifests **map predictably** to the names of the classes and defined types they contain.
+
+`init.pp` is special and **always contains a class with the same name as the module. You may not have a class named init.**
+
+Every other manifest contains a class or defined type named as follows:
+
+Name of module | :: | Other directories:: (if any) | Name of file (no extension)
+---------------|----|------------------------------|----------------------------
+ `my_module`   |`::`|                              | `other_class`
+ `my_module`   |`::`|    `implementation::`        |     `foo`
+
+Thus:
+
+* `my_module::other_class` would be in the file `my_module/manifests/other_class.pp`
+* `my_module::implementation::foo` would be in the file `my_module/manifests/implementation/foo.pp`
+
+The double colon that divides the sections of a class's name is called the **namespace separator.**
+
+### Autoloading Details
+
+While it is recommended to have each named class or defined type in a separate file, it is possible to autoload them by including them in a manifest autoloaded for one of its parent namespaces.
+
+{% highlight ruby %}
+    # /etc/puppetlabs/puppet/site.pp
+
+    node default {
+      include my_module::abc::def
+    }
+    
+    # my_module/abc.pp
+    class my_module::abc {
+      class def {
+        notify { 'I am mymodule::abc::def': }
+      }
+    }
+{% endhighlight %}
+
+
+### Allowed Module Names
+
+Module names should only contain **lowercase letters, numbers, and underscores,** and should **begin with a lowercase letter;** that is, they should match the expression `[a-z][a-z0-9_]*`. Note that these are the same restrictions that apply to class names, but with the added restriction that module names cannot contain the namespace separator (`::`) as modules cannot be nested.
+
+Although some names that violate these restrictions currently work, using them is not recommended.
+
+Certain module names are disallowed:
+
+* main
+* settings
+
+
+### Files
+
+Files in a module's `files` directory can be served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
+
+You can also access module files with [the `file` function][file_function]. This function takes a `<MODULE NAME>/<FILE NAME>` reference, and returns the content of the requested file from the module's `files` directory.
+
+Puppet URLs work transparently in both agent/master mode and standalone mode; in either case, they will retrieve the correct file from a module.
+
+[file]: /references/stable/type.html#file
+
+Puppet URLs are formatted as follows:
+
+ Protocol | 3 slashes | "Modules"/ | Name of module/ |  Name of file
+----------|-----------|------------|-----------------|---------------
+`puppet:` |   `///`   | `modules/` |   `my_module/`  | `service.conf`
+
+So `puppet:///modules/my_module/service.conf` would map to `my_module/files/service.conf`.
+
+### Templates
+
+Any ERB or EPP template (see ["Templates"][templates] for more details) can be rendered in a manifest with the `template` function for ERB templates (written in Ruby), and the `epp` function
+for EPP templates (written in the Puppet Language). The output of the template is a simple string, which can be used as the content attribute of a [`file`][file] resource or as the value of a variable.
+
+**The template and app functions can look up templates identified by shorthand:**
+
+Template function | (' | Name of module/ | Name of template | ')
+------------------|----|-----------------|------------------|----
+    `template`    |`('`|   `my_module/`  | `component.erb`  |`')`
+    `epp`         |`('`|   `my_module/`  | `component.epp`  |`')`
+
+So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp(mymodule/component.epp)` would render `component.epp`.
+
+
+Writing Modules
+-----
+
+To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
+
+When you run the above command, the puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+
+~~~
+$ puppet module generate examplecorp-mymodule
+
+We need to create a metadata.json file for this module.  Please answer the
+following questions; if the question is not applicable to this module, feel free
+to leave it blank.
+
+Puppet uses Semantic Versioning (semver.org) to version modules.
+What version is this module?  [0.1.0]
+--> 0.1.0
+
+Who wrote this module?  [examplecorp]
+--> Pat
+
+What license does this module code fall under?  [Apache 2.0]
+--> Apache 2.0
+
+How would you describe this module in a single sentence?
+--> It examples with Puppet.
+
+Where is this module's source code repository?
+--> https://github.com/examplecorp/examplecorp-mymodule
+
+Where can others go to learn more about this module?
+--> https://forge.puppetlabs.com/examplecorp/mymodule
+
+Where can others go to file issues about this module?
+-->
+
+
+{
+  "name": "examplecorp-mymodule",
+  "version": "0.1.0",
+  "author": "Pat",
+  "summary": "It examples with Puppet.",
+  "license": "Apache 2.0",
+  "source": "https://github.com/examplecorp/examplecorp-mymodule",
+  "project_page": "(https://forge.puppetlabs.com/examplecorp/mymodule)",
+  "issues_url": null,
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_range": ">= 1.0.0"
+    }
+  ]
+}
+
+
+About to generate this metadata; continue? [n/Y]
+--> Y
+
+Notice: Generating module at /Users/Pat/Development/examplecorp-mymodule...
+Notice: Populating ERB templates...
+Finished; module generated in examplecorp-mymodule.
+examplecorp-mymodule/manifests
+examplecorp-mymodule/manifests/init.pp
+examplecorp-mymodule/metadata.json
+examplecorp-mymodule/Rakefile
+examplecorp-mymodule/README.md
+examplecorp-mymodule/spec
+examplecorp-mymodule/spec/classes
+examplecorp-mymodule/spec/classes/init_spec.rb
+examplecorp-mymodule/spec/spec_helper.rb
+examplecorp-mymodule/tests
+examplecorp-mymodule/tests/init.pp
+~~~
+
+For best practices about writing your module, please see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
+
+You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described above](#module_layout). If you take this route, you **must** ensure that your metadata.json file is properly formatted or your module **will not work**.
+
+* [See here][classes] for more information on classes
+* [See here][defined_types] for more information on defined types
+
+
+Tips
+-----
+
+The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
+
+Manifests in one module should never reference files or templates stored in another module.
+
+Be wary of having classes declare classes from other modules, as this makes modules harder to redistribute. When possible, it's best to isolate "super-classes" that declare many other classes in a local "site" module.

--- a/source/puppet/3.7/reference/future_modules_fundamentals.markdown
+++ b/source/puppet/3.7/reference/future_modules_fundamentals.markdown
@@ -23,6 +23,8 @@ process and tags has changed with the introduction of Puppet Strings {% endcomme
 [forge]: http://forge.puppetlabs.com
 [file_function]: /references/3.7.latest/function.html#file
 
+<!-- Information about 4x functions, and support for data in modules and environments is missing.
+  -->
 Puppet Modules
 =====
 

--- a/source/puppet/3.7/reference/future_parameter_type_foundation.markdown
+++ b/source/puppet/3.7/reference/future_parameter_type_foundation.markdown
@@ -17,7 +17,7 @@ and defined types. Puppet's explicit parameter type declarations help you:
 
 Unlike compiled languages like C and Haskell, Puppet only checks types *at runtime*. That means they can
 express much more specific requirements (like the minimum or maximum length of a string), but the trade-off
-is that there's no check for type errors ahead of time.
+is that there's no check for type errors ahead of time. 
 
 
 Type Declarations are Simplified Type Assertions
@@ -93,8 +93,7 @@ There are two things to notice about the above code:
 1. The default value for `$param` doesn't match its type (Boolean vs Integer).
 2. The manifest runs anyway, because the default for `$param` gets overridden.
 
-So Puppet's type-checking only ensures that there are no type errors *in a given catalog*. It won't catch errors that, for whatever reason,
-don't affect the catalog in question.
+So Puppet's type-checking only ensures that there are no type errors *in a given catalog*. It won't catch errors that, for whatever reason, don't affect the catalog in question.
 
 ### Writing Your own Error Messages
 
@@ -134,3 +133,27 @@ class {'puppetdb::server':
 {% endhighlight %}
 
 See the documentation for [assert_type](function.html#asserttype) for more information.
+
+### Operations on Types
+
+#### Type Operators
+
+The following operators can be used with types:
+
+* `==`, `!=` --- check for equality, non equality
+* `<`, `>`, `<=`, `>=` --- is one type more general than another type
+* `=~`, `!~` --- is the left operand a value of the type, not value of the type
+
+#### Type in Case and Selector Options
+
+When a type is used as a case or selector option it matches a value of that type.
+
+{% highlight ruby %}
+    $test = 10
+    case $test {
+      Integer[0,9]         : { notice 'integer 0 to 9' }
+      Integer[10, default] : { notice 'integer 10 or more ' }
+    }
+{% endhighlight %}
+
+This would notice 'integer 10 or more'.


### PR DESCRIPTION
This provides an update of the future_parser documents to include new language features and remove restrictions that are no longer true.

It also in a few places add TODO notes for suggested changes, or for missing content where it was not clear exactly where such documentation should go.