### PR TITLE
Fix missing space in config with Hiera example

### DIFF
--- a/source/pe/3.7/config_intro.markdown
+++ b/source/pe/3.7/config_intro.markdown
@@ -35,4 +35,4 @@ You can also configure settings with Hiera. We recommend that you use this optio
 
 In your Hiera .yaml file, add the setting you want to configure. For example, to increase or decrease the number of JRuby instances, you would tune the `jruby_max_active_instances` setting with the following code:
 
-	puppet_enterprise::master::puppetserver::jruby_max_active_instances:<number of instances>
+	puppet_enterprise::master::puppetserver::jruby_max_active_instances: <number of instances>


### PR DESCRIPTION
Without a space between the key and the value, a Hiera setting won't be picked
up.