### PR TITLE
(PDB-1142) Point puppetdb 2.2 at new 2.2.x branch

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -113,7 +113,7 @@ externalsources:
   puppetdb_2.2:
     url: /puppetdb/2.2
     repo: git://github.com/puppetlabs/puppetdb.git
-    commit: origin/stable
+    commit: origin/2.2.x
     subdirectory: documentation
   puppetdb_master:
     url: /puppetdb/master


### PR DESCRIPTION
We're nearly ready for a 2.3.0 release, and this is the first doc step: updating the 2.2 docs to refer to the new 2.2.x branch instead of stable (which will subsequently be released as 2.3.0).  We'd like to merge this change first, so that we can safely start adding the 2.3.0 release notes to stable, etc.
