### PR TITLE
Add missing links for local scope to data type documentation

### DIFF
--- a/source/puppet/2.7/reference/lang_datatypes.markdown
+++ b/source/puppet/2.7/reference/lang_datatypes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppet/latest/reference/lang_datatypes.html"
 ---
 
 
+[local]: ./lang_scope.html#local-scopes
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax

--- a/source/puppet/3.5/reference/lang_datatypes.markdown
+++ b/source/puppet/3.5/reference/lang_datatypes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppet/latest/reference/lang_datatypes.html"
 ---
 
 
+[local]: ./lang_scope.html#local-scopes
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax

--- a/source/puppet/3.6/reference/lang_datatypes.markdown
+++ b/source/puppet/3.6/reference/lang_datatypes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppet/latest/reference/lang_datatypes.html"
 ---
 
 
+[local]: ./lang_scope.html#local-scopes
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax

--- a/source/puppet/3.7/reference/lang_datatypes.markdown
+++ b/source/puppet/3.7/reference/lang_datatypes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppet/latest/reference/lang_datatypes.html"
 ---
 
 
+[local]: ./lang_scope.html#local-scopes
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax

--- a/source/puppet/3/reference/lang_datatypes.markdown
+++ b/source/puppet/3/reference/lang_datatypes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppet/latest/reference/lang_datatypes.html"
 ---
 
 
+[local]: ./lang_scope.html#local-scopes
 [conditional]: ./lang_conditional.html
 [node]: ./lang_node_definitions.html
 [attribute]: ./lang_resources.html#syntax


### PR DESCRIPTION
The last paragraph of `lang_datatypes.markdown` for all versions since
2.7 has a reference to local scopes that is marked as a link, but no URL
to accompany it.