### PR TITLE
DOC-2203: Document new reserved words.

### DIFF
--- a/source/puppet/3.7/reference/future_lang_reserved.markdown
+++ b/source/puppet/3.7/reference/future_lang_reserved.markdown
@@ -33,9 +33,11 @@ Several words in the Puppet language are **reserved**. This means they:
 The following words are reserved:
 
 * `and` --- expression operator
+* `application` --- reserved for future use
 * `attr` --- reserved for future use
 * `case` --- language keyword
 * `class` --- language keyword
+* `consumes` --- reserved for future use
 * `default` --- language keyword
 * `define` --- language keyword
 * `else` --- language keyword
@@ -49,6 +51,7 @@ The following words are reserved:
 * `node` --- language keyword
 * `or` --- expression operator
 * `private` --- reserved for future use
+* `produces` --- reserved for future use
 * `true` --- boolean value
 * `type` --- reserved for future use
 * `undef` --- special value

--- a/source/puppet/3.8/reference/future_lang_reserved.markdown
+++ b/source/puppet/3.8/reference/future_lang_reserved.markdown
@@ -33,9 +33,11 @@ Several words in the Puppet language are **reserved**. This means they:
 The following words are reserved:
 
 * `and` --- expression operator
+* `application` --- reserved for future use
 * `attr` --- reserved for future use
 * `case` --- language keyword
 * `class` --- language keyword
+* `consumes` --- reserved for future use
 * `default` --- language keyword
 * `define` --- language keyword
 * `else` --- language keyword
@@ -49,6 +51,7 @@ The following words are reserved:
 * `node` --- language keyword
 * `or` --- expression operator
 * `private` --- reserved for future use
+* `produces` --- reserved for future use
 * `true` --- boolean value
 * `type` --- reserved for future use
 * `undef` --- special value

--- a/source/puppet/3.8/reference/lang_reserved.markdown
+++ b/source/puppet/3.8/reference/lang_reserved.markdown
@@ -31,7 +31,7 @@ Several words in the Puppet language are **reserved**. This means they:
 * Cannot be used as names for classes.
 * Cannot be used as names for custom resource types or defined resource types.
 
-> **Note:** As of Puppet 3, reserved words MAY be used as names for attributes in custom resource types. This is a change from the behavior of 2.7 and earlier.
+> **Note:** As of Puppet 3, reserved words _can_ be used as names for attributes in custom resource types. This is a change from the behavior of 2.7 and earlier.
 
 The following words are reserved:
 
@@ -59,6 +59,14 @@ The following words are reserved for future use:
 * `function`
 * `type`
 * `private`
+
+The following words are reserved when using the future parser:
+
+* `application`
+* `consumes`
+* `produces`
+
+As of Puppet 3.8.2, [Puppet warns you](./release_notes.html#deprecation-new-reserved-words) when using `application`, `consumes`, and `produces` with the future parser.
 
 Additionally, you cannot use the name of any existing [resource type][type_ref] or [function][func_ref] as the name of a function, and you cannot use the name of any existing [resource type][type_ref] as the name of a defined type.
 

--- a/source/puppet/4.2/reference/lang_reserved.markdown
+++ b/source/puppet/4.2/reference/lang_reserved.markdown
@@ -33,8 +33,10 @@ Several words in the Puppet language are **reserved**. This means they:
 The following words are reserved:
 
 * `and` --- expression operator
+* `application` --- reserved for future use
 * `attr` --- reserved for future use
 * `case` --- language keyword
+* `consumes` --- reserved for future use
 * `class` --- language keyword
 * `default` --- language keyword
 * `define` --- language keyword
@@ -49,6 +51,7 @@ The following words are reserved:
 * `node` --- language keyword
 * `or` --- expression operator
 * `private` --- reserved for future use
+* `produces` --- reserved for future use
 * `true` --- boolean value
 * `type` --- reserved for future use
 * `undef` --- special value


### PR DESCRIPTION
Document `application`, `consumes`, and `produces` in the 3.8 and 4.2
references. Note in the 3.8 reference that these words are only reserved in
the future parser.