### PR TITLE
PuppetDB: Fix command wire format indexes

### DIFF
--- a/source/_includes/puppetdb2.2.html
+++ b/source/_includes/puppetdb2.2.html
@@ -111,7 +111,7 @@
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v5.html">Catalog Wire Format - v5</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v3.html">Facts Wire Format - v3</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v3.html">Report Wire Format - v3</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v4.html">Report Wire Format - v4</a></li>
     </ul>
   </li>
   <li><strong>Wire Formats - Deprecated</strong>
@@ -120,6 +120,7 @@
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v1.html">Catalog Wire Format - v1</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v2.html">Facts Wire Format - v2</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v1.html">Facts Wire Format - v1</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v3.html">Report Wire Format - v3</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v1.html">Report Wire Format - v1</a></li>
     </ul>
   </li>

--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -88,7 +88,7 @@
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v5.html">Catalog Wire Format - v5</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v3.html">Facts Wire Format - v3</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v3.html">Report Wire Format - v3</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v4.html">Report Wire Format - v4</a></li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Previously we had not marged v3 of the reports command format is deprecated
in the index. It was still being pointed at by the index as 'stable' and v4
was only listed in the 'command API' section of the docs.

This corrects that for both 2.2 and master releases.

Signed-off-by: Ken Barber <ken@bob.sh>