### PR TITLE
(RE-4388) Remove Fedora 19 from the list of official platforms

### DIFF
--- a/source/_includes/platforms_fedora.markdown
+++ b/source/_includes/platforms_fedora.markdown
@@ -1,6 +1,5 @@
 We publish official packages and run automated testing on the following versions:
 
-* Fedora 19
 * Fedora 20
 
 <!-- When updating these, also edit guides/puppetlabs_package_repositories.markdown and add/delete the repo packages as needed. -->


### PR DESCRIPTION
Fedora 19 was EOL'ed on January 6, 2015:
https://fedoraproject.org/wiki/End_of_life