### PR TITLE
(maint) fix 404'ing link from install_linux

### DIFF
--- a/source/puppet/4.0/reference/install_linux.markdown
+++ b/source/puppet/4.0/reference/install_linux.markdown
@@ -24,7 +24,7 @@ Before installing Puppet, make sure you've read the [pre-install tasks.](./insta
 
 ## Review Supported Versions and Requirements 
 
-Most Linux systems including CentOS, Redhat, Ubuntu, and Debian have packages. We have not yet released a Mac OS X package. For a complete list of supported platforms, view the [system requirements page.](sysreqs)
+Most Linux systems including CentOS, Redhat, Ubuntu, and Debian have packages. We have not yet released a Mac OS X package. For a complete list of supported platforms, view the [system requirements page.](./system_requirements.html)
 
 
 ## Install a Release Package to Enable Puppet Labs Package Repositories


### PR DESCRIPTION
Reported via irc:

    13:32:36      rnelson0 | eric0 or anyone else from PL, it looks like http://docs.puppetlabs.com/puppet/4.0/reference/sysreqs is still a 404
    14:48:07           _rc | rnelson0: where's it linked to from?
    14:49:00      rnelson0 | http://docs.puppetlabs.com/puppet/4.0/reference/install_linux.html#review-supported-versions-and-requirements