### PR TITLE
(DOCUMENT-368) alternate ways to get 64 bit paths

### DIFF
--- a/source/puppet/3.7/reference/future_lang_windows_file_paths.markdown
+++ b/source/puppet/3.7/reference/future_lang_windows_file_paths.markdown
@@ -156,6 +156,20 @@ Prior to 3.7.3, you can manually compensate. On systems affected by file system 
 
 Prior to 3.7.3, there's no easy way for Puppet manifests to detect whether `sysnative` is available or necessary. Authors of public modules can choose to only support 3.7.3+, or can ship a renamed version of the `$system32` fact to support older versions. Private users can predict the mix of OS versions and architectures where their code will be run, and simply do the right thing for that environment.
 
+One consideration for `exec` when you can't use `$system32` is to use `path =>` and set it appropriately, the first search path item first followed by others in the order you want them searched in. For instance, if you want to always use the 64-bit version of `cmd.exe` you can use:
+
+    exec { '64_bit_cmd':
+      path    => "c:\\windows\\sysnative;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
+If you always instead would rather always get a 32-bit process if it is available, you should set path more like the following:
+
+    exec { '32_bit_cmd':
+      path    => "c:\\windows\\sysWOW64;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
 Finally, it's possible to automatically detect which directory to use in Ruby plugin code. Do something like [this example from the puppetlabs/powershell module](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb#L6-L13):
 
 ~~~ ruby

--- a/source/puppet/3.7/reference/lang_windows_file_paths.markdown
+++ b/source/puppet/3.7/reference/lang_windows_file_paths.markdown
@@ -156,6 +156,20 @@ Prior to 3.7.3, you can manually compensate. On systems affected by file system 
 
 Prior to 3.7.3, there's no easy way for Puppet manifests to detect whether `sysnative` is available or necessary. Authors of public modules can choose to only support 3.7.3+, or can ship a renamed version of the `$system32` fact to support older versions. Private users can predict the mix of OS versions and architectures where their code will be run, and simply do the right thing for that environment.
 
+One consideration for `exec` when you can't use `$system32` is to use `path =>` and set it appropriately, the first search path item first followed by others in the order you want them searched in. For instance, if you want to always use the 64-bit version of `cmd.exe` you can use:
+
+    exec { '64_bit_cmd':
+      path    => "c:\\windows\\sysnative;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
+If you always instead would rather always get a 32-bit process if it is available, you should set path more like the following:
+
+    exec { '32_bit_cmd':
+      path    => "c:\\windows\\sysWOW64;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
 Finally, it's possible to automatically detect which directory to use in Ruby plugin code. Do something like [this example from the puppetlabs/powershell module](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb#L6-L13):
 
 ~~~ ruby

--- a/source/puppet/3.8/reference/future_lang_windows_file_paths.markdown
+++ b/source/puppet/3.8/reference/future_lang_windows_file_paths.markdown
@@ -156,6 +156,20 @@ Prior to 3.7.3, you can manually compensate. On systems affected by file system 
 
 Prior to 3.7.3, there's no easy way for Puppet manifests to detect whether `sysnative` is available or necessary. Authors of public modules can choose to only support 3.7.3+, or can ship a renamed version of the `$system32` fact to support older versions. Private users can predict the mix of OS versions and architectures where their code will be run, and simply do the right thing for that environment.
 
+One consideration for `exec` when you can't use `$system32` is to use `path =>` and set it appropriately, the first search path item first followed by others in the order you want them searched in. For instance, if you want to always use the 64-bit version of `cmd.exe` you can use:
+
+    exec { '64_bit_cmd':
+      path    => "c:\\windows\\sysnative;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
+If you always instead would rather always get a 32-bit process if it is available, you should set path more like the following:
+
+    exec { '32_bit_cmd':
+      path    => "c:\\windows\\sysWOW64;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
 Finally, it's possible to automatically detect which directory to use in Ruby plugin code. Do something like [this example from the puppetlabs/powershell module](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb#L6-L13):
 
 ~~~ ruby

--- a/source/puppet/3.8/reference/lang_windows_file_paths.markdown
+++ b/source/puppet/3.8/reference/lang_windows_file_paths.markdown
@@ -156,6 +156,20 @@ Prior to 3.7.3, you can manually compensate. On systems affected by file system 
 
 Prior to 3.7.3, there's no easy way for Puppet manifests to detect whether `sysnative` is available or necessary. Authors of public modules can choose to only support 3.7.3+, or can ship a renamed version of the `$system32` fact to support older versions. Private users can predict the mix of OS versions and architectures where their code will be run, and simply do the right thing for that environment.
 
+One consideration for `exec` when you can't use `$system32` is to use `path =>` and set it appropriately, the first search path item first followed by others in the order you want them searched in. For instance, if you want to always use the 64-bit version of `cmd.exe` you can use:
+
+    exec { '64_bit_cmd':
+      path    => "c:\\windows\\sysnative;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
+If you always instead would rather always get a 32-bit process if it is available, you should set path more like the following:
+
+    exec { '32_bit_cmd':
+      path    => "c:\\windows\\sysWOW64;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
 Finally, it's possible to automatically detect which directory to use in Ruby plugin code. Do something like [this example from the puppetlabs/powershell module](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb#L6-L13):
 
 ~~~ ruby

--- a/source/puppet/4.1/reference/lang_windows_file_paths.markdown
+++ b/source/puppet/4.1/reference/lang_windows_file_paths.markdown
@@ -156,6 +156,20 @@ Prior to 3.7.3, you can manually compensate. On systems affected by file system 
 
 Prior to 3.7.3, there's no easy way for Puppet manifests to detect whether `sysnative` is available or necessary. Authors of public modules can choose to only support 3.7.3+, or can ship a renamed version of the `$system32` fact to support older versions. Private users can predict the mix of OS versions and architectures where their code will be run, and simply do the right thing for that environment.
 
+One consideration for `exec` when you can't use `$system32` is to use `path =>` and set it appropriately, the first search path item first followed by others in the order you want them searched in. For instance, if you want to always use the 64-bit version of `cmd.exe` you can use:
+
+    exec { '64_bit_cmd':
+      path    => "c:\\windows\\sysnative;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
+If you always instead would rather always get a 32-bit process if it is available, you should set path more like the following:
+
+    exec { '32_bit_cmd':
+      path    => "c:\\windows\\sysWOW64;c:\\windows\\system32;$::path",
+      command => 'cmd.exe /c echo process is %PROCESSOR_ARCHITECTURE%',
+    }
+
 Finally, it's possible to automatically detect which directory to use in Ruby plugin code. Do something like [this example from the puppetlabs/powershell module](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb#L6-L13):
 
 ~~~ ruby

--- a/source/windows/troubleshooting.markdown
+++ b/source/windows/troubleshooting.markdown
@@ -122,6 +122,8 @@ Instead, wrap the builtin in `cmd.exe`:
       path => 'c:\windows\system32;c:\windows'
     }
 
+Keep in mind that in 32-bit versions of Puppet, you may be subject to file system redirection (where system32 is switched to sysWOW64 automatically by Windows). We have ways of dealing with the [redirection](/puppet/latest/reference/lang_windows_file_paths.html#file-system-redirection-when-running-32-bit-puppet-on-64-bit-windows).
+
 Or, better still, use the tip from above:
 
     exec { 'cmd.exe /c echo foo':


### PR DESCRIPTION
On Windows, the search path is able to be used to search for a process. This allows
us to take advantage of using the search path to enter a specific order of searches
for an executable so that we are always using the 64-bit version or alternatively,
always selecting the 32-bit version based on where the executable is found first on
the path. This allows a process that is sometimes in sysnative and sometimes in
system32 based on whether we are in a 32-bit process on a 64-bit OS or in a 32-bit
process on a 32-bit OS. Either way the proper item will be selected provided the
search strings are correct.