### PR TITLE
(maint) Tweak how some OpenBSD user provider features are set

### DIFF
--- a/lib/puppet_docs/quarantine/get_typedocs.rb
+++ b/lib/puppet_docs/quarantine/get_typedocs.rb
@@ -84,6 +84,7 @@ Puppet::Type.eachtype { |type|
   # Override several features missing due to bug #18426:
   if type.name == :user
     docobject[:providers][:useradd][:features] << :manages_passwords << :manages_password_age << :libuser
+    docobject[:providers][:openbsd][:features] << :manages_passwords << :manages_loginclass
   end
   if type.name == :group
     docobject[:providers][:groupadd][:features] << :libuser


### PR DESCRIPTION
Original discussion here: puppetlabs/puppet#3911