### PR TITLE
(DOC-1887) Puppet 4 URL changes

### DIFF
--- a/source/guides/rest_api-puppet-4.markdown
+++ b/source/guides/rest_api-puppet-4.markdown
@@ -1,0 +1,309 @@
+---
+layout: default
+title: HTTP API
+---
+
+HTTP API
+========
+
+Both puppet master and puppet agent have pseudo-RESTful HTTP API's that they use to communicate.
+The basic structure of the url to access this API is
+
+    https://yourpuppetmaster:8140/{environment}/{resource}/{key}
+    https://yourpuppetclient:8139/{environment}/{resource}/{key}
+
+Details about what resources are available and the formats they return are
+below.
+
+## HTTP API Security
+
+Puppet usually takes care of security and SSL certificate
+management for you, but if you want to use the HTTP API outside of that
+you'll need to manage certificates yourself when you connect. This can be done by using
+a pre-existing signed agent certificate, by generating and signing a certificate on the puppet
+master and manually distributing it to the connecting host, or by re-implementing puppet
+agent's generate / submit signing request / received signed certificate behavior in your custom app.
+
+The security policy for the HTTP API can be controlled through the
+[`rest_authconfig`][authconf] file. For testing purposes, it is also possible to
+permit unauthenticated connections from all hosts or a subset of hosts; see the
+[`rest_authconfig` documentation][authconf] for more details.
+
+[authconf]: ./rest_auth_conf.html
+
+## Testing the HTTP API using curl
+
+An example of how you can use the HTTP API to retrieve the catalog for a node
+can be seen using [curl](http://en.wikipedia.org/wiki/CURL).
+
+    curl --cert /etc/puppet/ssl/certs/mymachine.pem --key /etc/puppet/ssl/private_keys/mymachine.pem --cacert /etc/puppet/ssl/ca/ca_crt.pem -H 'Accept: yaml' https://puppetmaster:8140/production/catalog/mymachine
+
+Most of this command consists of pointing curl to the appropriate SSL certificates, which
+will be different depending on your ssldir location and your node's certname.
+For simplicity and brevity, future invocations of curl will be provided in insecure mode, which
+is specified with the `-k` or `--insecure` flag.
+Insecure connections can be enabled for one or more nodes in the [`rest_authconfig`][authconf]
+file. The above curl invocation without certificates would be as follows:
+
+    curl --insecure -H 'Accept: yaml' https://puppetmaster:8140/production/catalog/mymachine
+
+Basically we just send a header specifying the format or formats we want back,
+and the HTTP URI for getting a catalog for mymachine in the production
+environment.  Here's a snippet of the output you might get back:
+
+    --- &id001 !ruby/object:Puppet::Resource::Catalog
+      aliases: {}
+        applying: false
+          classes: []
+          ...
+
+Another example to get back the CA Certificate of the puppetmaster doesn't
+require you to be authenticated with your own signed SSL Certificates, since
+that's something you would need before you authenticate.
+
+    curl --insecure -H 'Accept: s' https://puppetmaster:8140/production/certificate/ca
+
+    -----BEGIN CERTIFICATE-----
+    MIICHTCCAYagAwIBAgIBATANBgkqhkiG9w0BAQUFADAXMRUwEwYDVQQDDAxwdXBw
+
+## The master and agent shared API
+
+### Resources
+
+Returns a list of resources, like executing `puppet resource` (`ralsh`) on the command line.
+
+GET `/{environment}/resource/{resource_type}/{resource_name}`
+
+GET `/{environment}/resources/{resource_type}`
+
+Example:
+
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/resource/user/puppet
+    curl -k -H "Accept: yaml" https://puppetclient:8139/production/resources/user
+
+### Certificate
+
+Get a certficate or the master's CA certificate.
+
+GET `/certificate/{ca, other}`
+
+Example:
+
+    curl -k -H "Accept: s" https://puppetmaster:8140/production/certificate/ca
+    curl -k -H "Accept: s" https://puppetclient:8139/production/certificate/puppetclient
+
+## The master HTTP API
+
+A valid and signed certificate is required to retrieve these resources.
+
+### Catalogs
+
+Get a catalog from the node.
+
+GET `/{environment}/catalog/{node certificate name}`
+
+Example:
+
+    curl -k -H "Accept: pson" https://puppetmaster:8140/production/catalog/myclient
+
+### Certificate Revocation List
+
+Get the certificate revocation list.
+
+GET `{environment}/certificate_revocation_list/ca`
+
+Example:
+
+    curl -k -H "Accept: s" https://puppetmaster:8140/production/certificate_revocation_list/ca
+
+### Certificate Request
+
+Retrieve or save certificate requests.
+
+GET `/{environment}/certificate_requests/no_key`
+
+GET `/{environment}/certificate_request/{node certificate name}`
+
+PUT `/{environment}/certificate_request/no_key`
+
+Example:
+
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/certificate_requests/all
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/certificate_request/{agent certname}
+    curl -k -X PUT -H "Content-Type: text/plain" --data-binary @cert_request.csr https://puppetmaster:8140/production/certificate_request/no_key
+
+
+To manually generate a CSR from an existing private key:
+
+    openssl req -new -key private_key.pem -subj "/CN={node certname}" -out request.csr
+
+The subject can only include a /CN=, nothing else. Puppet master will determine the certname from the body of the cert, so the request can be pointed to any key for this endpoint.
+
+### Certificate Status
+
+**Puppet 2.7.0 and later.**
+
+Read or alter the status of a certificate or pending certificate request. This endpoint is roughly equivalent to the puppet cert command; rather than returning complete certificates, signing requests, or revocation lists, this endpoint returns information about the various certificates (and potential and former certificates) known to the CA.
+
+GET `/{environment}/certificate_status/{certname}`
+
+Retrieve a PSON hash containing information about the specified host's
+certificate. Similar to `puppet cert --list {certname}`.
+
+GET `/{environment}/certificate_statuses/no_key`
+
+Retrieve a list of PSON hashes containing information about all
+known certificates. Similar to `puppet cert --list --all`.
+
+PUT `/{environment}/certificate_status/{certname}`
+
+Change the status of the specified host's certificate. The desired state is sent in the body of the PUT request as a one-item PSON hash; the two allowed complete hashes are `{"desired_state":"signed"}` (for signing a certificate signing request; similar to `puppet cert --sign`) and `{"desired_state":"revoked"}` (for revoking a certificate; similar to `puppet cert --revoke`); see examples below for details.
+
+When revoking certificates, you may wish to use a
+DELETE request instead, which will also clean up other info about the
+host.
+
+DELETE `/{environment}/certificate_status/{hostname}`
+
+Cause the certificate authority to discard all SSL information regarding a host (including
+any certificates, certificate requests, and keys). This **does not** revoke the certificate if one is present; if you wish to emulate the behavior of `puppet cert --clean`, you must PUT a `desired_state` of revoked before deleting the host's SSL information.
+
+Examples:
+
+    curl -k -H "Accept: pson" https://puppetmaster:8140/production/certificate_status/testnode.localdomain
+    curl -k -H "Accept: pson" https://puppetmaster:8140/production/certificate_statuses/all
+    curl -k -X PUT -H "Content-Type: text/pson" --data '{"desired_state":"signed"}' https://puppetmaster:8140/production/certificate_status/client.network.address
+    curl -k -X PUT -H "Content-Type: text/pson" --data '{"desired_state":"revoked"}' https://puppetmaster:8140/production/certificate_status/client.network.address
+    curl -k -X DELETE -H "Accept: pson" https://puppetmaster:8140/production/certificate_status/client.network.address
+
+### Reports
+
+Submit a report.
+
+PUT `/{environment}/report/{node certificate name}`
+
+Example:
+
+    curl -k -X PUT -H "Content-Type: text/yaml" -d "{key:value}" https://puppetclient:8139/production/report/puppetclient
+
+### Resource Types
+
+Return a list of resources from the master
+
+GET `/{environment}/resource_type/{hostclass,definition,node}`
+
+GET `/{environment}/resource_types/*`
+
+Example:
+
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/resource_type/puppetclient
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/resource_types/*
+
+### File Bucket
+
+Get or put a file into the file bucket.
+
+GET `/{environment}/file_bucket_file/md5/{checksum}`
+
+PUT `/{environment}/file_bucket_file/md5/{checksum}`
+
+GET `/{environment}/file_bucket_file/md5/{checksum}?diff_with={checksum}` (diff 2 files; **Puppet 2.6.5 and later**)
+
+HEAD `/{environment}/file_bucket_file/md5/{checksum}` (determine if a file is present; **Puppet 2.6.5 and later**)
+
+Examples:
+
+    curl -k -H "Accept: s" https://puppetmaster:8140/production/file_bucket_file/md5/e30d4d879e34f64e33c10377e65bbce6
+    curl -k -X PUT -H "Content-Type: text/plain" Accept: s" https://puppetmaster:8140/production/file_bucket_file/md5/e30d4d879e34f64e33c10377e65bbce6 --data-binary @foo.txt
+    curl -k -H "Accept: s" https://puppetmaster:8140/production/file_bucket_file/md5/e30d4d879e34f64e33c10377e65bbce6?diff_with=6572b5dc4c56366aaa36d996969a8885
+    curl -k -I -H "Accept: s" https://puppetmaster:8140/production/file_bucket_file/md5/e30d4d879e34f64e33c10377e65bbce6
+
+### File Server
+
+Get a file from the file server.
+
+GET `/file_{metadata, content}/{file}`
+
+File serving is covered in more depth in the [fileserver configuration documentation](/guides/file_serving.html)
+
+### Node
+
+Returns the Puppet::Node information (including facts) for the specified node
+
+GET `/{environment}/node/{node certificate name}`
+
+Example:
+
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/node/puppetclient
+
+### Status
+
+Just used for testing
+
+GET `/{environment}/status/no_key`
+
+Example:
+
+    curl -k -H "Accept: pson" https://puppetmaster:8140/production/status/puppetclient
+
+### Facts
+
+GET `/{environment}/facts/{node certname}`
+
+    curl -k -H "Accept: yaml" https://puppetmaster:8140/production/facts/{node certname}
+
+PUT `/{environment}/facts/{node certname}`
+
+    curl -k -X PUT -H 'Content-Type: text/yaml' --data-binary @/var/lib/puppet/yaml/facts/hostname.yaml https://localhost:8140/production/facts/{node certname}
+
+
+### Facts Search
+
+GET `/{environment}/facts_search/search?{facts search string}`
+
+    curl -k -H "Accept: pson" https://puppetmaster:8140/production/facts_search/search?facts.processorcount.ge=2&facts.operatingsystem=Ubuntu
+
+Facts search strings are constructed as a series of terms separated by `&`; if there is more than one term, the search combines the terms with boolean AND. There is currently no API for searching with boolean OR. Each term is composed as follows:
+
+    facts.{name of fact}.{comparison type}={string for comparison}
+
+If you leave off the `.{comparison type}`, the comparison will default to simple equality. The following comparison types are available:
+
+#### String/general comparison
+
+* `eq` --- `==` (default)
+* `ne` --- `!=`
+
+#### Numeric comparison
+
+* `lt` --- `<`
+* `le` --- `<=`
+* `gt` --- `>`
+* `ge` --- `>=`
+
+## The agent HTTP API
+
+By default, puppet agent is set not to listen to HTTP requests.  To enable this you
+must set `listen = true` in the puppet.conf or pass `--listen true` to puppet agent
+when starting. Due to a known bug in the 2.6.x releases of Puppet, puppet agent will not start
+with `listen = true` unless a namespaceauth.conf file exists, even though this file
+is not consulted. The node's [rest_authconfig][authconf] file must also allow
+access to the agent's resources, which isn't permitted by default.
+
+### Facts
+
+GET `/{environment}/facts/no_key`
+
+Example:
+
+    curl -k -H "Accept: yaml" https://puppetclient:8139/production/facts/no_key
+
+### Run
+
+Cause the client to update like puppetrun or puppet kick
+
+PUT `/{environment}/run/no_key`
+
+Example:
+
+    curl -k -X PUT -H "Content-Type: text/pson" -d "{}" https://puppetclient:8139/production/run/no_key

--- a/source/guides/rest_auth_conf-puppet-4.markdown
+++ b/source/guides/rest_auth_conf-puppet-4.markdown
@@ -1,0 +1,243 @@
+---
+layout: default
+title: HTTP Access Control
+---
+
+HTTP Access Control
+===================
+
+Learn how to configure access to Puppet's HTTP API using the `rest_authconfig` file, a.k.a. `auth.conf`. **This document is currently being checked for accuracy. If you note any errors, please email them to <faq@puppetlabs.com>.**
+
+* * *
+
+HTTP
+----
+
+Puppet master and puppet agent communicate with each other over a pseudo-RESTful [HTTP network API](./rest_api.html). By default, the usage of this API is limited to the standard types of master/agent communications. However, it can be exposed to other processes and used to build advanced tools on top of Puppet's existing infrastructure and functionality. (HTTP API calls are formatted as `https://{server}:{port}/{environment}/{resource}/{key}`.)
+
+As you might guess, this can be turned into a security hazard, so access to the HTTP API is strictly controlled by a special configuration file.
+
+auth.conf
+---------
+
+The official name of the file controlling HTTP API access, taken from the [configuration option](/references/stable/configuration.html) that sets its location, is `rest_authconfig`, but it's more frequently known by its default filename of `auth.conf`. If you don't set a different location for it, Puppet will look for the file at `$confdir/auth.conf`.
+
+You cannot configure different environments to use multiple `rest_authconfig` files.
+
+File Format
+-----------
+
+The auth.conf file consists of a series of ACLs (Access Control Lists); ACLs should be separated by double newlines. Lines starting with `#` are interpreted as comments.
+
+    # This is a comment
+    path /facts
+    method find, search
+    auth yes
+    allow custominventory.site.net, devworkstation.site.net
+
+    # A more complicated rule
+    path ~ ^/file_(metadata|content)/user_files/
+    auth yes
+    allow /^(.+\.)?example.com$/
+    allow_ip 192.168.100.0/24
+
+    # An exception allowing one authenticated workstation to access any endpoint
+    path /
+    auth yes
+    allow devworkstation.site.net
+
+Due to a known bug, trailing whitespace is not permitted after any line in auth.conf in versions prior to 2.7.3.
+
+ACL format
+----------
+
+Each auth.conf ACL is formatted as follows:
+
+    path [~] {/path/to/resource|regex}
+    [environment {list of environments}]
+    [method {list of methods}]
+    [auth[enthicated] {yes|no|on|off|any}]
+    [allow {hostname|certname|*}]
+
+Lists of values are comma-separated, with an optional space after the comma.
+
+### Path
+
+An ACL's `path` is interpreted as either a regular expression (with tilde) or a path prefix (no tilde). The root of the path in an ACL is AFTER the environment in an HTTP API call URL; that is, only put the `/{resource}/{key}` portion of the URL in the path. ACLs without a resource path are not permitted.
+
+### Environment
+
+The `environment` directive can contain a single [environment](/puppet/latest/reference/environments.html) or a comma-separated list (spaces after commas OK). If environment isn't explicitly specified, it will default to all environments.
+
+### Method
+
+Available methods are `find`, `search`, `save`, and `destroy`; you can specify one method or a comma-separated list (spaces after commas OK). If method isn't explicitly specified, it will default to all methods.
+
+### Auth
+
+Whether the ACL matches authenticated requests.
+
+- **`auth yes`** (or `on`) means this ACL will **only** match requests authenticated with an agent certificate.
+- **`auth any`** means this ACL will match **both** authenticated and unauthenticated requests.
+- **`auth no`** (or `off`) means this ACL will **only** match requests that are **not** authenticated with an agent certificate. Authenticated requests (like from puppet agent) will skip this ACL.
+
+Most communications between puppet agent and the puppet master are authenticated, so you will usually be using `auth yes`.
+
+The value of `auth` must be **one** of the above options; it cannot be a list. If auth isn't explicitly specified, it will default to `yes`.
+
+### `allow`
+
+The node or nodes allowed to access this type of request. Can be a hostname, a certificate common name, a comma-separated list of hostnames/certnames (spaces after commas OK), or `*` (which matches all nodes). If the path for this ACL was a regular expression, `allow` directives may include backreferences to captured groups (e.g. `$1`).
+
+An ACL may include multiple `allow` directives, which has the same effect as a single `allow` directive with a comma-separated list.
+
+**Behavior in 0.25.x through 2.7.0:** No fine-grained globbing of hostnames/certnames is available in allow directives; you must specify exact host/certnames, or a single asterisk that matches everything.
+
+**Behavior in 2.7.1 and later:** Hostnames/certnames can also be specified by regular expression. Unlike with path directives, you don't need to use a tilde; just use the slash-quoting used in languages like Perl and Ruby (e.g. `allow /^[\w-]+.example.com$/`). Regular expression allow directives can include backreferences to regex paths with the standard `$1, $2` etc. variables.
+
+Any nodes which aren't specifically allowed to access the resource will be denied.
+
+### `allow_ip`
+
+> **Note:** The `allow_ip` directive was added in Puppet 3.0.0. Previous versions of Puppet **cannot** allow nodes by IP address.
+
+An IP address or range of IP addresses allowed to access this type of request. Can be:
+
+* A single IP address
+* A glob representing a group of IP addresses (e.g. `192.168.100.*`)
+* CIDR notation representing a group of IP addresses (e.g. `192.168.100.0/24`)
+
+Any nodes which aren't specifically allowed to access the resource will be denied.
+
+### Deny
+
+A `deny` directive is syntactically permitted, but has no effect.
+
+Matching ACLs to Requests
+-------------------------
+
+Puppet composes a full list of ACLs by combining auth.conf with a list of default ACLs. When a request is received, ACLs are tested in their order of appearance, and **matching will stop at the first ACL that matches the request.**
+
+An ACL matches a request only if its path, environment, method, and authentication **all** match that of the request. These four elements are equal peers in determining the match.
+
+### Matching Paths
+
+If an ACL's `path` does not start with a tilde and a space, it matches the beginning of the resource path; an ACL with the line:
+
+    path /file
+
+...will match both `/file_metadata` and `/file_content` resources.
+
+Regular expression paths don't have to match from the beginning of the resource path, but it's good practice to use positional anchors.
+
+    path ~ ^/catalog/([^/]+)$
+    method find
+    allow $1
+
+Captured groups from a regex path are available in the allow directive. The ACL above will allow nodes to retrieve their own catalog but prevent them from accessing other catalogs.
+
+### Determining Whether a Request is Allowed
+
+Once an ACL has been determined to match an incoming request, Puppet consults the `allow` directive(s). If the request was unauthenticated, reverse DNS is used to determine the requesting node's hostname; the request is allowed if that hostname is allowed. If the request was authenticated, the certificate common name is read from the SSL certificate, and the hostname is ignored; the request is allowed if that certname is allowed.
+
+Consequences of ACL Matching Behavior
+-------------------------------------
+
+Since ACLs are matched in linear order, auth.conf has to be manually arranged with the most specific paths at the top and the least specific paths at the bottom, lest the whole search get short-circuited and the (usually restrictive) fallback rule be applied to every request. Furthermore, since the default ACLs required for normal Puppet functionality are appended to the ACLs read from auth.conf, **you must manually interleave copies of the default ACLs into your auth.conf if you are specifying _any_ ACLs that are less specific than any of the default ACLs.**
+
+Default ACLs
+------------
+
+Puppet appends a list of default ACLs to the ACLs read from auth.conf. However, if any custom ACLs have a path identical to that of a default ACL, that default ACL will be omitted when composing the full list of ACLs. **Note that this is not the same criteria for determining whether the two ACLs match the same requests,** as only the paths are compared:
+
+    # A custom ACL
+    path /file
+    auth no
+    allow magpie.example.com
+
+    # This default ACL will not be appended to the rules
+    path /file
+    allow *
+
+These two ACLs match completely disjoint sets of requests (unauthenticated for the custom one, authenticated for the default one), but since the mechanism that appends default ACLs is not examining the authentication/methods/environments of the ACLs, it considers the one to override the other, even though they're effectively unrelated. Puppet agent will break if you only declare the custom ACL, will work if you manually declare the default ACL, and will work if you only declare the custom one but change its path to `/fil`. When in doubt, manually re-declare all default ACLs in your auth.conf file.
+
+The following is a list of the default ACLs used by Puppet:
+
+    # Allow authenticated nodes to retrieve their own catalogs:
+
+    path ~ ^/catalog/([^/]+)$
+    method find
+    allow $1
+
+    # allow nodes to retrieve their own node definition
+
+    path ~ ^/node/([^/]+)$
+    method find
+    allow $1
+
+    # Allow authenticated nodes to access any file services --- in practice, this results in fileserver.conf being consulted:
+
+    path /file
+    allow *
+
+    # Allow authenticated nodes to access the certificate revocation list:
+
+    path /certificate_revocation_list/ca
+    method find
+    allow *
+
+    # Allow authenticated nodes to send reports:
+
+    path /report
+    method save
+    allow *
+
+    # Allow unauthenticated access to certificates:
+
+    path /certificate/ca
+    auth no
+    method find
+    allow *
+
+    path /certificate/
+    auth no
+    method find
+    allow *
+
+    # Allow unauthenticated nodes to submit certificate signing requests:
+
+    path /certificate_request
+    auth no
+    method find, save
+    allow *
+
+    # Deny all other requests:
+
+    path /
+    auth any
+
+An example auth.conf file containing these rules is provided in the Puppet source, in [conf/auth.conf](http://github.com/puppetlabs/puppet/blob/2.6.x/conf/auth.conf).
+
+Danger Mode
+-----------
+
+If you want to test the HTTP API for application prototyping without worrying about specifying your final set of ACLs ahead of time, you can set a completely permissive auth.conf:
+
+    path /
+    auth any
+    allow *
+
+**Note** Make sure any testing configurations using this pattern do not make it to production systems.
+
+authconfig / namespaceauth.conf
+-------------------------------
+
+Older versions of Puppet communicated over an XMLRPC interface instead of the current HTTP interface, and access to these APIs was governed by a file known as `authconfig` (after the configuration option listing its location) or `namespaceauth.conf` (after its default filename). This legacy file will not be fully documented, but an example namespaceauth.conf file can be found in the puppet source at [conf/namespaceauth.conf](http://github.com/puppetlabs/puppet/blob/2.6.x/conf/namespaceauth.conf).
+
+puppet agent and the HTTP API
+-----------------------------
+
+If started with the `listen = true` configuration option, puppet agent will accept incoming HTTP API requests. This is most frequently used to trigger puppet runs with the `run` endpoint. Several caveats apply:
+
+* A [known bug](http://projects.puppetlabs.com/issues/6442) in the 2.6.x releases of Puppet prevents puppet agent from being started with the `listen = true` option unless namespaceauth.conf is present, even though the file is never consulted. The workaround is to create an empty file: `# touch $(puppet agent --configprint authconfig)`
+* Puppet agent uses the same default ACLs as puppet master, which allow access to several useless endpoints while denying access to any agent-specific ones. For best results, you should short-circuit the defaults by denying access to `/` at the end of your auth.conf file.

--- a/source/guides/rest_auth_conf-puppet-4.markdown
+++ b/source/guides/rest_auth_conf-puppet-4.markdown
@@ -30,13 +30,13 @@ File Format
 The auth.conf file consists of a series of ACLs (Access Control Lists); ACLs should be separated by double newlines. Lines starting with `#` are interpreted as comments.
 
     # This is a comment
-    path /facts
+    path /puppet/v3/facts
     method find, search
     auth yes
     allow custominventory.site.net, devworkstation.site.net
 
     # A more complicated rule
-    path ~ ^/file_(metadata|content)/user_files/
+    path ~ ^/puppet/v3/file_(metadata|content)/user_files/
     auth yes
     allow /^(.+\.)?example.com$/
     allow_ip 192.168.100.0/24
@@ -63,7 +63,7 @@ Lists of values are comma-separated, with an optional space after the comma.
 
 ### Path
 
-An ACL's `path` is interpreted as either a regular expression (with tilde) or a path prefix (no tilde). The root of the path in an ACL is AFTER the environment in an HTTP API call URL; that is, only put the `/{resource}/{key}` portion of the URL in the path. ACLs without a resource path are not permitted.
+An ACL's `path` is interpreted as either a regular expression (with tilde) or a path prefix (no tilde). ACLs without a resource path are not permitted.
 
 ### Environment
 
@@ -124,13 +124,13 @@ An ACL matches a request only if its path, environment, method, and authenticati
 
 If an ACL's `path` does not start with a tilde and a space, it matches the beginning of the resource path; an ACL with the line:
 
-    path /file
+    path /puppet/v3/file
 
-...will match both `/file_metadata` and `/file_content` resources.
+...will match both `/puppet/v3/file_metadata` and `/puppet/v3/file_content` resources.
 
 Regular expression paths don't have to match from the beginning of the resource path, but it's good practice to use positional anchors.
 
-    path ~ ^/catalog/([^/]+)$
+    path ~ ^/puppet/v3/catalog/([^/]+)$
     method find
     allow $1
 
@@ -151,12 +151,12 @@ Default ACLs
 Puppet appends a list of default ACLs to the ACLs read from auth.conf. However, if any custom ACLs have a path identical to that of a default ACL, that default ACL will be omitted when composing the full list of ACLs. **Note that this is not the same criteria for determining whether the two ACLs match the same requests,** as only the paths are compared:
 
     # A custom ACL
-    path /file
+    path /puppet/v3/file
     auth no
     allow magpie.example.com
 
     # This default ACL will not be appended to the rules
-    path /file
+    path /puppet/v3/file
     allow *
 
 These two ACLs match completely disjoint sets of requests (unauthenticated for the custom one, authenticated for the default one), but since the mechanism that appends default ACLs is not examining the authentication/methods/environments of the ACLs, it considers the one to override the other, even though they're effectively unrelated. Puppet agent will break if you only declare the custom ACL, will work if you manually declare the default ACL, and will work if you only declare the custom one but change its path to `/fil`. When in doubt, manually re-declare all default ACLs in your auth.conf file.
@@ -165,48 +165,48 @@ The following is a list of the default ACLs used by Puppet:
 
     # Allow authenticated nodes to retrieve their own catalogs:
 
-    path ~ ^/catalog/([^/]+)$
+    path ~ ^/puppet/v3/catalog/([^/]+)$
     method find
     allow $1
 
     # allow nodes to retrieve their own node definition
 
-    path ~ ^/node/([^/]+)$
+    path ~ ^/puppet/v3/node/([^/]+)$
     method find
     allow $1
 
     # Allow authenticated nodes to access any file services --- in practice, this results in fileserver.conf being consulted:
 
-    path /file
+    path /puppet/v3/file
     allow *
 
     # Allow authenticated nodes to access the certificate revocation list:
 
-    path /certificate_revocation_list/ca
+    path /puppet-ca/v1/certificate_revocation_list/ca
     method find
     allow *
 
     # Allow authenticated nodes to send reports:
 
-    path /report
+    path /puppet/v3/report
     method save
     allow *
 
     # Allow unauthenticated access to certificates:
 
-    path /certificate/ca
+    path /puppet-ca/v1/certificate/ca
     auth no
     method find
     allow *
 
-    path /certificate/
+    path /puppet-ca/v1/certificate/
     auth no
     method find
     allow *
 
     # Allow unauthenticated nodes to submit certificate signing requests:
 
-    path /certificate_request
+    path /puppet-ca/v1/certificate_request
     auth no
     method find, save
     allow *

--- a/source/puppet/4.0/reference/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.0/reference/subsystem_agent_master_comm.markdown
@@ -1,0 +1,116 @@
+---
+title: "Subsystems: Agent/Master HTTPS Communications"
+layout: default
+canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+---
+
+[rest_api]: /guides/rest_api.html
+[authconf]: /guides/rest_auth_conf.html
+[facts]: ./lang_variables.html#facts-and-built-in-variables
+[catalog]: ./lang_summary.html#compilation-and-catalogs
+[file]: /references/3.7.latest/type.html#file
+[static]: /references/3.7.latest/indirection.html#catalog
+
+
+
+The Puppet agent and the Puppet master server communicate via HTTPS over host-verified SSL.
+
+> **Note on verification:** If the agent does not yet have its own certificate, it will make several unverified requests before it can switch to verified mode. In these requests, the agent doesn't identify itself to the master and doesn't check the master's cert against the CA. In the descriptions below, assume every request is host-verified unless stated otherwise.
+
+The agent/master HTTP interface is REST-like, but varies from strictly RESTful design in several ways. The endpoints used by the agent are detailed in the [HTTP API reference][rest_api]. Note that all HTTP endpoints are preceded by the environment being used. Note also that access to each individual endpoint is controlled by [auth.conf][authconf] on the master.
+
+## Persistent Connections / Keepalive
+
+When acting as an HTTPS client, Puppet will try to re-use connections in order to reduce TLS overhead, by sending `Connection: Keep-Alive` in the HTTP request. This helps improve performance for runs with dozens of HTTPS requests.
+
+Puppet will only cache verified HTTPS connections, so it excludes the unverified connections a new agent makes to request a new certificate. Puppet also will not cache connections when a custom HTTP connection class has been specified. (This is an esoteric use case that most users will never see.)
+
+You can use [the `http_keepalive_timeout` setting][keepalive_setting] to configure the keepalive duration. It must be shorter than the maximum keepalive allowed by the Puppet master web server.
+
+An HTTP server may disable persistent connections ([Apache example](http://httpd.apache.org/docs/current/mod/core.html#keepalive)). If so, Puppet will request that the connection be kept open as usual, but the server will decline by sending `Connection: close` in the HTTP response and Puppet will start a new connection for its next request. (In Puppet 3.7.4 and up, WEBrick Puppet masters running on Ruby 1.8.7 will close connections to work around a Ruby bug.)
+
+[keepalive_setting]: /references/3.7.latest/configuration.html#httpkeepalivetimeout
+
+## Diagram
+
+This flow diagram illustrates the pattern of agent-side checks and HTTPS requests to the Puppet master during a single Puppet run.
+
+[See below the image for a textual description of this process](#check-for-keys-and-certificates), which explains the illustrated steps in more detail.
+
+[![An illustration of the process described below -- this diagram contains no new content, but is simply a visual interpretation of everything from "check for keys and certificates" on down.](./images/agent-master-https-sequence-small.gif)](./images/agent-master-https-sequence-large.gif)
+
+## Check for Keys and Certificates
+
+1. Does the agent have a private key at `$ssldir/private_keys/<name>.pem`?
+    * If no, generate one.
+2. Does the agent have a copy of the CA certificate at `$ssldir/certs/ca.pem`?
+    * If no, fetch it. (Unverified GET request to `/certificate/ca`. Since the agent is retrieving the foundation for all future trust over an untrusted link, this could be vulnerable to MITM attacks, but it's also just a convenience; you can make this step unnecessary by distributing the CA cert as part of your server provisioning process, so that agents never ask for a CA cert over the network. If you do this, an attacker could temporarily deny Puppet service to brand new nodes, but would be unable to take control of them with a rogue Puppet master.)
+3. Does the agent have a signed certificate at `$ssldir/certs/<name>.pem`?
+    * If yes, skip the following section and continue to "request node object."
+    * (If it has a cert but it doesn't match the private key, bail with an error.)
+
+## Obtain a Certificate (if necessary)
+
+Note that if the agent has submitted a certificate signing request, an admin user will need to run `puppet cert sign <name>` on the CA Puppet master before the agent can fetch a signed certificate. (Unless autosign is enabled.) Since incoming CSRs are unverified, you can use fingerprints to prove them, by comparing `puppet agent --fingerprint` on the agent to `puppet cert list` on the CA master.
+
+1. Try to fetch an already-signed certificate from the master. (Unverified GET request to `/certificate/<name>`.)
+    * If it gets one, skip the rest of this section and continue to "request node object."
+    * (If it gets one that doesn't match the private key, bail with an error.)
+2. Determine whether the agent has already requested a certificate signing: Look for `$ssldir/certificate_requests/<name>.pem`.
+    * If this file exists, the agent will bail, assuming it needs user intervention on the master. If `waitforcert` is enabled, it will wait a few seconds and start this section over.
+3. Double-check with the master whether the agent has already requested a certificate signing; the agent may have just lost the local copy of the request. (Unverified GET request to `/certificate_request/<name>`.)
+    * If this request doesn't 404, the agent will bail, assuming it needs user intervention on the master. If `waitforcert` is enabled, it will wait a few seconds and start this section over.
+4. If the agent has reached this step, it has never requested a certificate, so request one now. (Unverified PUT request to `/certificate_request/<name>`.)
+5. Return to the first step of this section, in case the master has autosign enabled; if it doesn't, the agent will end up bailing at step 2.
+
+## Request Node Object and Switch Environments
+
+1. Do a GET request to `/node/<name>`.
+    * If successful, read the environment from the node object.
+        * If the node object has one: In all subsequent requests during this run, use this environment instead of the one in the agent's config file.
+    * If unsuccessful, or if the node object had no environment set, continue using the environment from the agent's config file.
+
+> **Note:** This step was added in Puppet 3.0.0, to allow an ENC to centrally assign nodes to environments. The lenient failure mode is because many users' [auth.conf][authconf] files didn't allow access to node objects, since that rule was only added to the default auth.conf in Puppet 2.7.0 and many people don't update their config files for every upgrade.
+
+## Fetch Plugins
+
+If `pluginsync` is enabled on the agent:
+
+1. Do a GET request to `/file_metadatas/plugins` with `recurse=true` and `links=manage`. This is a special file server mountpoint that scans the `lib` directory of every module. Note the funky Rails-esque endpoint pluralization on `file_metadata`.
+2. Check whether any of the discovered plugins need to be downloaded.
+    * If so, do a GET request to `/file_content/plugins/<file>` for each one.
+
+## Request Catalog While Submitting Facts
+
+1. Do a POST request to `/catalog/<name>`, where the post data is all of the node's [facts][] encoded as JSON. Receive a compiled [catalog][] in return.
+
+> **Note:** This used to be a GET request with facts encoded as base64-encoded zlib-compressed JSON submitted as a URL parameter. This would sometimes cause failures with certain web servers and a large amount of facts, and was changed to a POST in Puppet 2.7.0. GETs should still work in Puppet 3 if something other than an agent tries one, but agents will use POSTs.
+>
+> Note also that submitting facts isn't necessarily logically bound to requesting a catalog, and could be done out of band on a different schedule; this is just the way Puppet happens to do it, because the original design assumptions were that relevant facts could change at any moment and you'd always want to guarantee the most recent data. We're experimenting with other ways, some of which might turn out to be better ideas.
+
+## Make File Source Requests While Applying Catalog
+
+[File][] resources can specify file contents as either a `content` or `source` attribute. Content attributes go into the catalog, and Puppet agent needs no additional data. Source attributes only put references into the catalog, and may require additional HTTPS requests.
+
+If you are using the normal compiler, then for each file source, Puppet agent will:
+
+1. Do a GET request to `/file_metadata/<something>`.
+2. Compare the metadata to the state of the file on disk.
+    * If it is in sync, move on to the next file source.
+    * If it is out of sync, do a GET request to `/file_content/<something>` for the current content.
+
+If you are using the [static compiler][static], all file metadata is embedded in the catalog. For each file source, Puppet agent will:
+
+1. Compare the embedded metadata to the state of the file on disk.
+    * If it is in sync, move on to the next file source.
+    * If it is out of sync, do a GET request to `/file_bucket_file/md5/<checksum>` for the current content.
+
+Note that this is cheaper in terms of network traffic, but potentially more expensive during catalog compilation. Large amounts of files, especially recursive directories, will amplify the effect in both directions.
+
+## Submit Report
+
+If `report` is enabled on the agent:
+
+1. Do a PUT request to `/report/<name>`. The content of the PUT should be a Puppet report object in YAML format.
+
+> **Note:** Yes, using PUT for this is not quite proper, but that's how it was implemented. It may change in the future.

--- a/source/puppet/4.0/reference/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.0/reference/subsystem_catalog_compilation.markdown
@@ -1,0 +1,157 @@
+---
+layout: default
+title: "Subsystems: Catalog Compilation"
+canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+---
+
+[environment]: ./environments.html
+[certname]: ./config_important_settings.html#basics
+[resource_declaration]: ./lang_resources.html
+[relationships]: ./lang_relationships.html
+[cert_extensions]: ./ssl_attributes_extensions.html
+[facts]: ./lang_facts_and_builtin_vars.html
+[enc]: /guides/external_nodes.html
+[exported resources]: ./lang_exported.html
+[puppetdb]: /puppetdb/latest
+[functions]: ./lang_functions.html
+[main manifest]: ./dirs_manifest.html
+[modules]: ./modules_fundamentals.html
+[node terminus]: /references/3.7.latest/configuration.html#nodeterminus
+[plain_node]: /references/3.7.latest/indirection.html#plain-terminus
+[exec_node]: /references/3.7.latest/indirection.html#exec-terminus
+[ldap_node]: /references/3.7.latest/indirection.html#ldap-terminus
+[ldap_guide]: /guides/ldap_nodes.html
+[trusted_on]: ./config_important_settings.html#getting-new-features-early
+[facts_builtin]: ./lang_facts_and_builtin_vars.html
+[node definitions]: ./lang_node_definitions.html
+[agent_provided]: #agent-provided-data
+[resources]: ./lang_resources.html
+[class declarations]: ./lang_classes.html#declaring-classes
+[node scope]: ./lang_scope.html#node-scope
+[variables]: ./lang_variables.html
+[class definitions]: ./lang_classes.html#defining-classes
+[classes]: ./lang_classes.html
+[manifest naming conventions]: ./modules_fundamentals.html#manifests
+[modulepath]: ./dirs_modulepath.html
+
+Background Info
+-----
+
+### What's a catalog?
+
+When configuring a node, Puppet agent uses a document called a **catalog,** which it downloads from a Puppet master server. The catalog describes the [desired state for each resource][resource_declaration] that should be managed, and may specify [dependency information][relationships] for resources that should be managed in a certain order.
+
+### Why is it used?
+
+Puppet manifests are concise because they can express variation between nodes with conditional logic, templates, and functions. By resolving these on the master and giving the agent just a specific catalog, Puppet is able to:
+
+* **Separate privileges:** Each individual node has little to no knowledge about other nodes. It only receives its own resources.
+* **Reduce the agent's resource consumption:** Since the agent doesn't have to compile, it can use less CPU and memory.
+* **Simulate changes:** Since the agent is just checking resources and not running arbitrary code, it has the option of simulating changes. If you do a Puppet run in _noop_ mode, the agent will check against its current state and report on what _would_ have changed without actually making any changes.
+* **Record and query configurations:** If you use PuppetDB, you can [query it for information about managed resources on any node](/puppetdb/latest/api/index.html).
+
+### What about Puppet apply?
+
+Puppet apply compiles its own catalog and then applies it, so it plays the role of both Puppet master and Puppet agent.
+
+
+Information Sources
+-----
+
+Puppet compiles a catalog using three main sources of configuration info:
+
+* Agent-provided data
+* External data
+* Puppet manifests (and associated templates and file sources)
+
+All of these sources are used by both agent/master deployments and by stand-alone Puppet apply nodes.
+
+### Agent-Provided Data
+
+When agents request a catalog, they send four pieces of information to the Puppet master:
+
+* Their **name,** which is embedded in the request URL. (e.g. `/production/catalog/web01.example.com`) This is almost always the same as the [certname][].
+* Their **certificate,** which contains their [certname][] and possibly some [extra information][cert_extensions]. (This is the one item not used by Puppet apply.)
+* Their [**facts.**][facts]
+* Their requested [environment][], which is embedded in the request URL. (e.g. `/production/catalog/web01.example.com`) Before requesting a catalog, agents will ask the master which environment they should be in, but they will use the environment in their own config file if the master doesn't have an opinion.
+
+
+### External Data
+
+Puppet can use external data at several stages when compiling, but there are two main kinds to be aware of:
+
+* Data from an [ENC][] or other node terminus, which is available before compilation starts. This data arrives in the form of a **node object,** which can contain any of the following:
+    * **Classes** that should be assigned to the node, and parameters to configure the classes
+    * Extra **top-scope variables** that should be set for the node
+    * An **environment** for the node (which will override its requested environment)
+* Data from other sources, which is accessed as needed during compilation. It may be invoked by the main manifest or by classes or defined types in modules. This kind of data includes:
+    * [Exported resources][] queried from [PuppetDB][]
+    * The results of [functions][], which can access arbitrary data sources including Hiera or an external CMDB
+
+### Puppet Manifests, Templates, etc.
+
+This is the heart of a Puppet deployment. It can include:
+
+* The [main manifest][], which might be broken out into per-node `.pp` files for easier organization
+* [Modules][] downloaded from the [Puppet Forge](https://forge.puppetlabs.com)
+* [Modules][] written specifically for your site
+
+The Process of Catalog Compilation
+-----
+
+This description is simplified. It doesn't delve into the internals of the parser, model, evaluator, etc., and some items are presented out of order for the sake of conceptual clarity.
+
+For practical purposes, you can treat Puppet apply nodes as simply a combined agent and master.
+
+This process begins after the catalog request has been received.
+
+### Step 1: Retrieve the Node Object
+
+Once the Puppet master has the agent-provided information for this request, it asks its configured **[node terminus][]** for a node object.
+
+By default, Puppet master uses the [`plain` node terminus][plain_node], which just returns a blank node object. This results in only manifests and agent-provided info being used in compilation.
+
+The next most common node terminus is the [`exec` node terminus][exec_node], which will request data from an [external node classifier (ENC)][enc]. This may return classes, variables, and/or an environment, depending on how the ENC is designed.
+
+Less commonly, some people use the [`ldap` node terminus][ldap_node], which will fetch ENC-like information from an LDAP database. See the page on [LDAP nodes][ldap_guide] for more information.
+
+Finally, it's possible to write a custom node terminus that retrieves classes, variables, and environments from any kind of external system.
+
+### Step 2: Set Variables from the Node Object, from Facts, and from the Certificate
+
+* Any variables provided by the node object will now be set as top-scope Puppet variables.
+* The node's facts are also set as top-scope variables.
+* If you have set [`trusted_node_data = true`][trusted_on] in the master's puppet.conf, then facts will also be set in the protected `$facts` hash, and certain data from the node's certificate will be set in the protected `$trusted` hash. See [the page on facts and built-in variables][facts_builtin] for more details.
+
+All of these variables will be available for use by any manifest or template during the subsequent stages of compilation.
+
+### Step 3: Evaluate the Main Manifest
+
+Puppet now parses the [main manifest][]. The node's [environment][] may specify a main manifest to use; if it doesn't, the Puppet master will use the main manifest from its config file.
+
+The main manifest can contain any arbitrary Puppet code. The way it is evaluated is:
+
+* If there are any [node definitions][] in the manifest, Puppet **must** find one that matches the node's **name** (see [agent-provided information][agent_provided], above). See [the page on node definitions][node definitions] for information on how node statements match names.
+    * If at least one node definition is present and Puppet cannot find a match, it will fail compilation now.
+* Any code **outside** any node definition is evaluated. Any [resources][] are added to the node's catalog. Any [class declarations][] cause classes to be loaded from modules and declared (see Step 3a below).
+* If a matching node definition was found, any code in it is evaluated at [node scope][]. (This means it may contain [variable assignments][variables] that can override top-scope variables.) Any resources are added to the catalog, and any class declarations cause classes to be loaded and declared.
+
+### Step 3a: Load and Evaluate Classes from Modules
+
+It's possible for the main manifest to contain [class definitions][], but usually classes are defined elsewhere, in [modules][].
+
+If any [classes][] were declared in the main manifest and their definitions were not present, Puppet will automatically load the manifests containing them from its collection of [modules][]. It will follow the normal [manifest naming conventions][] to locate the files it should load.
+
+The set of locations Puppet will load modules from is called the [modulepath][]. The modulepath can be influenced by the node's [environment][].
+
+Once a class is loaded, the Puppet code in it is evaluated, and any resources are added to the catalog. If it was declared at node scope, it has access to any node-scope variables; otherwise, it only has access to top-scope variables.
+
+Classes can also declare other classes; if they do, Puppet will load and evaluate those in the same way.
+
+### Step 4: Evaluate Classes from the Node Object
+
+Finally, after Puppet has evaluated the main manifest and any classes it declared (and any classes _they_ declared), it will load from modules and evaluate any classes that were specified by the node object. Resources from those classes will be added to the catalog.
+
+If a matching node definition was found in step 3, these classes are evaluated **at node scope,** which means they can access any node-scope variables set by the main manifest. If no node definitions were present in the main manifest, they will be evaluated at top scope.
+
+

--- a/source/puppet/4.0/reference/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.0/reference/subsystem_catalog_compilation.markdown
@@ -16,10 +16,10 @@ canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
 [functions]: ./lang_functions.html
 [main manifest]: ./dirs_manifest.html
 [modules]: ./modules_fundamentals.html
-[node terminus]: /references/3.7.latest/configuration.html#nodeterminus
-[plain_node]: /references/3.7.latest/indirection.html#plain-terminus
-[exec_node]: /references/3.7.latest/indirection.html#exec-terminus
-[ldap_node]: /references/3.7.latest/indirection.html#ldap-terminus
+[node terminus]: /references/4.0.latest/configuration.html#nodeterminus
+[plain_node]: /references/4.0.latest/indirection.html#plain-terminus
+[exec_node]: /references/4.0.latest/indirection.html#exec-terminus
+[ldap_node]: /references/4.0.latest/indirection.html#ldap-terminus
 [ldap_guide]: /guides/ldap_nodes.html
 [trusted_on]: ./config_important_settings.html#getting-new-features-early
 [facts_builtin]: ./lang_facts_and_builtin_vars.html
@@ -70,10 +70,10 @@ All of these sources are used by both agent/master deployments and by stand-alon
 
 When agents request a catalog, they send four pieces of information to the Puppet master:
 
-* Their **name,** which is embedded in the request URL. (e.g. `/production/catalog/web01.example.com`) This is almost always the same as the [certname][].
+* Their **name,** which is embedded in the request URL. (e.g. `/puppet/v3/catalog/web01.example.com?environment=production`) This is almost always the same as the [certname][].
 * Their **certificate,** which contains their [certname][] and possibly some [extra information][cert_extensions]. (This is the one item not used by Puppet apply.)
 * Their [**facts.**][facts]
-* Their requested [environment][], which is embedded in the request URL. (e.g. `/production/catalog/web01.example.com`) Before requesting a catalog, agents will ask the master which environment they should be in, but they will use the environment in their own config file if the master doesn't have an opinion.
+* Their requested [environment][], which is embedded in the request URL. (e.g. `/puppet/v3/catalog/web01.example.com?environment=production`) Before requesting a catalog, agents will ask the master which environment they should be in, but they will use the environment in their own config file if the master doesn't have an opinion.
 
 
 ### External Data


### PR DESCRIPTION
Update URLs in Puppet docs to conform to Puppet 4 URL changes. This has almost no content changes, I just went through and changed all the URLs I could find.

The first 2 commits just copy files - guides that are Puppet 4 specific I just copied to files that end with `-puppet-4`, and references I copied over from puppet/3.7 to puppet/4.0. Te rest of the commits show the actual changes I made.