### PR TITLE
(maint) Specify x86 or x64 in MSI

### DIFF
--- a/source/puppet/4.0/reference/install_windows.markdown
+++ b/source/puppet/4.0/reference/install_windows.markdown
@@ -35,7 +35,7 @@ If you haven't done this yet, go back to the [pre-install tasks][pre_install], m
 [Puppet Labs' Windows packages can be found here.][downloads] You will need the most recent package for your OS's architecture:
 
 * 64-bit versions of Windows Vista/2008 and higher use `puppet-agent-<VERSION>-x64.msi`.
-* 32-bit versions of Windows, as well as the 64-bit version of Windows Server 2003, use `puppet-agent-<VERSION>.msi`.
+* 32-bit versions of Windows, as well as the 64-bit version of Windows Server 2003, use `puppet-agent-<VERSION>-x86.msi`.
 
 These packages bundle all of Puppet's prerequisites, so you don't need to download anything else.
 
@@ -63,7 +63,7 @@ Once the installer finishes, Puppet will be installed, running, and at least par
 
 Use the `msiexec` command to install the Puppet package:
 
-    msiexec /qn /i puppet-agent-<VERSION>.msi
+    msiexec /qn /i puppet-agent-<VERSION>-x64.msi
 
 If you don't specify any further options, this is the same as installing graphically with the default puppet master hostname (`puppet`).
 
@@ -71,7 +71,7 @@ You can specify `/l*v install.txt` to log the progress of the installation to a 
 
 You can also set several MSI properties to pre-configure Puppet as you install it. For example:
 
-    msiexec /qn /i puppet.msi PUPPET_MASTER_SERVER=puppet.example.com
+    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
 
 See the next heading for info about these MSI properties.
 
@@ -197,7 +197,7 @@ Which Windows user account the puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-agent-<VERSION>.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -223,7 +223,7 @@ Puppet can be uninstalled through the "Add or Remove Programs" interface or from
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x puppet-agent-1.0.0.msi
+    msiexec /qn /x puppet-agent-1.0.0-x64.msi
     msiexec /qn /x <PRODUCT CODE>
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [confdir][] and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, the confdir and vardir can be manually deleted.


### PR DESCRIPTION
The puppet-agent MSI always includes the architecture. This is new in
puppet-agent 1.0, as previous versions of the MSI didn't specify x86.