### PR TITLE
Release PuppetDB 3.0

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -201,7 +201,6 @@ symlink_latest:
   - facter
   - pe
 lock_latest: {
-  puppetdb: "2.3"
 }
 version_notes:
   # Default notes for upstreams. Tweak these whenever latest de-syncs or re-syncs with PE!
@@ -215,8 +214,8 @@ version_notes:
   /puppet/3.8: "This is the version of Puppet included in Puppet Enterprise 3.8."
   /puppet/4.2: '<p class="noisy">This is the latest version of Puppet. Puppet Enterprise 3.8 users should see <a href="/puppet/3.8/reference/">the Puppet 3.8 docs</a> and <a href="/pe/latest/">the Puppet Enterprise 3.8 docs</a>.</p>'
   /puppetdb/2.2: "This is the version of PuppetDB included in Puppet Enterprise 3.7. If you're using the open source release, there's a <a href=\"/puppetdb/latest/\">newer version</a> available."
-  /puppetdb/2.3: "This is the version of PuppetDB included in Puppet Enterprise 3.8."
-  /puppetdb/3.0: '<p class="noisy">This page is for an unreleased version of PuppetDB. PE 3.8 users should see <a href="/puppetdb/2.3/">the PuppetDB 2.3 docs</a>. Other users should see <a href="/puppetdb/latest/">the latest official release</a>.</p>'
+  /puppetdb/2.3: "This is the version of PuppetDB included in Puppet Enterprise 3.8. If you're using the open source release, there's a <a href=\"/puppetdb/latest/\">newer version</a> available."
+  /puppetdb/3.0: '<p class="noisy">This version of PuppetDB is not included in Puppet Enterprise 3.8. PE 3.8 users should see <a href="/puppetdb/2.3/">the PuppetDB 2.3 docs</a>.</p>'
   /puppetdb/master: '<p class="noisy">This page is for an unreleased version of PuppetDB. PE 3.8 users should see <a href="/puppetdb/2.3/">the PuppetDB 2.3 docs</a>. Other users should see <a href="/puppetdb/latest/">the latest official release</a>.</p>'
   /facter/2.2: 'This is the version of Facter included in Puppet Enterprise 3.7. Open source Puppet users should see <a href="/facter/latest">the latest version of the docs</a>.'
   /facter/2.4: 'This is the version of Facter included in Puppet Enterprise 3.8. Open source Puppet users should see <a href="/facter/latest">the latest version of the docs</a>.'

--- a/source/puppet/3.7/reference/config_file_puppetdb.markdown
+++ b/source/puppet/3.7/reference/config_file_puppetdb.markdown
@@ -4,14 +4,10 @@ title: "Config Files: puppetdb.conf"
 canonical: "/puppet/latest/reference/config_file_puppetdb.html"
 ---
 
-[puppetdb_connection]: /puppetdb/master/puppetdb_connection.html
+[puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html
 
 
 The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/puppetdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
-
-## PuppetDB Documentation
-
-If you're using PuppetDB 3.0 or higher (unreleased as of this writing), [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
 
 ## PuppetDB 2.3 and Earlier
 

--- a/source/puppet/3.8/reference/config_file_puppetdb.markdown
+++ b/source/puppet/3.8/reference/config_file_puppetdb.markdown
@@ -4,14 +4,10 @@ title: "Config Files: puppetdb.conf"
 canonical: "/puppet/latest/reference/config_file_puppetdb.html"
 ---
 
-[puppetdb_connection]: /puppetdb/master/puppetdb_connection.html
+[puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html
 
 
 The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/puppetdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
-
-## PuppetDB Documentation
-
-If you're using PuppetDB 3.0 or higher (unreleased as of this writing), [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
 
 ## PuppetDB 2.3 and Earlier
 

--- a/source/puppet/4.1/reference/config_file_puppetdb.markdown
+++ b/source/puppet/4.1/reference/config_file_puppetdb.markdown
@@ -4,14 +4,14 @@ title: "Config Files: puppetdb.conf"
 canonical: "/puppet/latest/reference/config_file_puppetdb.html"
 ---
 
-[puppetdb_connection]: /puppetdb/master/puppetdb_connection.html
+[puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html
 
 
 The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/puppetdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
 
 ## PuppetDB Documentation
 
-If you're using PuppetDB 3.0 or higher (unreleased as of this writing), [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
+If you're using PuppetDB 3.0 or higher, [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
 
 ## PuppetDB 2.3 and Earlier
 

--- a/source/puppet/4.2/reference/config_file_puppetdb.markdown
+++ b/source/puppet/4.2/reference/config_file_puppetdb.markdown
@@ -4,14 +4,14 @@ title: "Config Files: puppetdb.conf"
 canonical: "/puppet/latest/reference/config_file_puppetdb.html"
 ---
 
-[puppetdb_connection]: /puppetdb/master/puppetdb_connection.html
+[puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html
 
 
 The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/puppetdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your Puppet master to it](/puppetdb/latest/connect_puppet_master.html).
 
 ## PuppetDB Documentation
 
-If you're using PuppetDB 3.0 or higher (unreleased as of this writing), [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
+If you're using PuppetDB 3.0 or higher, [`puppetdb.conf` is documented in the PuppetDB docs.][puppetdb_connection]
 
 ## PuppetDB 2.3 and Earlier
 

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -8,6 +8,7 @@ PuppetDB is the fast, scalable, and reliable data warehouse for Puppet. It cache
 
 ## Current Versions
 
+* [PuppetDB 3.0](./3.0) is compatible with Puppet 4.x.
 * [PuppetDB 2.3](./2.3) is included with Puppet Enterprise 3.8. It's compatible with Puppet 4.x and 3.x.
 
 ## Older Versions
@@ -28,5 +29,4 @@ PuppetDB is the fast, scalable, and reliable data warehouse for Puppet. It cache
 
 These versions haven't been released.
 
-* [PuppetDB 3.0](./3.0)
 * [PuppetDB (master)](./master) --- this isn't tied to a specific version number; instead, it's whatever is currently in the `master` branch in the PuppetDB repository on GitHub.


### PR DESCRIPTION
Unlock latest, move it to 'current versions' in the index, and change version notes in _config.yml.