### PR TITLE
DOC-2160: Update frontpage link to install docs.

### DIFF
--- a/source/_layouts/frontpage.html
+++ b/source/_layouts/frontpage.html
@@ -337,7 +337,7 @@
                                           <a href="/puppet/latest/reference/release_notes.html">Puppet Release Notes</a>
                                       </li>
                                       <li>
-                                          <a href="/guides/install_puppet/pre_install.html">Install Puppet</a>
+                                          <a href="/puppet/latest/reference/install_pre.html">Install Puppet</a>
                                       </li>
                                       <li>
                                           <a href="/references/latest/type.html">Type Reference</a>
@@ -350,9 +350,6 @@
                                       </li>
                                       <li>
                                           <a href="/puppet/4.0/reference/whered_it_go.html">Puppet 4: New File Locations</a>
-                                      </li>
-                                      <li>
-                                          <a href="/puppet/4.0/reference/install_pre.html#next-install-puppet">Puppet 4: Installing</a>
                                       </li>
                                   </ul>
                               </div>


### PR DESCRIPTION
The frontpage link to "Install Puppet" points to the outdated
pre-install instructions on /guides, while a second link points to the
Puppet 4 installation instructions. Point the "Install Puppet" link at
the latest pre-install docs and remove the Puppet 4-specific link.