### PR TITLE
(DOCUMENT-294) Fix 404'd link

### DIFF
--- a/source/guides/install_puppet/install_el.markdown
+++ b/source/guides/install_puppet/install_el.markdown
@@ -23,7 +23,7 @@ To install on other operating systems, see the pages linked in the navigation si
 Step 1: Enable Dependencies (RHEL Only)
 -----
 
-CentOS and other community forks have several packages Puppet depends on in their main repos, but RHEL itself is split into channels. If you're installing Puppet on RHEL, you'll want to make sure the "optional" channel is enabled. [Instructions are available here.](https://access.redhat.com/site/documentation/en-US/OpenShift_Enterprise/1/html/Client_Tools_Installation_Guide/Installing_Using_the_Red_Hat_Enterprise_Linux_Optional_Channel.html)
+CentOS and other community forks have several packages Puppet depends on in their main repos, but RHEL itself is split into channels. If you're installing Puppet on RHEL, you'll want to make sure the "optional" channel is enabled. [Instructions are available here.](https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/supplementary-repos.html)
 
 Step 2: Enable the Puppet Labs Package Repository
 -----


### PR DESCRIPTION
Fixes 404'd link 

https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/1/html/Client_Tools_Installation_Guide/Installing_Using_the_Red_Hat_Enterprise_Linux_Optional_Channel.html => https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/supplementary-repos.html