### PR TITLE
Clarify upgrade order

### DIFF
--- a/source/puppet/4.2/reference/upgrade_major_pre.md
+++ b/source/puppet/4.2/reference/upgrade_major_pre.md
@@ -80,4 +80,4 @@ Puppet 4.0 introduces several breaking changes, some of which didn't go through 
 
 ## You're Ready!
 
-If your Puppet 3 system is updated and tuned for the upgrade, you're ready to proceed. For Puppet agents, see the [Agent upgrade guide](./upgrade_major_agent.html); for Puppet server, see the [Server upgrade guide](./upgrade_major_server.html).
+If your Puppet 3 system is updated and tuned for the upgrade, you're ready to proceed. For Puppet server, see the [Server upgrade guide](./upgrade_major_server.html); for Puppet agents, see the [Agent upgrade guide](./upgrade_major_agent.html). Upgrading to Puppet Server 2.1, with backwards compatibility for communicating with Puppet 3 agents, is recommended prior to upgrading agents.

--- a/source/puppet/4.2/reference/upgrade_major_server.markdown
+++ b/source/puppet/4.2/reference/upgrade_major_server.markdown
@@ -21,7 +21,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process. There's more going on under the hood, and more decisions you need to make during the process.
 
-This page walks you through getting an upgraded Puppet Server that can handle Puppet 3 agents. Don't start upgrading agents after the servers are stabilized.
+This page walks you through getting an upgraded Puppet Server that can handle Puppet 3 agents. Don't start upgrading agents until after the servers are stabilized.
 
 ## Prepare to Upgrade
 


### PR DESCRIPTION
The server upgrade docs point out upgrading the server prior to
upgrading the agent; that point seems like it should be made during the
preparation phase. Change the order of presenting agent and server
upgrade docs - server should really be addressed first - and explicitly
point out this ordering.