### PR TITLE
(maint) Windows enhancements

### DIFF
--- a/source/guides/install_puppet/install_windows.markdown
+++ b/source/guides/install_puppet/install_windows.markdown
@@ -69,7 +69,7 @@ Once the installer finishes, Puppet will be installed, running, and at least par
 
 Use the `msiexec` command to install the Puppet package:
 
-    msiexec /qn /i puppet-<VERSION>.msi
+    msiexec /qn /norestart /i puppet-<VERSION>.msi
 
 If you don't specify any further options, this is the same as installing graphically with the default puppet master hostname (`puppet`).
 
@@ -77,7 +77,7 @@ You can specify `/l*v install.txt` to log the progress of the installation to a 
 
 You can also set several MSI properties to pre-configure Puppet as you install it. For example:
 
-    msiexec /qn /i puppet.msi PUPPET_MASTER_SERVER=puppet.example.com
+    msiexec /qn /norestart /i puppet.msi PUPPET_MASTER_SERVER=puppet.example.com
 
 See the next heading for info about these MSI properties.
 
@@ -202,7 +202,7 @@ Which Windows user account the puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-<VERSION>.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /norestart /i puppet-<VERSION>.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -241,8 +241,8 @@ Puppet can be uninstalled through the "Add or Remove Programs" interface or from
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x puppet-3.5.1.msi
-    msiexec /qn /x <PRODUCT CODE>
+    msiexec /qn /norestart /x puppet-3.5.1.msi
+    msiexec /qn /norestart /x <PRODUCT CODE>
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [confdir][] and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, the confdir and vardir can be manually deleted.
 

--- a/source/pe/3.2/deploy_nonroot-agent.markdown
+++ b/source/pe/3.2/deploy_nonroot-agent.markdown
@@ -148,6 +148,8 @@ On **windows systems** as non-admin user you should be able to enforce the follo
 * `exec`
 * `file`
 
