### PR TITLE
Update PuppetDB version info

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -181,9 +181,9 @@ version_notes:
   /puppet/3.8: "This is the version of Puppet included in Puppet Enterprise 3.8."
   /puppet/4.0: '<p class="noisy">This is the latest version of Puppet. Puppet Enterprise 3.8 users should see <a href="/pe/latest/">the Puppet Enterprise 3.8 docs</a>.</p>'
   /puppet/pre4.0: "<p class=\"noisy\">This page is about a version of Puppet that isn't released yet. If you use the current version of Puppet or of Puppet Enterprise, see <a href=\"/puppet/latest/index.html\">the current Puppet docs.</a></p>"
-  /puppetdb/2.2: "This is the version of PuppetDB included in Puppet Enterprise 3.7 and 3.8. If you're using the open source release, there's a <a href=\"/puppetdb/latest/\">newer version</a> available."
-  /puppetdb/2.3: '<p class="noisy">PuppetDB 2.3 is not included in Puppet Enterprise 3.7 or 3.8. PE 3.7 and 3.8 users should see <a href="/puppetdb/2.2/">the PuppetDB 2.2 docs</a>.</p>'
-  /puppetdb/master: '<p class="noisy">This page is for an unreleased version of PuppetDB. PE 3.7 or 3.8 users should see <a href="/puppetdb/2.2/">the PuppetDB 2.2 docs</a>. Other users should see <a href="/puppetdb/latest/">the latest official release</a>.</p>'
+  /puppetdb/2.2: "This is the version of PuppetDB included in Puppet Enterprise 3.7. If you're using the open source release, there's a <a href=\"/puppetdb/latest/\">newer version</a> available."
+  /puppetdb/2.3: "This version of PuppetDB is included in Puppet Enterprise 3.8."
+  /puppetdb/master: '<p class="noisy">This page is for an unreleased version of PuppetDB. PE 3.8 users should see <a href="/puppetdb/2.3/">the PuppetDB 2.3 docs</a>. Other users should see <a href="/puppetdb/latest/">the latest official release</a>.</p>'
   /facter/2.2: 'This is the version of Facter included in Puppet Enterprise 3.7. Open source Puppet users should see <a href="/facter/latest">the latest version of the docs</a>.'
   /facter/2.3: '<p class="noisy">Facter 2.3 is not included in Puppet Enterprise 3.8. PE 3.8 users should see <a href="/facter/2.2">the Facter 2.2 docs.</a></p>'
   /facter/2.4: '<p class="noisy">This version of Facter is included in Puppet Enterprise 3.8. </a></p>'


### PR DESCRIPTION
The alert text about PupppetDB/PE versions is incorrect. 