### PR TITLE
(maint) Change PDB docs header

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -153,7 +153,7 @@ version_notes:
   /facter/: '<p class="noisy">This page is about an old version of Facter. If you use the current version of Facter, see <a href="/facter/latest">the latest version of the docs.</a> If you use Puppet Enterprise 3.7, see <a href="/facter/2.2">the Facter 2.2 docs.</a></p>'
   # Version-specific notes:
   /puppet/3.7: "This is the version of Puppet included in Puppet Enterprise 3.7."
-  /puppetdb/2.2: "This is the version of PuppetDB included in Puppet Enterprise 3.7. It also applies to open source Puppet."
+  /puppetdb/2.2: "This is the version of PuppetDB included in Puppet Enterprise 3.7. This page also applies to open source Puppet."
   /puppetdb/master: '<p class="noisy">This page is for an unreleased version of PuppetDB. PE 3.7 users should see <a href="/puppetdb/2.2/">the PuppetDB 2.2 docs</a>. Other users should see <a href="/puppetdb/latest/">the latest official release</a>.</p>'
   /facter/2.2: 'This is the version of Facter included in Puppet Enterprise 3.7. Open source Puppet users should see <a href="/facter/latest">the latest version of the docs</a>.'
   /facter/2.3: '<p class="noisy">Facter 2.3 is not included in Puppet Enterprise 3.7. PE 3.7 users should see <a href="/facter/2.2">the Facter 2.2 docs.</a></p>'


### PR DESCRIPTION
This is a slight change to the header on the PuppetDB configuration docs.
It was previously unclear what "It" referred to.