### PR TITLE
(maint) add PDB notes for upgrading from v3 API to v4

### DIFF
--- a/source/_includes/puppetdb_master.html
+++ b/source/_includes/puppetdb_master.html
@@ -59,6 +59,7 @@
   </li>
   <li><strong>Query API Version 4</strong>
     <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/upgrading-from-v3.html">Upgrading from Version 3</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/query.html">Query Structure</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/operators.html">Available Operators</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/paging.html">Query Paging</a></li>


### PR DESCRIPTION
This adds a document to our index page that describes the differences between
the v3 and v4 query APIs.