+**NOTE**: A non-root agent on Windows is extremely limited as compared to non-root *nix. While you can use the above resources, you are limited on usage based on what the agent user has access to do (which isn't much). For instance, you can't create a file\directory in `C:\Windows` unless your user has permission to do so.
+
 You should also be able to inspect the following resource types (use `puppet resource <resource type>`):
 
 * `host`

--- a/source/pe/3.2/install_windows.markdown
+++ b/source/pe/3.2/install_windows.markdown
@@ -53,7 +53,7 @@ Automated Installation
 
 For automated deployments, Puppet can be installed unattended on the command line as follows:
 
-    msiexec /qn /i puppet.msi
+    msiexec /qn /norestart /i puppet.msi
 
 You can also specify `/l*v install.txt` to log the progress of the installation to a file.
 
@@ -73,7 +73,7 @@ The following public MSI properties can also be specified:
 
 For example:
 
-    msiexec /qn /i puppet.msi PUPPET_MASTER_SERVER=puppet.acme.com
+    msiexec /qn /norestart /i puppet.msi PUPPET_MASTER_SERVER=puppet.acme.com
 
 **Note:** If a value for the `environment` variable already exists in puppet.conf, specifying it during installation will NOT override that value.
 
@@ -98,7 +98,7 @@ Puppet can be uninstalled through the Windows standard __Add or Remove Programs_
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x [puppet.msi|product-code]
+    msiexec /qn /norestart /x [puppet.msi|product-code]
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [data directory](#data-directory) intact, including any SSL keys. To completely remove Puppet from the system, the data directory can be manually deleted.
 

--- a/source/pe/3.2/trouble_windows.markdown
+++ b/source/pe/3.2/trouble_windows.markdown
@@ -42,7 +42,7 @@ Similarly, the MSI will not overwrite the custom facts written to the `PuppetLab
 
 Puppet may fail to install when trying to perform an unattended install from the command line, e.g.
 
-    msiexec /qn /i puppet.msi
+    msiexec /qn /norestart /i puppet.msi
 
 To get troubleshooting data, specify an installation log, e.g. /l*v install.txt. Look in the log for entries like the following:
 

--- a/source/pe/3.3/deploy_nonroot-agent.markdown
+++ b/source/pe/3.3/deploy_nonroot-agent.markdown
@@ -148,6 +148,8 @@ On **windows systems** as non-admin user you should be able to enforce the follo
 * `exec`
 * `file`
 
+**NOTE**: A non-root agent on Windows is extremely limited as compared to non-root *nix. While you can use the above resources, you are limited on usage based on what the agent user has access to do (which isn't much). For instance, you can't create a file\directory in `C:\Windows` unless your user has permission to do so.
+
 You should also be able to inspect the following resource types (use `puppet resource <resource type>`):
 
 * `host`

--- a/source/pe/3.3/install_windows.markdown
+++ b/source/pe/3.3/install_windows.markdown
@@ -29,10 +29,10 @@ In particular, note that puppet *must* be run with elevated privileges (a.k.a., 
 [server]: ./images/windows/wizard_server.png
 [signcert]: ./install_agents.html#signing-agent-certificates
 
-Installing Windows Puppet Enterprise Agents 
+Installing Windows Puppet Enterprise Agents
 -----
 
-**Note**: Windows nodes can only run the puppet agent component; the puppet master component must be run on a supported Linux machine. 
+**Note**: Windows nodes can only run the puppet agent component; the puppet master component must be run on a supported Linux machine.
 
 The PE Windows installer is a standard Windows .msi package and will run as a graphical wizard. Alternately, you can run the installer unattended; [see "Automated Installation"](#automated-installation) for more information.
 
@@ -40,7 +40,7 @@ The installer must be run with elevated privileges. Installing Puppet **does not
 
 **To install Puppet Enterprise on a Windows node**:
 
-1. [Download][pedownloads] and run the installer. 
+1. [Download][pedownloads] and run the installer.
 
 2. When prompted by the install dialog, provide the hostname of your puppet master server.
 
@@ -61,7 +61,7 @@ Automated Installation
 
 For automated deployments, Puppet can be installed unattended on the command line as follows:
 
-    msiexec /qn /i puppet.msi
+    msiexec /qn /norestart /i puppet.msi
 
 You can also specify `/l*v install.txt` to log the progress of the installation to a file.
 
@@ -85,7 +85,7 @@ MSI Property                                                   | Puppet Setting 
 
 For example:
 
-    msiexec /qn /i puppet.msi PUPPET_MASTER_SERVER=puppet.acme.com
+    msiexec /qn /norestart /i puppet.msi PUPPET_MASTER_SERVER=puppet.acme.com
 
 **Note:** If a value for the `environment` variable already exists in puppet.conf, specifying it during installation will NOT override that value.
 
@@ -160,7 +160,7 @@ Which Windows user account the puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-<VERSION>.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /norestart /i puppet-<VERSION>.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -193,7 +193,7 @@ Puppet can be uninstalled through the Windows standard __Add or Remove Programs_
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x [puppet.msi|product-code]
+    msiexec /qn /norestart /x [puppet.msi|product-code]
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [data directory](#data-directory) intact, including any SSL keys. To completely remove Puppet from the system, the data directory can be manually deleted.
 

--- a/source/pe/3.3/trouble_windows.markdown
+++ b/source/pe/3.3/trouble_windows.markdown
@@ -42,7 +42,7 @@ Similarly, the MSI will not overwrite the custom facts written to the `PuppetLab
 
 Puppet may fail to install when trying to perform an unattended install from the command line, e.g.
 
-    msiexec /qn /i puppet.msi
+    msiexec /qn /norestart /i puppet.msi
 
 To get troubleshooting data, specify an installation log, e.g. /l*v install.txt. Look in the log for entries like the following:
 

--- a/source/puppet/4.0/reference/install_windows.markdown
+++ b/source/puppet/4.0/reference/install_windows.markdown
@@ -55,13 +55,13 @@ For standalone Puppet nodes that won't be connecting to a master, use the defaul
 
 ![Puppet master hostname selection][server]
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured. 
+Once the installer finishes, Puppet will be installed, running, and at least partially configured.
 
 ### Automated Installation
 
 Use the `msiexec` command to install the Puppet package:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi
 
 If you don't specify any further options, this is the same as installing graphically with the default Puppet master hostname (`puppet`).
 
@@ -69,11 +69,11 @@ You can specify `/l*v install.txt` to log the progress of the installation to a 
 
 You can also set several MSI properties to pre-configure Puppet as you install it. For example:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
 
 See the next heading for info about these MSI properties.
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured. 
+Once the installer finishes, Puppet will be installed, running, and at least partially configured.
 
 ### MSI Properties
 
@@ -195,7 +195,7 @@ Which Windows user account the Puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -221,7 +221,7 @@ Puppet can be uninstalled through the "Add or Remove Programs" interface or from
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x puppet-agent-1.0.0-x64.msi
-    msiexec /qn /x <PRODUCT CODE>
+    msiexec /qn /norestart /x puppet-agent-1.0.0-x64.msi
+    msiexec /qn /norestart /x <PRODUCT CODE>
 
 Uninstalling will remove Puppet's program directory, the Puppet agent service, and all related registry keys. It will leave the [confdir][] and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, the confdir and vardir can be manually deleted.

--- a/source/puppet/4.1/reference/install_windows.markdown
+++ b/source/puppet/4.1/reference/install_windows.markdown
@@ -56,13 +56,13 @@ For standalone Puppet nodes that won't be connecting to a master, use the defaul
 
 ![Puppet master hostname selection][server]
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured. 
+Once the installer finishes, Puppet will be installed, running, and at least partially configured.
 
 ### Automated Installation
 
 Use the `msiexec` command to install the Puppet package:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi
 
 If you don't specify any further options, this is the same as installing graphically with the default puppet master hostname (`puppet`).
 
@@ -70,11 +70,11 @@ You can specify `/l*v install.txt` to log the progress of the installation to a 
 
 You can also set several MSI properties to pre-configure Puppet as you install it. For example:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
 
 See the next heading for info about these MSI properties.
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured. 
+Once the installer finishes, Puppet will be installed, running, and at least partially configured.
 
 ### MSI Properties
 
@@ -196,7 +196,7 @@ Which Windows user account the puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -222,7 +222,7 @@ Puppet can be uninstalled through the "Add or Remove Programs" interface or from
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x puppet-agent-1.0.0-x64.msi
-    msiexec /qn /x <PRODUCT CODE>
+    msiexec /qn /norestart /x puppet-agent-1.0.0-x64.msi
+    msiexec /qn /norestart /x <PRODUCT CODE>
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [confdir][], [codedir][], and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, the confdir, codedir, and vardir can be manually deleted.

--- a/source/puppet/4.2/reference/install_windows.markdown
+++ b/source/puppet/4.2/reference/install_windows.markdown
@@ -62,7 +62,7 @@ Once the installer finishes, Puppet will be installed, running, and at least par
 
 Use the `msiexec` command to install the Puppet package:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi
 
 If you don't specify any further options, this is the same as installing graphically with the default puppet master hostname (`puppet`).
 
@@ -70,7 +70,7 @@ You can specify `/l*v install.txt` to log the progress of the installation to a 
 
 You can also set several MSI properties to pre-configure Puppet as you install it. For example:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
 
 See the next heading for info about these MSI properties.
 
@@ -196,7 +196,7 @@ Which Windows user account the puppet agent service should use. This is importan
 
 This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, you would install with:
 
-    msiexec /qn /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
+    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
 **Default:** `LocalSystem`
 
@@ -222,7 +222,7 @@ Puppet can be uninstalled through the "Add or Remove Programs" interface or from
 
 To uninstall from the command line, you must have the original MSI file or know the <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
 
-    msiexec /qn /x puppet-agent-1.0.0-x64.msi
-    msiexec /qn /x <PRODUCT CODE>
+    msiexec /qn /norestart /x puppet-agent-1.0.0-x64.msi
+    msiexec /qn /norestart /x <PRODUCT CODE>
 
 Uninstalling will remove Puppet's program directory, the puppet agent service, and all related registry keys. It will leave the [confdir][], [codedir][], and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, the confdir, codedir, and vardir can be manually deleted.

--- a/source/windows/troubleshooting.markdown
+++ b/source/windows/troubleshooting.markdown
@@ -36,7 +36,7 @@ Similarly, the MSI will not overwrite the custom facts written to the `PuppetLab
 
 Puppet may fail to install when trying to perform an unattended install from the command line, e.g.
 
-    msiexec /qn /i puppet.msi
+    msiexec /qn /norestart /i puppet.msi
 
 To get troubleshooting data, specify an installation log, e.g. `/l*v install.txt`. Look in the log for entries like the following:
 


### PR DESCRIPTION
* With MSIExec, always add `/norestart` to the options.
* In the deploy non-root agent guide, be sure to add extra information so that users know we really don't recommend that setting with Windows. It's a path of trouble and provides an extremely limited use of Puppet - Windows just doesn't have the same non-root access that *nix provides.