### PR TITLE
Lift the requirement for aligned hashrockets

### DIFF
--- a/source/guides/style_guide.markdown
+++ b/source/guides/style_guide.markdown
@@ -61,7 +61,6 @@ Module manifests:
 * Must have trailing commas after all resource attributes and parameter definitions,
 * Should not exceed a 140-character line width,
 * Should leave one empty line between resources, except when using dependency chains, and
-* Should align hash rockets (`=>`) within blocks of attributes, remembering to arrange hashes for maximum readability first.
 
 ## 6. Quoting
 
@@ -195,9 +194,9 @@ All resource titles must be quoted. If you are using an array of titles you must
 
 ### 9.2. Arrow Alignment
 
-All of the hash rockets (`=>`) in a resource's attribute/value list should
-be aligned. The hash rockets should be placed one space ahead of the longest
-attribute name. Nested blocks must be indented by two spaces, and hash rockets within a nested block should be aligned (one space ahead of the longest attribute name).
+All of the hash rockets (`=>`) in a resource's attribute/value do not have to 
+be aligned. The hash rockets can be aligned one space ahead of the longest
+attribute name. Nested blocks can be indented by two spaces, and hash rockets within a nested block should be aligned (one space ahead of the longest attribute name). Or hash rockets can be placed one space from their attribute name and one space from their value. Organizations should, however, pick one system and stick to it.
  
 
 **Good:**
@@ -222,6 +221,20 @@ attribute name. Nested blocks must be indented by two spaces, and hash rockets w
     }
 ~~~
 
+**Also Good:**
+
+~~~
+    exec { 'hambone':
+      path => '/usr/bin',
+      cwd => '/tmp',
+    }
+
+    exec { 'test':
+      subscribe => File['/etc/test'],
+      refreshonly => true,
+    }
+~~~
+
 **Bad:**
 
 ~~~
@@ -231,7 +244,7 @@ attribute name. Nested blocks must be indented by two spaces, and hash rockets w
     }
 
     exec { 'test':
-      subscribe => File['/etc/test'],
+      subscribe =>   File['/etc/test'],
       refreshonly => true,
     }
 ~~~


### PR DESCRIPTION
Hashrockets have been required to be aligned for a long time. This
has long been attributed to readability. I wonder if there is real
data to support this, or if readability is a matter of preference.

At OpenStack, we find that the aligned hashrockets restriction causes
unnecessary churn in the code base. Every time a new parameter is added
with a different length, the entire code bock shifts in or out.

There are two major problems from this. Removing the restriction removes
the problem:

1) git-blame doesn't show correct information. Instead of showing the
last person/commit that materially changed the line in question, it shows
the last person/commit that tabbed the line in or out.
There are whitespace-ignoring options that can be used on the command
line, but there is a lot of tooling around git and not all of it runs
in this mode.

2) Code review has more code changing. What should be a one line change
to review now looks like several other parameters have been changed or
added. At OpenStack we review a lot of code, increasing the speed that
we can review at is the single biggest way to move our project forward
faster.

This came out of a discussion this review:
https://review.openstack.org/#/c/164819/