### PR TITLE
DOCUMENT-385: Clarify exportable resources.

### DIFF
--- a/source/guides/exported_resources.markdown
+++ b/source/guides/exported_resources.markdown
@@ -8,6 +8,8 @@ Exported Resource Design Patterns
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 [For more information on the syntax, behavior, and prerequisites of exported resources, see the Exported Resources section of the Puppet language reference.][lang_exported]
 
 [lang_exported]: /puppet/latest/reference/lang_exported.html

--- a/source/guides/exported_resources.markdown
+++ b/source/guides/exported_resources.markdown
@@ -6,9 +6,9 @@ title: Exported Resource Design Patterns
 Exported Resource Design Patterns
 ==================================
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 [For more information on the syntax, behavior, and prerequisites of exported resources, see the Exported Resources section of the Puppet language reference.][lang_exported]
 

--- a/source/puppet/2.7/reference/lang_exported.markdown
+++ b/source/puppet/2.7/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/2.7/reference/lang_exported.markdown
+++ b/source/puppet/2.7/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.5/reference/lang_exported.markdown
+++ b/source/puppet/3.5/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.5/reference/lang_exported.markdown
+++ b/source/puppet/3.5/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.6/reference/lang_exported.markdown
+++ b/source/puppet/3.6/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.6/reference/lang_exported.markdown
+++ b/source/puppet/3.6/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.7/reference/future_lang_exported.markdown
+++ b/source/puppet/3.7/reference/future_lang_exported.markdown
@@ -32,9 +32,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.7/reference/future_lang_exported.markdown
+++ b/source/puppet/3.7/reference/future_lang_exported.markdown
@@ -34,6 +34,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.7/reference/lang_exported.markdown
+++ b/source/puppet/3.7/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.7/reference/lang_exported.markdown
+++ b/source/puppet/3.7/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.8/reference/future_lang_exported.markdown
+++ b/source/puppet/3.8/reference/future_lang_exported.markdown
@@ -32,9 +32,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3.8/reference/future_lang_exported.markdown
+++ b/source/puppet/3.8/reference/future_lang_exported.markdown
@@ -34,6 +34,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.8/reference/lang_exported.markdown
+++ b/source/puppet/3.8/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3.8/reference/lang_exported.markdown
+++ b/source/puppet/3.8/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/3/reference/lang_exported.markdown
+++ b/source/puppet/3/reference/lang_exported.markdown
@@ -38,6 +38,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/3/reference/lang_exported.markdown
+++ b/source/puppet/3/reference/lang_exported.markdown
@@ -36,9 +36,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/4.1/reference/lang_exported.markdown
+++ b/source/puppet/4.1/reference/lang_exported.markdown
@@ -32,9 +32,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/4.1/reference/lang_exported.markdown
+++ b/source/puppet/4.1/reference/lang_exported.markdown
@@ -34,6 +34,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/4.2/reference/lang_exported.markdown
+++ b/source/puppet/4.2/reference/lang_exported.markdown
@@ -32,9 +32,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
 
-**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 

--- a/source/puppet/4.2/reference/lang_exported.markdown
+++ b/source/puppet/4.2/reference/lang_exported.markdown
@@ -34,6 +34,8 @@ Purpose
 
 Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
 
+**Note**: Exported resources only include node-specific data, and the catalog compiler constructs and publishes exported resources from that data. This means you can only export node-specific resources stored in the catalog. Generic data not stored in the catalog, such as an entire arbitrary file on a node's filesystem, can't be exported even if referenced by the source parameter of a file resource.
+
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 
 For more details, see [Exported Resource Design Patterns][exported_guide].

--- a/source/puppet/4.3/reference/lang_exported.markdown
+++ b/source/puppet/4.3/reference/lang_exported.markdown
@@ -32,7 +32,9 @@ An **exported resource declaration** specifies a desired state for a resource, *
 Purpose
 -----
 
-Exported resources allow nodes to share information with each other. This is useful when one node has information that another node needs in order to manage a resource --- the node with the information can construct and publish the resource, and the node managing the resource can collect it.
+Exported resources allow the Puppet compiler to share information among nodes by combining information from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or activity of other nodes.
+
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use information that's never sent to the compiler, such as the contents of arbitrary files on a node.
 
 The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can export a [`nagios_service`][nagios_service] resource describing how to monitor the service, including information like its hostname and port. The Nagios server can then collect every `nagios_service` resource, and will automatically start monitoring the Postgres server.
 


### PR DESCRIPTION
In all articles that use text from `lang_exported` (including future
parser documentation and the Exported Resources guide), add a note
clarifying that only node-specific resources publishable by the catalog
are exportable, and arbitrary data not stored or published by the
catalog are not.