### PR TITLE
DOC-2188: Adjust Puppet Server branches per SERVER-828

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -156,11 +156,11 @@ externalsources:
     repo: git://github.com/nfagerlund/marionette-collective.git
     commit: origin/docs_1.2
     subdirectory: website
-#  puppetserver_master:
-#    url: /puppetserver/master
-#    repo: git://github.com/puppetlabs/puppet-server.git
-#    commit: origin/master
-#    subdirectory: documentation
+ puppetserver_master:
+   url: /puppetserver/master
+   repo: git://github.com/puppetlabs/puppet-server.git
+   commit: origin/master
+   subdirectory: documentation
   puppetserver_1.0:
     url: /puppetserver/1.0
     repo: git://github.com/puppetlabs/puppet-server.git
@@ -174,12 +174,12 @@ externalsources:
   puppetserver_1.1:
     url: /puppetserver/1.1
     repo: git://github.com/puppetlabs/puppet-server.git
-    commit: origin/stable
+    commit: origin/1.x
     subdirectory: documentation
   puppetserver_2.1:
     url: /puppetserver/2.1
     repo: git://github.com/puppetlabs/puppet-server.git
-    commit: origin/master
+    commit: origin/stable
     subdirectory: documentation
   pe3.7:
     url: /pe/3.7


### PR DESCRIPTION
DO NOT MERGE UNTIL SERVER-828 IS RESOLVED.

2.1.x is moving to stable, and 1.1.x is moving to 1.x. I'm also re-enabling
master, so there's a way to preview what the docs look like for the next
version.