### PR TITLE
(maint) correct filename in example

### DIFF
--- a/source/hiera/1/puppet.markdown
+++ b/source/hiera/1/puppet.markdown
@@ -276,7 +276,7 @@ Assuming a hierarchy of:
       - base::linux
       - localrepos::apt
 
-    # web01.example.com
+    # web01.example.com.yaml
     ---
     classes:
       - apache


### PR DESCRIPTION
The filename for %{::clientcert} is %{::clientcert}.yaml.  Spotted by irc
user blaubarschbube

    https://botbot.me/freenode/puppet/2015-03-10/?msg=33803065&page=9