### PR TITLE
(maint) Remove lucid from list of supported platforms

### DIFF
--- a/source/_includes/platforms_debian_like.markdown
+++ b/source/_includes/platforms_debian_like.markdown
@@ -4,7 +4,6 @@ We publish official packages and run automated testing on the following versions
 * Debian 7 "Wheezy" (current stable release) (also supported by [Puppet Enterprise][peinstall])
 * Ubuntu 14.04 LTS "Trusty Tahr" (also supported by [Puppet Enterprise][peinstall])
 * Ubuntu 12.04 LTS "Precise Pangolin" (also supported by [Puppet Enterprise][peinstall])
-* Ubuntu 10.04 LTS "Lucid Lynx" (also supported by [Puppet Enterprise][peinstall])
 
 [peinstall]: /pe/latest/install_basic.html
 <!-- When updating these, you don't need to update any other area of the docs. -->


### PR DESCRIPTION
Ubuntu 10.04 (Lucid Lynx) goes End of Life on 2015-04-30, so we are no
longer supporting our software on this platform.

https://lists.ubuntu.com/archives/ubuntu-announce/2015-March/000193.html