### PR TITLE
Fix paths still pointing to /etc/puppet.

### DIFF
--- a/source/puppet/4.0/reference/upgrade_agent.markdown
+++ b/source/puppet/4.0/reference/upgrade_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/4.0/reference/upgrade_agent.html"
+canonical: "/puppet/latest/reference/upgrade_agent.html"
 ---
 
 This guide will help you update your Puppet 3.x agents to Puppet 4.0.
@@ -30,8 +30,8 @@ upgrade instructions](server_upgrade.markdown) on at least one host so the agent
     `/opt/puppetlabs/bin/puppet agent -tv`
 
 * Ensure that Puppet will continue to run automatically. If you used a cron job to periodically run `puppet agent -t`, 
-make sure you update the path to the binary; if you run puppet as a daemon, ensure it's set to start up on system boot.  
-Here's a handy `puppet resource` command to do just that:
+  make sure you update the path to the binary; if you run puppet as a daemon, ensure it's set to start up on system boot.  
+  Here's a handy `puppet resource` command to do just that:
 
     `/opt/puppetlabs/bin/puppet resource service puppet ensure=running enable=true`
 

--- a/source/puppet/4.1/reference/config_ssl_external_ca.markdown
+++ b/source/puppet/4.1/reference/config_ssl_external_ca.markdown
@@ -5,25 +5,23 @@ canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: /references/3.8.latest/configuration.html#sslclientverifyheader
-[client_header]: /references/3.8.latest/configuration.html#sslclientheader
-[ca_auth]: /references/3.8.latest/configuration.html#sslclientcaauth
+[verify_header]: /references/4.1.latest/configuration.html#sslclientverifyheader
+[client_header]: /references/4.1.latest/configuration.html#sslclientheader
+[ca_auth]: /references/4.1.latest/configuration.html#sslclientcaauth
 [puppetdb]: /puppetdb/latest
 
-In lieu of its built-in CA and PKI tools, Puppet can use an existing external CA for all of its SSL communications.
+In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
-This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please get in touch with Puppet Labs so we can learn more about it.
+This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet Labs so we can learn more about it.
 
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, MAY.
+> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-
-Supported External CA Configurations
------
+## Supported External CA Configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca)  The intermediate
+2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
    CA directly issues SSL certificates; the root CA doesn't.
 3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
     * One intermediate CA issues SSL certificates for Puppet master servers.
@@ -35,19 +33,17 @@ These are fully supported by Puppet Labs, which means:
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
 
 Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
 
-
-General Notes and Requirements
------
+## General Notes and Requirements
 
 ### Rack Webserver is Required
 
 The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
 
-In practice, this means Apache or Nginx.  We fully support any web server that can:
+In practice, this means Apache or Nginx. We fully support any web server that can:
 
 * Terminate SSL
 * Verify the authenticity of a client SSL certificate
@@ -61,47 +57,36 @@ Puppet always expects its SSL credentials to be in `.pem` format.
 
 ### Normal Puppet Master Certificate Requirements Still Apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject CN or as a Subject Alternative Name (DNS).
+Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ### Format of X-Client-DN Request Header
 
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting](/references/3.8.latest/configuration.html#sslclientheader).
+Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
 
 This header should conform to the following specifications:
 
-* The value of the client certificate DN should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by Apache ≥ 2.2's `mod_ssl`) is fully supported.
+* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
 * Alternatively, the value of this request header may be in "OpenSSL" format.
 
 ### Revocation
 
-Certificate revocation list (CRL) checking works in all three supported
-configurations, so long as the CRL file is distributed to the agents and masters
-using an "out of band" process.  Puppet won't automatically update the CRL on any
-of the components in the system.
+Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
 
 #### If Unused:
 
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent.
-Set `certificate_revocation = false` in the
-`[agent]` section of [puppet.conf][conf] on **every agent node.**
+If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
 
 (If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
 
 #### If Used:
 
-If revocation lists **are** being used by the external CA, then the CRL file must
-be manually distributed to **every agent node** as a PEM encoded bundle.  Puppet will not automatically distribute this file.
+If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
 
 To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
-Option 1: Single CA
------
+## Option 1: Single CA
 
-A single CA is the default configuration of Puppet when the internal CA is
-being used.  A single, externally issued CA may also be used in a similar
-manner.
-
-
+When Puppet uses its internal CA, it defaults to a single CA configuration. A single externally issued CA can also be used in a similar manner.
 
                    +------------------------+
                    |                        |
@@ -118,7 +103,6 @@ manner.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
 ### Puppet Master
 
 {% capture master_basic %}
@@ -131,14 +115,16 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-    [master]
-    ca = false
-    certname = <some static string, e.g. 'puppetmaster'>
+~~~
+[master]
+ca = false
+certname = <some static string, e.g. 'puppetmaster'>
+~~~
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
 
-Once this configuration is set, put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                         | File location
 -----------------------------------|-------------------------------------------
@@ -151,54 +137,54 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 With these files in place, the web server should be configured to:
 
-* Use the root CA certificate, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+* Use the root CA certificate, the master's certificate, and the master's key.
+* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
+* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca.pem"
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 1
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 1
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {% capture master_config_ru %}
-The `config.ru` file for rack has no special configuration when using an
-external CA.  Please follow the standard rack documentation for using Puppet
-with rack.  The following example will work with this version of Puppet:
+The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
 
-    ~~~ ruby
-    $0 = "master"
-    ARGV << "--rack"
-    ARGV << "--confdir=/etc/puppet"
-    ARGV << "--vardir=/var/lib/puppet"
-    require 'puppet/util/command_line'
-    run Puppet::Util::CommandLine.new.execute
+~~~ ruby
+$0 = "master"
+ARGV << "--rack"
+ARGV << "--confdir=/etc/puppetlabs/puppet"
+ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
+require 'puppet/util/command_line'
+run Puppet::Util::CommandLine.new.execute
 ~~~
 {% endcapture %}
 
@@ -208,7 +194,7 @@ with rack.  The following example will work with this version of Puppet:
 
 You don't need to change any settings.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
@@ -216,19 +202,14 @@ Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 
-
-
-Option 2: Single Intermediate CA
------
+## Option 2: Single Intermediate CA
 
 The single intermediate CA configuration builds from the single self-signed CA
 configuration and introduces one additional intermediate CA.
 
-
-
                    +------------------------+
                    |                        |
-                   |  self-signed Root CA   |
+                   |  Root self-signed CA   |
                    |                        |
                    +-----------+------------+
                                |
@@ -249,9 +230,7 @@ configuration and introduces one additional intermediate CA.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
-The Root CA does not issue SSL certificates in this configuration.  The
-intermediate CA issues SSL certificates for clients and servers alike.
+The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
 
 ### Puppet Master
 
@@ -259,7 +238,9 @@ intermediate CA issues SSL certificates for clients and servers alike.
 
 You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
 
-    $ cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+~~~ bash
+cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+~~~
 
 Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
 
@@ -271,57 +252,60 @@ With these files in place, the web server should be configured to:
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca_bundle.pem"
-        SSLCertificateChainFile "/path/to/ca_bundle.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca_bundle.pem"
+    SSLCertificateChainFile "/path/to/ca_bundle.pem"
 
-        # Allow only clients with a SSL certificate issued by the intermediate CA with
-        # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-        # intermediate CA certificate.
-        <Location />
-            SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-        </Location>
+    # Allow only clients with a SSL certificate issued by the intermediate CA with
+    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
+    # intermediate CA certificate.
+    <Location />
+        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
+    </Location>
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 2
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
-
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {{ master_config_ru }}
 
 ### Puppet Agent
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its puppet.conf:
+With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
 
-    [agent]
-    ssl_client_ca_auth = $certdir/issuer.pem
+~~~
+[agent]
+ssl_client_ca_auth = $certdir/issuer.pem
+~~~
 
 The value should point to somewhere in the `$certdir`.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|------------------------------------------------
@@ -330,16 +314,11 @@ Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
 
-
-
-Option 3: Two Intermediate CAs Issued by One Root CA
------
+## Option 3: Two Intermediate CAs Issued by One Root CA
 
 This configuration uses different CAs to issue Puppet master certificates and Puppet agent
 certificates. This makes them easily distinguishable, and prevents any agent certificate from being
 usable for a Puppet master.
-
-
 
                    +------------------------+
                    |                        |
@@ -364,10 +343,7 @@ usable for a Puppet master.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
-In this configuration Puppet agents are configured to only authenticate peer
-certificates issued by the Master CA.  Puppet masters are configured to only
-authenticate peer certificates issued by the Agent CA.
+In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
 
 > **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
 
@@ -377,69 +353,74 @@ authenticate peer certificates issued by the Agent CA.
 
 You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
 
-    $ cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
+~~~ bash
+cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
+~~~
 
 Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
 
 With these files in place, the web server should be configured to:
 
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
+* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
+* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-        SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
+    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
 
-        # Allow only clients with a SSL certificate issued by the intermediate CA with
-        # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-        # Agent CA certificate.
-        <Location />
-            SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-        </Location>
+    # Allow only clients with a SSL certificate issued by the intermediate CA with
+    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
+    # Agent CA certificate.
+    <Location />
+        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
+    </Location>
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 2
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
-
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {{ master_config_ru }}
 
 ### Puppet Agent
 
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its puppet.conf:
+With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
 
-    [agent]
-    ssl_client_ca_auth = $certdir/ca_master.pem
+~~~
+[agent]
+ssl_client_ca_auth = $certdir/ca_master.pem
+~~~
 
 The value should point to somewhere in the `$certdir`.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|------------------------------------------------
@@ -447,4 +428,3 @@ Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
-

--- a/source/puppet/4.1/reference/dirs_confdir.markdown
+++ b/source/puppet/4.1/reference/dirs_confdir.markdown
@@ -6,10 +6,7 @@ canonical: "/puppet/latest/reference/dirs_confdir.html"
 
 [listen]: /references/4.1.latest/configuration.html#listen
 
-
-
 Puppet's `confdir` is the main directory for Puppet's configuration. It contains config files and SSL data.
-
 
 ## Location
 

--- a/source/puppet/4.1/reference/dirs_modulepath.markdown
+++ b/source/puppet/4.1/reference/dirs_modulepath.markdown
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
+canonical: "/puppet/latest/reference/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html
@@ -14,45 +15,46 @@ title: "Directories: The Modulepath (Default Config)"
 [puppet.conf]: ./config_file_main.html
 [environment.conf]: ./config_file_environment.html
 
-The Puppet master service and the Puppet apply command both load most of their content from modules. (See the page on [module structure and behavior][module_fundamentals] for more details.)
+The Puppet master service and the `puppet apply` command both load most of their content from modules. (See the page on [module structure and behavior][module_fundamentals] for more details.)
 
 Puppet automatically loads modules from one or more directories. The list of directories Puppet will find modules in is called the **modulepath.**
 
-The modulepath is set by the current node's [environment][].
+The modulepath is set by the current node's [environment][environments].
 
 ## Format
 
 `/etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules`
 
-The modulepath is a list of directories separated by the system _path-separator character._ On \*nix systems this is the colon (`:`, as seen above), and on Windows it is the semi-colon (`;`).
+The modulepath is a list of directories separated by the system _path-separator character._ On \*nix systems, this is the colon (`:`, as seen above), and on Windows it is the semi-colon (`;`).
 
 It is an ordered list, with earlier directories having priority over later ones. See ["Loading Content from Modules"][inpage_loading] below.
-
 
 ## Contents
 
 Every directory in the modulepath should only contain valid Puppet modules.
 
-The names of those modules must only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and will cause errors when attempting to use the module.
+The names of those modules must only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and cause errors when attempting to use the module.
 
 For details about module contents and structure, see [the documentation on modules][module_fundamentals].
 
 ## Location
 
-The modulepath is set by the current node's [environment][]. By default, it will usually be something like:
+The modulepath is set by the current node's [environment][environments]. By default, it is usually be something like:
 
 `<ACTIVE ENVIRONMENT'S MODULES DIRECTORY>:$codedir/modules:/opt/puppetlabs/puppet/modules`
 
 You can view the effective modulepath for any environment by specifying the environment when [requesting the setting value][config_print]:
 
-    $ sudo puppet config print modulepath --section master --environment test
-    /etc/puppet/environments/test/modules:/etc/puppet/modules:/usr/share/puppet/modules
+~~~ bash
+sudo puppet config print modulepath --section master --environment test
+/etc/puppetlabs/code/environments/test/modules:/etc/puppetlabs/code/modules:/usr/share/puppet/modules
+~~~
 
 ## Configuration
 
 Each environment can set its full modulepath in [environment.conf][] with the `modulepath` setting. The default value is that environment's `modules` directory followed by the **base modulepath.**
 
-When running Puppet apply, you also have the option of directly setting `--modulepath` on the command line.
+When running `puppet apply` on the command line, you also have the option of directly setting the modulepath with the `--modulepath` flag.
 
 ### The `modulepath` Setting
 
@@ -60,7 +62,7 @@ The `modulepath` setting can only be set in [environment.conf][]. It configures 
 
 The default value of `modulepath` is `./modules:$basemodulepath`.
 
-Note that the modulepath can include relative paths like `./modules` or `./site`. Puppet will look for these paths inside the environment's directory.
+Note that the modulepath can include relative paths, such as `./modules` or `./site`. Puppet looks for these paths inside the environment's directory.
 
 If you want an environment to have access to the global module directories, it should include `$basemodulepath`.
 
@@ -72,24 +74,23 @@ The default value of the `basemodulepath` setting is `$codedir/modules:/opt/pupp
 
 ### Using `--modulepath`
 
-When using Puppet apply, you can supply a full modulepath as a command line option. This will override the modulepath from the current environment.
-
+When running `puppet apply`, you can supply a full modulepath as a command line option. This overrides the modulepath from the current environment.
 
 ## Loading Content from Modules
 
 [inpage_loading]: #loading-content-from-modules
 
-Puppet will use modules from every directory in the modulepath.
+Puppet uses modules from every directory in the modulepath.
 
 ### Empty and Absent Directories
 
-Directories in the modulepath may be empty, and may even be absent. In both cases, this is not an error; it just means no modules will be loaded from that directory.
+Directories in the modulepath can be empty, and might even be absent. In both cases, this is not an error; it just means Puppet does not load modules from those directories.
 
 If no modules are present across the entire modulepath, or if modules are present but none of them contains a `lib` directory, then Puppet agent will log an error when attempting to sync plugins from the Puppet master. This error is benign and will not prevent the rest of the Puppet run.
 
 ### Duplicate or Conflicting Modules and Content
 
-If the modulepath contains multiple modules with the same name, Puppet will use the version from the directory that comes _earliest_ in the modulepath. This allows directories earlier in the modulepath to override the later directories.
+If the modulepath contains multiple modules with the same name, Puppet uses the version from the directory that comes _earliest_ in the modulepath. This allows directories earlier in the modulepath to override later directories.
 
 For most content, this earliest-module-wins behavior is on an all-or-nothing, **per-module** basis --- **all** of the manifests, files, and templates in the winning version will be available for use, and **none* of that content from any subsequent versions will be available. This behavior covers:
 
@@ -102,12 +103,11 @@ For most content, this earliest-module-wins behavior is on an all-or-nothing, **
 > **However,** Puppet occasionally shows problematic behavior with **Ruby plugins loaded directly from modules.** This includes:
 >
 > - Plugins used by the Puppet master (custom resource types, custom functions)
-> - Plugins used by Puppet apply
+> - Plugins used by `puppet apply`
 > - Plugins that happen to be present in Puppet agent's modulepath (which should generally be empty, but may not be when running Puppet agent on a node that is also a Puppet master server)
 >
 > With these plugins, the earlier module still wins, but the plugins are handled on a **per-file** basis instead of per-module. This means that if a duplicate module in a later directory has **additional** plugin files that don't exist in the winning module, those extra files will be loaded, and Puppet will use a mixture of files from the winning and duplicate modules.
 >
-> The upshot is, if you do a major refactor of the Ruby plugins in some module and then maintain two versions of that module in your modulepath, it can sometimes result in weirdness.
+> The upshot is, if you refactor a module's Ruby plugins and then maintain two versions of that module in your modulepath, it can sometimes result in weirdness.
 >
-> This is essentially the same Ruby loading problem that environments have, [as described elsewhere in this manual.](./environments_limitations.html#plugins-running-on-the-puppet-master-are-weird) It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.
-
+> This is essentially the same Ruby loading problem that environments have, [as described elsewhere in this manual](./environments_limitations.html#plugins-running-on-the-puppet-master-are-weird). It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.

--- a/source/puppet/4.1/reference/lang_classes.markdown
+++ b/source/puppet/4.1/reference/lang_classes.markdown
@@ -36,59 +36,56 @@ canonical: "/puppet/latest/reference/lang_classes.html"
 [declare]: #declaring-classes
 [setting_parameters]: #include-like-vs-resource-like
 [override]: #using-resource-like-declarations
-[ldap_nodes]: http://projects.puppetlabs.com/projects/1/wiki/Ldap_Nodes
+[ldap_nodes]: /guides/ldap_nodes.html
 [hiera]: /hiera/latest
 [external_data]: /hiera/latest/puppet.html
 [array_search]: /hiera/latest/lookup_types.html#array-merge
 [hiera_hierarchy]: /hiera/latest/hierarchy.html
 
-
-
-**Classes** are named blocks of Puppet code, which are stored in [modules][] for later use and are not applied until they are invoked by name. They can be added to a node's [catalog][] by either **declaring** them in your manifests or by **assigning** them from an [ENC][].
+**Classes** are named blocks of Puppet code that are stored in [modules][] for later use and are not applied until they are invoked by name. They can be added to a node's [catalog][] by either **declaring** them in your manifests or **assigning** them from an [ENC][].
 
 Classes generally configure large or medium-sized chunks of functionality, such as all of the packages, config files, and services needed to run an application.
 
-Defining Classes
------
+## Defining Classes
 
 Defining a class makes it available for later use. It doesn't yet add any resources to the catalog; to do that, you must [declare it (see below)][declare] or [assign it from an ENC][enc].
 
 ### Syntax
 
 ~~~ ruby
-    # A class with no parameters
-    class base::linux {
-      file { '/etc/passwd':
-        owner => 'root',
-        group => 'root',
-        mode  => '0644',
-      }
-      file { '/etc/shadow':
-        owner => 'root',
-        group => 'root',
-        mode  => '0440',
-      }
-    }
+# A class with no parameters
+class base::linux {
+  file { '/etc/passwd':
+    owner => 'root',
+    group => 'root',
+    mode  => '0644',
+  }
+  file { '/etc/shadow':
+    owner => 'root',
+    group => 'root',
+    mode  => '0440',
+  }
+}
 ~~~
 
 ~~~ ruby
-    # A class with parameters
-    class apache (String $version = 'latest') {
-      package {'httpd':
-        ensure => $version, # Using the class parameter from above
-        before => File['/etc/httpd.conf'],
-      }
-      file {'/etc/httpd.conf':
-        ensure  => file,
-        owner   => 'httpd',
-        content => template('apache/httpd.conf.erb'), # Template from a module
-      }
-      service {'httpd':
-        ensure    => running,
-        enable    => true,
-        subscribe => File['/etc/httpd.conf'],
-      }
-    }
+# A class with parameters
+class apache (String $version = 'latest') {
+  package {'httpd':
+    ensure => $version, # Using the class parameter from above
+    before => File['/etc/httpd.conf'],
+  }
+  file {'/etc/httpd.conf':
+    ensure  => file,
+    owner   => 'httpd',
+    content => template('apache/httpd.conf.erb'), # Template from a module
+  }
+  service {'httpd':
+    ensure    => running,
+    enable    => true,
+    subscribe => File['/etc/httpd.conf'],
+  }
+}
 ~~~
 
 The general form of a class definition is:
@@ -108,15 +105,13 @@ The general form of a class definition is:
 * A block of arbitrary Puppet code, which generally contains at least one [resource declaration][resource_declaration]
 * A closing curly brace
 
-
 ### Class Parameters and Variables
-
 
 **Parameters** allow a class to request external data. If a class needs to configure itself with data other than [facts][], that data should usually enter the class via a parameter.
 
 Each class parameter can be used as a normal [variable][] inside the class definition. The values of these variables are not set with [normal assignment statements][variable_assignment] or looked up from top or node scope; instead, they are [set based on user input when the class is declared][setting_parameters].
 
-Note that if a class parameter lacks a default value, the user of the module **must** set a value themselves (either in their [external data][external_data] or an [override][]). As such, you should supply defaults wherever possible.
+Note that if a class parameter lacks a default value, the module's user **must** set a value themselves (either in their [external data][external_data] or an [override][]). As such, you should supply defaults wherever possible.
 
 Each parameter can be preceeded by an optional [**data type**][literal_types]. If you include one, Puppet will check the parameter's value at runtime to make sure that it has the right data type, and raise an error if the value is illegal. If no data type is provided, the parameter will accept values of any data type.
 
@@ -128,7 +123,7 @@ Class definitions should be stored in [modules][]. Puppet is **automatically awa
 
 Classes should be stored in their module's `manifests/` directory as one class per file, and each filename should reflect the name of its class; see [Module Fundamentals][modules] and [Namespaces and Autoloading][namespace] for more details.
 
-A class definition statement isn't an expression, and can't be used where a value is expected.
+A class definition statement isn't an expression and can't be used where a value is expected.
 
 > #### Other Locations
 >
@@ -138,21 +133,19 @@ A class definition statement isn't an expression, and can't be used where a valu
 > * A file in the same module whose corresponding class name is a truncated version of this class's name. That is, the class `first::second::third` could be put in `first::second`'s file, `first/manifests/second.pp`.
 > * Lexically inside another class definition. This puts the interior class under the exterior class's [namespace][], causing its real name to be something other than the name with which it was defined. (For example: in `class first { class second { ... } }`, the interior class's real name is `first::second`.) Note that this doesn't cause the interior class to be automatically declared along with the exterior class.
 >
-> Again: You should basically never do these.
-
-
+> Again: You should never do these.
 
 ### Containment
 
 A class [contains][] all of its resources. This means any [relationships][] formed with the class as a whole will be extended to every resource in the class.
 
-Classes can also contain other classes, but _you must manually specify that a class should be contained._ For details, [see the "Containing Classes" section of the Containment page.][contain_classes]
+Classes can also contain other classes, but _you must manually specify that a class should be contained._ For details, [see the "Containing Classes" section of the Containment page][contain_classes].
 
 A contained class is automatically [tagged][tags] with the name of its container.
 
 ### Auto-Tagging
 
-Every resource in a class gets automatically [tagged][tags] with the class's name (and each of its [namespace segments][namespace]).
+Every resource in a class gets automatically [tagged][tags] with the class's name and each of its [namespace segments][namespace].
 
 ### Inheritance
 
@@ -166,14 +159,14 @@ Inheritance causes three things to happen:
 * The base class becomes the [parent scope][parent_scope] of the derived class, so that the new class receives a copy of all of the base class's variables and resource defaults.
 * Code in the derived class is given special permission to override any resource attributes that were set in the base class.
 
-> #### Aside: When to Inherit
+> **Aside: When to Inherit**
 >
 > Class inheritance should be used **very sparingly,** generally only in the following situations:
 >
 > * When you need to override resource attributes in the base class.
 > * To let a "params class" provide default values for another class's parameters:
 >
->       class example (String $my_param = $example::params::myparam) inherits example::params { ... }
+> `class example (String $my_param = $example::params::myparam) inherits example::params { ... }`
 >
 >   This pattern works by guaranteeing that the params class is evaluated before Puppet attempts to evaluate the main class's parameter list. It is especially useful when you want your default values to change based on system facts and other data, since it lets you isolate and encapsulate all that conditional logic.
 >
@@ -186,14 +179,14 @@ Inheritance causes three things to happen:
 The attributes of any resource in the base class can be overridden with a [reference][resource_reference] to the resource you wish to override, followed by a set of curly braces containing attribute => value pairs:
 
 ~~~ ruby
-    class base::freebsd inherits base::unix {
-      File['/etc/passwd'] {
-        group => 'wheel'
-      }
-      File['/etc/shadow'] {
-        group => 'wheel'
-      }
-    }
+class base::freebsd inherits base::unix {
+  File['/etc/passwd'] {
+    group => 'wheel'
+  }
+  File['/etc/shadow'] {
+    group => 'wheel'
+  }
+}
 ~~~
 
 This is identical to the syntax for [adding attributes to an existing resource][add_attribute], but in a derived class, it gains the ability to rewrite resources instead of just adding to them. Note that you can also use [multi-resource references][multi_ref] here.
@@ -201,11 +194,11 @@ This is identical to the syntax for [adding attributes to an existing resource][
 You can remove an attribute's previous value without setting a new one by overriding it with the special value [`undef`][undef]:
 
 ~~~ ruby
-    class base::freebsd inherits base::unix {
-      File['/etc/passwd'] {
-        group => undef,
-      }
-    }
+class base::freebsd inherits base::unix {
+  File['/etc/passwd'] {
+    group => undef,
+  }
+}
 ~~~
 
 This causes the attribute to be unmanaged by Puppet.
@@ -214,29 +207,26 @@ This causes the attribute to be unmanaged by Puppet.
 
 #### Appending to Resource Attributes
 
-Some resource attributes (such as the [relationship metaparameters][relationships]) can accept multiple values in an array. When overriding attributes in a derived class, you can add to the existing values instead of replacing them by using the `+>` ("plusignment") keyword instead of the standard `=>` hash rocket:
+Some resource attributes, such as the [relationship metaparameters][relationships], can accept multiple values in an array. When overriding attributes in a derived class, you can add to the existing values instead of replacing them by using the `+>` ("plusignment") keyword instead of the standard `=>` hash rocket:
 
 ~~~ ruby
-    class apache {
-      service {'apache':
-        require => Package['httpd'],
-      }
-    }
+class apache {
+  service {'apache':
+    require => Package['httpd'],
+  }
+}
 
-    class apache::ssl inherits apache {
-      # host certificate is required for SSL to function
-      Service['apache'] {
-        require +> [ File['apache.pem'], File['httpd.conf'] ],
-        # Since `require` will retain its previous values, this is equivalent to:
-        # require => [ Package['httpd'], File['apache.pem'], File['httpd.conf'] ],
-      }
-    }
+class apache::ssl inherits apache {
+  # host certificate is required for SSL to function
+  Service['apache'] {
+    require +> [ File['apache.pem'], File['httpd.conf'] ],
+    # Since `require` will retain its previous values, this is equivalent to:
+    # require => [ Package['httpd'], File['apache.pem'], File['httpd.conf'] ],
+  }
+}
 ~~~
 
-
-
-Declaring Classes
------
+## Declaring Classes
 
 **Declaring** a class in a Puppet manifest adds all of its resources to the catalog. You can declare classes in [node definitions][node], at top scope in the [site manifest][sitedotpp], and in other classes or [defined types][definedtype]. Declaring classes isn't the only way to add them to the catalog; you can also [assign classes to nodes with an ENC](#assigning-classes-from-an-enc).
 
@@ -277,21 +267,20 @@ Resource-like class declarations require that you **only declare a given class o
 >
 > This was the original reason for adding external data bindings to include-like declarations: since external data is set **before** compile-time and has a **fixed hierarchy,** the compiler can safely rely on it without risk of conflicts.
 
-
 ### Using `include`
 
 The `include` [function][] is the standard way to declare classes.
 
 ~~~ ruby
-    include base::linux
-    include base::linux # no additional effect; the class is only declared once
+include base::linux
+include base::linux # no additional effect; the class is only declared once
 
-    include Class['base::linux'] # including a class reference
+include Class['base::linux'] # including a class reference
 
-    include base::linux, apache # including a list
+include base::linux, apache # including a list
 
-    $my_classes = ['base::linux', 'apache']
-    include $my_classes # including an array
+$my_classes = ['base::linux', 'apache']
+include $my_classes # including an array
 ~~~
 
 The `include` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It can accept:
@@ -305,10 +294,10 @@ The `include` function uses [include-like behavior][include-like]. (Multiple dec
 The `require` function (not to be confused with the [`require` metaparameter][relationships]) declares one or more classes, then causes them to become a [dependency][relationships] of the surrounding container.
 
 ~~~ ruby
-    define apache::vhost (Integer $port, String $docroot, String $servername, String $vhost_name) {
-      require apache
-      ...
-    }
+define apache::vhost (Integer $port, String $docroot, String $servername, String $vhost_name) {
+  require apache
+  ...
+}
 ~~~
 
 In the above example, Puppet will ensure that every resource in the `apache` class gets applied before every resource in **any** `apache::vhost` instance.
@@ -324,17 +313,17 @@ The `require` function uses [include-like behavior][include-like]. (Multiple dec
 The `contain` function is meant to be used _inside another class definition._ It declares one or more classes, then causes them to become [contained][contains] by the surrounding class. For details, [see the "Containing Classes" section of the Containment page.][contain_classes]
 
 ~~~ ruby
-    class ntp {
-      file { '/etc/ntp.conf':
-        ...
-        require => Package['ntp'],
-        notify  => Class['ntp::service'],
-      }
-      contain ntp::service
-      package { 'ntp':
-        ...
-      }
-    }
+class ntp {
+  file { '/etc/ntp.conf':
+    ...
+    require => Package['ntp'],
+    notify  => Class['ntp::service'],
+  }
+  contain ntp::service
+  package { 'ntp':
+    ...
+  }
+}
 ~~~
 
 In the above example, any resource that forms a `before` or `require` relationship with class `ntp` will also be applied before or after class `ntp::service`, respectively.
@@ -349,30 +338,32 @@ The `contain` function uses [include-like behavior][include-like]. (Multiple dec
 
 The `hiera_include` function requests a list of class names from [Hiera][], then declares all of them. Since it uses the [array lookup type][array_search], it will get a combined list that includes classes from **every level** of the [hierarchy][hiera_hierarchy]. This allows you to abandon [node definitions][node] and use Hiera like a lightweight ENC.
 
-    # /etc/puppetlabs/puppet/hiera.yaml
-    ...
-    hierarchy:
-      - "%{::clientcert}"
-      - common
+~~~ yaml
+# /etc/puppetlabs/code/hiera.yaml
+...
+hierarchy:
+  - "%{::clientcert}"
+  - common
 
-    # /etc/puppetlabs/puppet/hieradata/web01.example.com.yaml
-    ---
-    classes:
-      - apache
-      - memcached
-      - wordpress
+# /etc/puppetlabs/code/hieradata/web01.example.com.yaml
+---
+classes:
+  - apache
+  - memcached
+  - wordpress
 
-    # /etc/puppetlabs/puppet/hieradata/common.yaml
-    ---
-    classes:
-      - base::linux
-
-~~~ ruby
-    # /etc/puppetlabs/puppet/manifests/site.pp
-    hiera_include(classes)
+# /etc/puppetlabs/code/hieradata/common.yaml
+---
+classes:
+  - base::linux
 ~~~
 
-On the node `web01.example.com`, the example above would declare the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only declare `base::linux`.
+~~~ ruby
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
+hiera_include(classes)
+~~~
+
+On the node `web01.example.com` in the production environment, the example above would declare the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only declare `base::linux`.
 
 The `hiera_include` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It accepts a single lookup key.
 
@@ -381,12 +372,12 @@ The `hiera_include` function uses [include-like behavior][include-like]. (Multip
 Resource-like declarations look like [normal resource declarations][resource_declaration], using the special `class` pseudo-resource type.
 
 ~~~ ruby
-    # Overriding a parameter:
-    class {'apache':
-      version => '2.2.21',
-    }
-    # Declaring a class with no parameters:
-    class {'base::linux':}
+# Specifying the "version" parameter:
+class {'apache':
+  version => '2.2.21',
+}
+# Declaring a class with no parameters:
+class {'base::linux':}
 ~~~
 
 Resource-like declarations use [resource-like behavior][resource-like]. (Multiple declarations prohibited; parameters can be overridden at compile-time.) You can provide a value for any class parameter by specifying it as resource attribute; any parameters not specified will follow the normal external/default/fail lookup path.
@@ -394,10 +385,10 @@ Resource-like declarations use [resource-like behavior][resource-like]. (Multipl
 In addition to class-specific parameters, you can also specify a value for any [metaparameter][metaparameters]. In such cases, every resource contained in the class will also have that metaparameter:
 
 ~~~ ruby
-    # Cause the entire class to be noop:
-    class {'apache':
-      noop => true,
-    }
+# Cause the entire class to be noop:
+class {'apache':
+  noop => true,
+}
 ~~~
 
 However, note that:
@@ -405,51 +396,45 @@ However, note that:
 * Any resource can specifically override metaparameter values received from its container.
 * Metaparameters which can take more than one value (like the [relationship][relationships] metaparameters) will merge the values from the container and any resource-specific values.
 
-
-
-Assigning Classes From an ENC
------
+## Assigning Classes From an ENC
 
 Classes can also be assigned to nodes by [external node classifiers][enc] and [LDAP node data][ldap_nodes]. Note that most ENCs assign classes with include-like behavior, and some ENCs assign them with resource-like behavior. See the [documentation of the ENC interface][enc] or the documentation of your specific ENC for complete details.
 
-
-
-Appendix: Smart Parameter Defaults
-------------------------------------
+## Appendix: Smart Parameter Defaults
 
 This design pattern can make for significantly cleaner code while enabling some really sophisticated behavior around default values.
 
 ~~~ ruby
-    # /etc/puppet/modules/webserver/manifests/params.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/params.pp
 
-    class webserver::params {
-      $packages = $operatingsystem ? {
-        /(?i-mx:ubuntu|debian)/        => 'apache2',
-        /(?i-mx:centos|fedora|redhat)/ => 'httpd',
-      }
-      $vhost_dir = $operatingsystem ? {
-        /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
-        /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
-      }
-    }
+class webserver::params {
+  $packages = $operatingsystem ? {
+    /(?i-mx:ubuntu|debian)/        => 'apache2',
+    /(?i-mx:centos|fedora|redhat)/ => 'httpd',
+  }
+  $vhost_dir = $operatingsystem ? {
+    /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
+    /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
+  }
+}
 
-    # /etc/puppet/modules/webserver/manifests/init.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/init.pp
 
-    class webserver(
-      String $packages  = $webserver::params::packages,
-      String $vhost_dir = $webserver::params::vhost_dir
-    ) inherits webserver::params {
+class webserver(
+  String $packages  = $webserver::params::packages,
+  String $vhost_dir = $webserver::params::vhost_dir
+) inherits webserver::params {
 
-     package { $packages: ensure => present }
+ package { $packages: ensure => present }
 
-     file { 'vhost_dir':
-       path   => $vhost_dir,
-       ensure => directory,
-       mode   => '0750',
-       owner  => 'www-data',
-       group  => 'root',
-     }
-    }
+ file { 'vhost_dir':
+   path   => $vhost_dir,
+   ensure => directory,
+   mode   => '0750',
+   owner  => 'www-data',
+   group  => 'root',
+ }
+}
 ~~~
 
 To summarize what's happening here: When a class inherits from another class, it implicitly declares the base class. Since the base class's local scope already exists before the new class's parameters get declared, those parameters can be set based on information in the base class.
@@ -457,40 +442,40 @@ To summarize what's happening here: When a class inherits from another class, it
 This is functionally equivalent to doing the following:
 
 ~~~ ruby
-    # /etc/puppet/modules/webserver/manifests/init.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/init.pp
 
-    class webserver(String $packages = 'UNSET', String $vhost_dir = 'UNSET' ) {
+class webserver(String $packages = 'UNSET', String $vhost_dir = 'UNSET' ) {
 
-     if $packages == 'UNSET' {
-       $real_packages = $operatingsystem ? {
-         /(?i-mx:ubuntu|debian)/        => 'apache2',
-         /(?i-mx:centos|fedora|redhat)/ => 'httpd',
-       }
-     }
-     else {
-        $real_packages = $packages
-     }
-
-     if $vhost_dir == 'UNSET' {
-       $real_vhost_dir = $operatingsystem ? {
-         /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
-         /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
-       }
-     }
-     else {
-        $real_vhost_dir = $vhost_dir
+  if $packages == 'UNSET' {
+    $real_packages = $operatingsystem ? {
+      /(?i-mx:ubuntu|debian)/        => 'apache2',
+      /(?i-mx:centos|fedora|redhat)/ => 'httpd',
     }
+  }
+  else {
+     $real_packages = $packages
+  }
 
-     package { $real_packages: ensure => present }
-
-     file { 'vhost_dir':
-       path   => $real_vhost_dir,
-       ensure => directory,
-       mode   => '0750',
-       owner  => 'www-data',
-       group  => 'root',
-     }
+  if $vhost_dir == 'UNSET' {
+    $real_vhost_dir = $operatingsystem ? {
+      /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
+      /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
     }
+  }
+  else {
+     $real_vhost_dir = $vhost_dir
+  }
+
+  package { $real_packages: ensure => present }
+
+  file { 'vhost_dir':
+    path   => $real_vhost_dir,
+    ensure => directory,
+    mode   => '0750',
+    owner  => 'www-data',
+    group  => 'root',
+  }
+}
 ~~~
 
-... but it's a significant readability win, especially if the amount of logic or the number of parameters gets any higher than what's shown in the example.
+This is a significant readability win, especially if the amount of logic or the number of parameters grows beyond what's shown in the example.

--- a/source/puppet/4.1/reference/lang_scope.markdown
+++ b/source/puppet/4.1/reference/lang_scope.markdown
@@ -20,12 +20,11 @@ canonical: "/puppet/latest/reference/lang_scope.html"
 [diagram]: ./images/scope-euler-diagram.png
 [lambda]: ./lang_lambdas.html
 
-Scope Basics
------
+## Scope Basics
 
-A **scope** is a specific **area of code,** which is partially isolated from other areas of code. Scopes limit the reach of:
+A **scope** is a specific **area of code** that is partially isolated from other areas of code. Scopes limit the reach of:
 
-* [Variables][]
+* [Variables][variables]
 * [Resource defaults][resourcedefaults]
 
 Scopes **do not** limit the reach of:
@@ -37,7 +36,7 @@ Scopes **do not** limit the reach of:
 
 ![An Euler diagram of several scopes. Top scope contains node scope, which contains the example::other, example::four, and example::parent scopes. Example::parent contains the example::child scope.][diagram]
 
-Any given scope has access to its own contents, and also receives additional contents from its **parent scope,** from node scope, and from top scope. (The rules for how Puppet determines a local scope's parent are described below in [Scope Lookup Rules.][scope_lookup_rules])
+Any given scope has access to its own contents, and also receives additional contents from its **parent scope,** node scope, and top scope. (The rules for how Puppet determines a local scope's parent are described below in [Scope Lookup Rules][scope_lookup_rules].)
 
 In the diagram above:
 
@@ -46,24 +45,25 @@ In the diagram above:
 * Each of the `example::parent, example::other`, and `example::four` classes can access variables and defaults from their own scope, node scope, and top scope.
 * The `example::child` class can access variables and defaults from its own scope, `example::parent`'s scope, node scope, and top scope.
 
-
 ### Top Scope
 
 Code that is _outside_ any class definition, type definition, or node definition exists at **top scope.** Variables and defaults declared at top scope are available **everywhere.**
 
 ~~~ ruby
-    # site.pp
-    $variable = "Hi!"
+# site.pp
+$variable = "Hi!"
 
-    class example {
-      notify {"Message from elsewhere: $variable":}
-    }
+class example {
+  notify {"Message from elsewhere: $variable":}
+}
 
-    include example
+include example
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from elsewhere: Hi!
+~~~
+$ puppet apply site.pp
+notice: Message from elsewhere: Hi!
+~~~
 
 ### Node Scope
 
@@ -71,23 +71,25 @@ Code inside a [node definition][node] exists at **node scope.** Note that since 
 
 Variables and defaults declared at node scope are available **everywhere except top scope.**
 
-> Note: Classes and resources declared at top scope **bypass node scope entirely,** and so cannot access variables or defaults from node scope.
+> **Note:** Classes and resources declared at top scope **bypass node scope entirely,** and so cannot access variables or defaults from node scope.
 
 ~~~ ruby
-    # site.pp
-    $top_variable = "Available!"
-    node 'puppet.example.com' {
-      $variable = "Hi!"
-      notify {"Message from here: $variable":}
-      notify {"Top scope: $top_variable":}
-    }
-    notify {"Message from top scope: $variable":}
+# site.pp
+$top_variable = "Available!"
+node 'puppet.example.com' {
+  $variable = "Hi!"
+  notify {"Message from here: $variable":}
+  notify {"Top scope: $top_variable":}
+}
+notify {"Message from top scope: $variable":}
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi!
-    notice: Top scope: Available!
-    notice: Message from top scope:
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi!
+notice: Top scope: Available!
+notice: Message from top scope:
+~~~
 
 In this example, node scope can access top scope variables, but not vice-versa.
 
@@ -98,78 +100,80 @@ Code inside a [class definition][class], [defined type][definedtype], or [lambda
 Variables and defaults declared in a local scope are only available in **that scope and its children.** There are two different sets of rules for when scopes are considered related; see "[scope lookup rules](#scope-lookup-rules)" below.
 
 ~~~ ruby
-    # /etc/puppet/modules/scope_example/manifests/init.pp
-    class scope_example {
-      $variable = "Hi!"
-      notify {"Message from here: $variable":}
-      notify {"Node scope: $node_variable Top scope: $top_variable":}
-    }
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
+class scope_example {
+  $variable = "Hi!"
+  notify {"Message from here: $variable":}
+  notify {"Node scope: $node_variable Top scope: $top_variable":}
+}
 
-    # /etc/puppet/manifests/site.pp
-    $top_variable = "Available!"
-    node 'puppet.example.com' {
-      $node_variable = "Available!"
-      include scope_example
-      notify {"Message from node scope: $variable":}
-    }
-    notify {"Message from top scope: $variable":}
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
+$top_variable = "Available!"
+node 'puppet.example.com' {
+  $node_variable = "Available!"
+  include scope_example
+  notify {"Message from node scope: $variable":}
+}
+notify {"Message from top scope: $variable":}
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi!
-    notice: Node scope: Available! Top scope: Available!
-    notice: Message from node scope:
-    notice: Message from top scope:
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi!
+notice: Node scope: Available! Top scope: Available!
+notice: Message from node scope:
+notice: Message from top scope:
+~~~
 
 In this example, a local scope can see "out" into node and top scope, but outer scopes cannot see "in."
-
 
 ### Overriding Received Values
 
 Variables and defaults declared at node scope can override those received from top scope. Those declared at local scope can override those received from node and top scope, as well as any parent scopes. That is: if multiple variables with the same name are available, **Puppet will use the "most local" one.**
 
 ~~~ ruby
-    # /etc/puppet/modules/scope_example/manifests/init.pp
-    class scope_example {
-      $variable = "Hi, I'm local!"
-      notify {"Message from here: $variable":}
-    }
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
+class scope_example {
+  $variable = "Hi, I'm local!"
+  notify {"Message from here: $variable":}
+}
 
-    # /etc/puppet/manifests/site.pp
-    $variable = "Hi, I'm top!"
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
+$variable = "Hi, I'm top!"
 
-    node 'puppet.example.com' {
-      $variable = "Hi, I'm node!"
-      include scope_example
-    }
+node 'puppet.example.com' {
+  $variable = "Hi, I'm node!"
+  include scope_example
+}
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi, I'm local!
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi, I'm local!
+~~~
 
 Resource defaults are processed **by attribute** rather than as a block. Thus, defaults that declare different attributes will be merged, and only the attributes that conflict will be overridden.
 
 ~~~ ruby
-    # /etc/puppet/modules/scope_example/manifests/init.pp
-    class scope_example {
-      File { ensure => directory, }
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
+class scope_example {
+  File { ensure => directory, }
 
-      file {'/tmp/example':}
-    }
+  file {'/tmp/example':}
+}
 
-    # /etc/puppet/manifests/site.pp
-    File {
-      ensure => file,
-      owner  => 'puppet',
-    }
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
+File {
+  ensure => file,
+  owner  => 'puppet',
+}
 
-    include scope_example
+include scope_example
 ~~~
 
 In this example, `/tmp/example` would be a directory owned by the `puppet` user, and would combine the defaults from top and local scope.
 
-More Details
------
+## More Details
 
 ### Scope of External Node Classifier Data
 
@@ -178,7 +182,7 @@ More Details
 
 This gives approximately the best and most-expected behavior --- variables from an ENC are available everywhere, and classes may use node-specific variables.
 
-> Note: this means compilation will fail if the site manifest tries to set a variable that was already set at top scope by an ENC.
+> **Note:** this means compilation will fail if the site manifest tries to set a variable that was already set at top scope by an ENC.
 
 ### Named Scopes and Anonymous Scopes
 
@@ -195,24 +199,22 @@ Qualified variable names are formatted as follows, using the double-colon [names
 `$<NAME OF SCOPE>::<NAME OF VARIABLE>`
 
 ~~~ ruby
-    include apache::params
-    $local_copy = $apache::params::confdir
+include apache::params
+$local_copy = $apache::params::confdir
 ~~~
 
 This example would set the variable `$local_copy` to the value of the `$confdir` variable from the `apache::params` class.
 
-> Notes:
+> **Notes:**
 >
 > * Remember that top scope's name is the empty string. Thus, `$::my_variable` would always refer to the top-scope value of `$my_variable`, even if `$my_variable` has a different value in local scope.
 > * Note that a class must be [declared][declare_class] in order to access its variables; simply having the class available in your modules is insufficient.
 >
->   This means the availability of out-of-scope variables is **evaluation order dependent.** You should only access out-of-scope variables if the class accessing them can guarantee that the other class is already declared, usually by explicitly declaring it with `include` before trying to read its variables.
+> This means the availability of out-of-scope variables is **evaluation order dependent.** You should only access out-of-scope variables if the class accessing them can guarantee that the other class is already declared, usually by explicitly declaring it with `include` before trying to read its variables.
 
 Variables declared in **anonymous scopes** can only be accessed normally and do not have global qualified names.
 
-
-Scope Lookup Rules
------
+## Scope Lookup Rules
 
 [scope_lookup_rules]: #scope-lookup-rules
 
@@ -228,7 +230,7 @@ There are two different sets of scope lookup rules: **static scope** and **dynam
 In **static scope,** parent scopes are only assigned in the following ways:
 
 * Classes can receive parent scopes by [class inheritance][inheritance], using the `inherits` keyword. Any derived class receives the contents of its base class in addition to the contents of node and top scope.
-* A [lambda][]'s parent scope is the local scope in which the lambda is written. It can access variables in that scope by their short names.
+* A [lambda's][lambda] parent scope is the local scope in which the lambda is written. It can access variables in that scope by their short names.
 
 **All other** local scopes have no parents --- they only receive their own contents, and the contents of node scope (if applicable) and top scope.
 
@@ -256,8 +258,7 @@ In **dynamic scope,** parent scopes are assigned by both **inheritance** and **d
 
 This version of Puppet uses dynamic scope only for resource defaults.
 
-Messy Under-the-Hood Details
------
+## Messy Under-the-Hood Details
 
 * Node scope only exists if there is at least one node definition in the main manifest. If no node definitions exist, then ENC classes get declared at top scope.
 * Although top scope and node scope are described above as being special scopes, they are actually implemented as part of the chain of parent scopes, with node scope being a child of top scope and the parent of any classes declared inside the node definition. However, since the move to static scoping causes them to behave as little islands of dynamic scoping in a statically scoped world, it's simpler to think of them as special cases.

--- a/source/puppet/4.1/reference/lang_summary.markdown
+++ b/source/puppet/4.1/reference/lang_summary.markdown
@@ -34,8 +34,7 @@ Puppet uses its own configuration language, which was designed to be accessible 
 
 > To see how the Puppet language's features have evolved over time, see [History of the Puppet Language](/guides/language_history.html).
 
-Resources, Classes, and Nodes
------
+## Resources, Classes, and Nodes
 
 The core of the Puppet language is **declaring [resources][].** Every other part of the language exists to add flexibility and convenience to the way resources are declared.
 
@@ -43,16 +42,13 @@ Groups of resources can be organized into **[classes][],** which are larger unit
 
 Nodes that serve different roles will generally get different sets of classes. The task of configuring which classes will be applied to a given node is called **node classification.**  Nodes can be classified in the Puppet language using [node definitions][node]; they can also be classified using node-specific data from outside your manifests, such as that from an [ENC][] or [Hiera][].
 
-
-Ordering
------
+## Ordering
 
 Although Puppet's language is built around describing resources (and the relationships between them) in a declarative way, several parts of the language do depend on evaluation order. The most notable of these are variables, which must be set before they are referenced.
 
 In the rest of this document, we try to call out areas where the order of statements matters.
 
-Files
------
+## Files
 
 Puppet language files are called **manifests,** and are named with the `.pp` file extension. Manifest files:
 
@@ -73,11 +69,9 @@ Windows uses CRLF line endings instead of \*nix's LF line endings.
 * If a file is being downloaded to a Windows node with the `source` attribute, Puppet will transfer the file in "binary" mode, leaving the original newlines untouched.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](/references/4.1.latest/type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
-    > Note: When writing your own resource types, you can get this behavior by using the `flat` filetype.
+> **Note:** When writing your own resource types, you can get this behavior by using the `flat` filetype.
 
-
-Compilation and Catalogs
------
+## Compilation and Catalogs
 
 Puppet manifests can use conditional logic to describe many nodes' configurations at once. Before configuring a node, Puppet compiles manifests into a **catalog,** which is only valid for a single node and which contains no ambiguous logic.
 
@@ -89,39 +83,33 @@ Agent nodes cache their most recent catalog. If they request a catalog and the m
 
 For more information, see [the reference page on catalog compilation][compilation].
 
-
-Example
------
+## Example
 
 The following short manifest manages NTP. It uses [package][], [file][], and [service][] resources; a [case statement][case] based on a [fact][]; [variables][]; [ordering][] and [notification][] relationships; and [file contents being served from a module][fileserve].
 
 ~~~ ruby
-    case $operatingsystem {
-      centos, redhat: { $service_name = 'ntpd' }
-      debian, ubuntu: { $service_name = 'ntp' }
-    }
+case $operatingsystem {
+  centos, redhat: { $service_name = 'ntpd' }
+  debian, ubuntu: { $service_name = 'ntp' }
+}
 
-    package { 'ntp':
-      ensure => installed,
-    }
+package { 'ntp':
+  ensure => installed,
+}
 
-    service { 'ntp':
-      name      => $service_name,
-      ensure    => running,
-      enable    => true,
-      subscribe => File['ntp.conf'],
-    }
+service { 'ntp':
+  name      => $service_name,
+  ensure    => running,
+  enable    => true,
+  subscribe => File['ntp.conf'],
+}
 
-    file { 'ntp.conf':
-      path    => '/etc/ntp.conf',
-      ensure  => file,
-      require => Package['ntp'],
-      source  => "puppet:///modules/ntp/ntp.conf",
-      # This source file would be located on the Puppet master at
-      # /etc/puppetlabs/puppet/modules/ntp/files/ntp.conf (in Puppet Enterprise)
-      # or
-      # /etc/puppet/modules/ntp/files/ntp.conf (in open source Puppet)
-    }
+file { 'ntp.conf':
+  path    => '/etc/ntp.conf',
+  ensure  => file,
+  require => Package['ntp'],
+  source  => "puppet:///modules/ntp/ntp.conf",
+  # This source file would be located on the Puppet master at
+  # /etc/puppetlabs/code/modules/ntp/files/ntp.conf
+}
 ~~~
-
-

--- a/source/puppet/4.1/reference/modules_installing.markdown
+++ b/source/puppet/4.1/reference/modules_installing.markdown
@@ -4,7 +4,7 @@ title: "Installing Modules"
 canonical: "/puppet/latest/reference/modules_installing.html"
 ---
 
-[forge]: http://forge.puppetlabs.com
+[forge]: https://forge.puppetlabs.com
 [module_man]: /references/4.1.latest/man/module.html
 [modulepath]: /references/4.1.latest/configuration.html#modulepath
 
@@ -12,22 +12,20 @@ canonical: "/puppet/latest/reference/modules_installing.html"
 [fundamentals]: ./modules_fundamentals.html
 [plugins]: /guides/plugins_in_modules.html
 [documentation]: ./modules_documentation.html
-[errors]: https://docs.puppetlabs.com/windows/troubleshooting.html#error-messages
+[errors]: /windows/troubleshooting.html#error-messages
 
-Installing Modules
-=====
->**Puppet Enterprise Users Note**
->For a complete guide to installing and managing modules, you'll need to go to the [Installing Modules page](https://docs.puppetlabs.com/pe/3.8/modules_installing.html)
+> **Puppet Enterprise Users Note**
 >
+> For a complete guide to installing and managing modules, please see the [Installing Modules page](/pe/2015.2/modules_installing.html).
 
 ![Windows note](/images/windows-logo-small.jpg)
 
 * Windows nodes that pull configurations from a Linux or Unix Puppet master can use any Forge modules installed on the master. Continue reading to learn how to use the module tool on your Puppet master.
 * If you are getting SSL errors or cannot get the Puppet module tool to work, check out our [error messages documentation][errors].
 
->**Solaris Note**
+> **Solaris Note**
 >
->To use the Puppet module tool on Solaris systems, you must first install gtar.
+> To use the Puppet module tool on Solaris systems, you must first install gtar.
 
 The [Puppet Forge][forge] (Forge) is a repository of pre-existing modules, written and contributed by users. These modules solve a wide variety of problems, so using them can save you time and effort.
 
@@ -39,136 +37,147 @@ The `puppet module` subcommand is a tool for finding and managing new modules fr
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
+## Using the Module Tool
 
-Using the Module Tool
------
+The `puppet module` subcommand has several _actions._ The main actions used for managing modules are `install`, `list`, `search`, `uninstall`, and `upgrade`.
 
-The `puppet module` subcommand has several *actions.* The main actions used for managing modules are:
+If you have used a command line package manager tool (like `gem`, `apt-get`, or `yum`) before, these actions will generally do what you expect. You can view a full description of each action with `puppet man module` or by [viewing the man page here][module_man]. In short:
 
-`install`
-: Install a module from the Forge or a release archive.
+#### `install`
 
-      # puppet module install puppetlabs-apache --version 0.0.2
+Install a module from the Forge or a release archive.
 
-`list`
-: List installed modules.
+~~~ bash
+sudo puppet module install puppetlabs-apache --version 0.0.2
+~~~
 
-      # puppet module list
+#### `list`
 
-`search`
-: Search the Forge for a module.
+List installed modules.
 
-      # puppet module search apache
+~~~ bash
+sudo puppet module list
+~~~
 
-`uninstall`
-: Uninstall a Puppet module.
+#### `search`
 
-      # puppet module uninstall puppetlabs-apache
+Search the Forge for a module.
 
-`upgrade`
-: Upgrade a Puppet module.
+~~~ bash
+sudo puppet module search apache
+~~~
 
-      # puppet module upgrade puppetlabs-apache --version 0.0.3
+#### `uninstall`
 
-If you have used a command line package manager tool (like `gem`, `apt-get`, or `yum`) before, these actions will generally do what you expect. You can view a full description of each action with `puppet man module` or by [viewing the man page here][module_man].
+Uninstall a Puppet module.
 
-###Using the Module Tool Behind a Proxy
+~~~ bash
+sudo puppet module uninstall puppetlabs-apache
+~~~
+
+#### `upgrade`
+
+Upgrade a Puppet module.
+
+~~~ bash
+sudo puppet module upgrade puppetlabs-apache --version 0.0.3
+~~~
+
+## Using the Module Tool Behind a Proxy
 
 In order to use the Puppet module tool behind a proxy, you need to set the following:
 
-	export http_proxy=http://10.187.255.9:8080
-	export https_proxy=http://10.187.255.9:8080
+~~~
+export http_proxy=http://10.187.255.9:8080
+export https_proxy=http://10.187.255.9:8080
+~~~
 
 Alternatively, you can set these two proxy settings inside the `user` config section in the `puppet.conf` file: `http_proxy_host` and `http_proxy_port`. For more information, see [Configuration Reference](/references/4.1.latest/configuration.html).
 
-**Note:** Make sure to set these two proxy settings in the `user` section only. Otherwise, there can be adverse effects.
+> **Note:** Make sure to set these two proxy settings in the `user` section only. Otherwise, there can be adverse effects.
 
-Installing Modules
------
+## Installing Modules
 
-The `puppet module install` action will install a module and all of its dependencies. By default, it will install into the first directory in Puppet's modulepath.
+The `puppet module install` action will install a module and all of its dependencies. By default, it installs into the first directory in Puppet's [modulepath][].
 
 * Use the `--version` option to specify a version. You can use an exact version or a requirement string like `>=1.0.3`.
-* Use the `--force` option to forcibly install a module or re-install an existing module (**note:** does not install dependencies).
+* Use the `--force` option to forcibly install a module or re-install an existing module. (**Note:** Does not install dependencies.)
 * Use the `--environment` option to install into a different environment.
-* Use the `--modulepath` option to manually specify which directory to install into. **Note:** To avoid duplicating modules installed as dependencies, you may need to specify the modulepath as a list of directories; see [the documentation for setting the modulepath][modulepath] for details.
+* Use the `--modulepath` option to manually specify which directory to install into. (**Note:** To avoid duplicating modules installed as dependencies, you may need to specify the modulepath as a list of directories; see [the documentation for setting the modulepath][modulepath] for details.)
 * Use the `--ignore-dependencies` option to skip installing any modules required by this module.
 * Use the `--debug` option to see additional information about what the Puppet module tool is doing.
 
-
->**A note about installing**
+> **A note about installing**
 >
->As of Puppet 3.6, if any module in your /etc/puppetlabs/puppet/modules directory has incorrect versioning (anything other than major.minor.patch), attempting to install a module will result in this warning.
+> As of Puppet 3.6, if any module in your `modules` directory (`/etc/puppetlabs/code/modules` in Puppet 4) has incorrect versioning (anything other than major.minor.patch), attempting to install a module will result in this warning:
 >
->~~~
->Warning: module (/Users/youtheuser/.puppet/modules/module) has an invalid version number (0.1). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).
-~~~
+> `Warning: module (/Users/youtheuser/.puppet/modules/module) has an invalid version number (0.1). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).`
 >
->Despite the warning, your module will still be downloaded. The metadata of the offending module will not be altered. The versioning information has only been changed in memory during the run of the program.
-
+> Despite the warning, Puppet still downloads your module and does not permanently change the offending module's metadata. The versioning information has only been changed in memory during the run of the program.
 
 ### Installing From the Puppet Forge
 
 To install a module from the Puppet Forge, simply identify the desired module by its full name. The full name of a Forge module is formatted as username-modulename.
 
-    # puppet module install puppetlabs-apache
+~~~ bash
+sudo puppet module install puppetlabs-apache
+~~~
 
-### Installing From Another Module Repository
+### Installing from Another Module Repository
 
-The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/4.1.latest/configuration.html#modulerepository) setting in [`puppet.conf`](/guides/configuring.html), or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `https://forgeapi.puppetlabs.com`.
+The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/4.1.latest/configuration.html#modulerepository) setting in [`puppet.conf`](./config_file_main.html) or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `https://forgeapi.puppetlabs.com`.
 
 After setting the repository, follow the instructions above for installing from the Forge.
 
-    # puppet module install --module_repository http://dev-forge.example.com puppetlabs-apache
+~~~ bash
+sudo puppet module install --module_repository http://dev-forge.example.com puppetlabs-apache
+~~~
 
-### Installing From a Release Tarball
+### Installing from a Release Tarball
 
 To install a module from a release tarball, specify the path to the tarball instead of the module name.
 
 Make sure to use the `--ignore-dependencies` flag if you cannot currently reach the Puppet Forge or are installing modules that have not yet been published to the Forge. This flag will tell the Puppet module tool not to try to resolve dependencies by connecting to the Forge. Be aware that in this case you must manually install any dependencies.
 
-    # puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependencies
+~~~ bash
+sudo puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependencies
+~~~
 
+> **Note:** You can manually install modules without the `puppet module` tool. If you do, you must name your module's directory appropriately. Module directory names can only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and cause errors when attempting to use the module.
 
- >**Note:**
- >
- >It is possible to install modules manually without the assistance of the Puppet module tool. If you choose to do so, you must make sure that your module's directory is appropriately named. Module directory names can only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and will cause errors when attempting to use the module.
+## Finding Modules
 
+You can find modules by browsing the Forge's [web interface][forge] or using the module tool's `search` action. The search action accepts a single search term and returns a list of modules whose names, descriptions, or keywords match the search term.
 
-Finding Modules
------
-
-Modules can be found by browsing the Forge's [web interface][forge] or by using the module tool's `search` action. The search action accepts a single search term and returns a list of modules whose names, descriptions, or keywords match the search term.
-
-    $ puppet module search apache
-    Searching http://forge.puppetlabs.com ...
-    NAME                           DESCRIPTION            AUTHOR          KEYWORDS
-    puppetlabs-apache              This is a generic ...  @puppetlabs     apache web
-    puppetlabs-passenger           Module to manage P...  @puppetlabs     apache
-    DavidSchmitt-apache            Manages apache, mo...  @DavidSchmitt   apache
-    jamtur01-httpauth              Puppet HTTP Authen...  @jamtur01       apache
-    jamtur01-apachemodules         Puppet Apache Modu...  @jamtur01       apache
-    adobe-hadoop                   Puppet module to d...  @adobe          apache
-    adobe-hbase                    Puppet module to d...  @adobe          apache
-    adobe-zookeeper                Puppet module to d...  @adobe          apache
-    adobe-highavailability         Puppet module to c...  @adobe          apache mon
-    adobe-mon                      Puppet module to d...  @adobe          apache mon
-    puppetmanaged-webserver        Apache webserver m...  @puppetmanaged  apache
-    ghoneycutt-apache              Manages apache ser...  @ghoneycutt     apache web
-    ghoneycutt-sites               This module manage...  @ghoneycutt     apache web
-    fliplap-apache_modules_sles11  Exactly the same a...  @fliplap
-    mstanislav-puppet_yum          Puppet 2.              @mstanislav     apache
-    mstanislav-apache_yum          Puppet 2.              @mstanislav     apache
-    jonhadfield-wordpress          Puppet module to s...  @jonhadfield    apache php
-    saz-php                        Manage cli, apache...  @saz            apache php
-    pmtacceptance-apache           This is a dummy ap...  @pmtacceptance  apache php
-    pmtacceptance-php              This is a dummy ph...  @pmtacceptance  apache php
+~~~
+$ puppet module search apache
+Searching http://forge.puppetlabs.com ...
+NAME                           DESCRIPTION            AUTHOR          KEYWORDS
+puppetlabs-apache              This is a generic ...  @puppetlabs     apache web
+puppetlabs-passenger           Module to manage P...  @puppetlabs     apache
+DavidSchmitt-apache            Manages apache, mo...  @DavidSchmitt   apache
+jamtur01-httpauth              Puppet HTTP Authen...  @jamtur01       apache
+jamtur01-apachemodules         Puppet Apache Modu...  @jamtur01       apache
+adobe-hadoop                   Puppet module to d...  @adobe          apache
+adobe-hbase                    Puppet module to d...  @adobe          apache
+adobe-zookeeper                Puppet module to d...  @adobe          apache
+adobe-highavailability         Puppet module to c...  @adobe          apache mon
+adobe-mon                      Puppet module to d...  @adobe          apache mon
+puppetmanaged-webserver        Apache webserver m...  @puppetmanaged  apache
+ghoneycutt-apache              Manages apache ser...  @ghoneycutt     apache web
+ghoneycutt-sites               This module manage...  @ghoneycutt     apache web
+fliplap-apache_modules_sles11  Exactly the same a...  @fliplap
+mstanislav-puppet_yum          Puppet 2.              @mstanislav     apache
+mstanislav-apache_yum          Puppet 2.              @mstanislav     apache
+jonhadfield-wordpress          Puppet module to s...  @jonhadfield    apache php
+saz-php                        Manage cli, apache...  @saz            apache php
+pmtacceptance-apache           This is a dummy ap...  @pmtacceptance  apache php
+pmtacceptance-php              This is a dummy ph...  @pmtacceptance  apache php
+~~~
 
 Once you've identified the module you need, you can install it by name as described above.
 
-
-Managing Modules
------
+## Managing Modules
 
 ### Listing Installed Modules
 
@@ -178,7 +187,7 @@ Use the module tool's `list` action to see which modules you have installed (and
 
 ### Upgrading Modules
 
-Use the module tool's `upgrade` action to upgrade an installed module to the latest version. The target module must be identified by its full name (username-modulename).
+Use the module tool's `upgrade` action to upgrade an installed module to the latest version. You must identify the target module by its full name (username-modulename).
 
 * Use the `--version` option to specify a version.
 * Use the `--ignore-changes` option to upgrade the module while ignoring and overwriting any local changes that may have been made.
@@ -186,16 +195,18 @@ Use the module tool's `upgrade` action to upgrade an installed module to the lat
 
 ### Uninstalling Modules
 
-Use the module tool's `uninstall` action to remove an installed module. The target module must be identified by its full name:
+Use the module tool's `uninstall` action to remove an installed module. You must identify the target module by its full name  (username-modulename).
 
-    # puppet module uninstall apache
-    Error: Could not uninstall module 'apache':
-      Module 'apache' is not installed
-          You may have meant `puppet module uninstall puppetlabs-apache`
-    # puppet module uninstall puppetlabs-apache
-    Removed /etc/puppet/modules/apache (v0.0.3)
+~~~
+$ sudo puppet module uninstall apache
+Error: Could not uninstall module 'apache':
+  Module 'apache' is not installed
+      You may have meant `puppet module uninstall puppetlabs-apache`
+$ sudo puppet module uninstall puppetlabs-apache
+Removed /etc/puppetlabs/code/modules/apache (v0.0.3)
+~~~
 
-By default, the tool won't uninstall a module which other modules depend on or whose files have been edited since it was installed.
+By default, the tool won't uninstall a module that other modules depend on, or whose files have been edited since it was installed.
 
 * Use the `--force` option to uninstall even if the module is depended upon or has been manually edited.
 
@@ -205,24 +216,24 @@ By default, the tool won't uninstall a module which other modules depend on or w
 
 The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
-If you see an error similar to the following when upgrading or uninstalling,
+You might see an error similar to the following when upgrading or uninstalling:
 
 ~~~
 Notice: Preparing to upgrade 'puppetlabs-motd' ...
-Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/puppet/modules ...
+Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/code/modules ...
 Error: Could not upgrade module 'puppetlabs-motd' (v1.0.0 -> latest)
   Installed module has had changes made locally
 ~~~
 
-you can workaround it by upgrading or uninstalling using the `--ignore-changes` option.
+You can workaround it by upgrading or uninstalling using the `--ignore-changes` option.
 
 #### PE-only modules
 
-If you received an error while attempting to install a module from the Forge that looks like:
+You might see an error while attempting to install a module from the Forge that looks like:
 
 ~~~
- # puppet module install puppetlabs-mssql
-Notice: Preparing to install into /etc/puppetlabs/puppet/modules ...
+$ sudo puppet module install puppetlabs-mssql
+Notice: Preparing to install into /etc/puppetlabs/code/modules ...
 Notice: Downloading from https://forgeapi.puppetlabs.com ...
 Error: Request to Puppet Forge failed.
   The server being queried was https://forgeapi.puppetlabs.com/v3/releases?module=puppetlabs-mssql&module_groups=base+pe_only
@@ -230,6 +241,6 @@ Error: Request to Puppet Forge failed.
   The message we received said 'You must have a valid Puppet Enterprise license on this node in order to download puppetlabs-mssql. If you have a Puppet Enterprise license, please see https://docs.puppetlabs.com/forge/pe-only-modules for more information.'
 ~~~
 
-it is because the module you are trying to download is only available to Puppet Enterprise users. To use this module, download [Puppet Enterprise](http://puppetlabs.com/puppet/puppet-enterprise).
+It is because the module you are trying to download is only available to Puppet Enterprise users. To use this module, download [Puppet Enterprise](https://puppetlabs.com/puppet/puppet-enterprise).
 
-If you are a Puppet Enterprise user, use the [troubleshooting guide](https://docs.puppetlabs.com/pe/latest/modules_installing.html#errors).
+If you are a Puppet Enterprise user, use the [troubleshooting guide](/pe/2015.2/modules_installing.html#errors).

--- a/source/puppet/4.1/reference/services_agent_unix.markdown
+++ b/source/puppet/4.1/reference/services_agent_unix.markdown
@@ -32,7 +32,6 @@ This page describes how Puppet agent behaves on \*nix systems. For information a
 
 Not all operating systems can manage the same resources with Puppet; some resource types are OS-specific, and others may have OS-specific features. See the [resource type reference][] for details.
 
-
 ## Puppet Agent's Run Environment
 
 Puppet agent runs as a specific user (usually `root`) and initiates outbound connections on port 8140.
@@ -109,22 +108,27 @@ In Puppet Enterprise, the agent service is automatically configured and started;
 
 In open source Puppet, you can enable the service with:
 
-    $ sudo puppet resource service puppet ensure=running enable=true
+~~~ bash
+sudo puppet resource service puppet ensure=running enable=true
+~~~
 
 Alternately, you can run `sudo puppet agent` on the command line with no additional options; this will cause Puppet agent to start running and daemonize, but you won't have an easy interface for restarting or stopping it. To stop the daemon, use the process ID from the agent's [`pidfile`][pidfile]:
 
-    $ sudo kill $(puppet config print pidfile --section agent)
+~~~ bash
+sudo kill $(puppet config print pidfile --section agent)
+~~~
 
 #### Configuring the Run Interval
 
 The Puppet agent service defaults to doing a configuration run every 30 minutes. You can configure this with [the `runinterval` setting][runinterval] in [puppet.conf][]:
 
-    # /etc/puppet/puppet.conf
-    [agent]
-      runinterval = 2h
+~~~
+# /etc/puppetlabs/puppet/puppet.conf
+[agent]
+  runinterval = 2h
+~~~
 
 If you don't need an aggressive schedule of configuration runs, a longer run interval will let your Puppet master server(s) handle many more agent nodes.
-
 
 ### Running Puppet Agent as a Cron Job
 
@@ -134,7 +138,9 @@ This behavior is good for building a cron job that does configuration runs. You 
 
 You can use the Puppet resource command to set up this cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
-    $ sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+~~~ bash
+sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+~~~
 
 ### Running Puppet Agent On Demand
 
@@ -148,11 +154,15 @@ If you are currently logged into the machine that needs to run Puppet agent, you
 
 **Run in the foreground, with verbose logging to the terminal:**
 
-    $ sudo puppet agent --test
+~~~ bash
+sudo puppet agent --test
+~~~
 
 **Run once in the background:**
 
-    $ sudo puppet agent --onetime
+~~~ bash
+sudo puppet agent --onetime
+~~~
 
 Note that this won't notify you when the run is completed.
 
@@ -160,7 +170,9 @@ Note that this won't notify you when the run is completed.
 
 To run Puppet agent remotely on one machine, you can simply use ssh:
 
-    $ ssh ops@magpie.example.com sudo puppet agent --test
+~~~ bash
+ssh ops@magpie.example.com sudo puppet agent --test
+~~~
 
 To run remotely on _many_ machines, you will need some form of orchestration or parallel execution tool.
 
@@ -172,13 +184,11 @@ Alternately, [parallel SSH][pssh] can be a more lightweight solution for doing P
 
 [pssh]: https://code.google.com/p/parallel-ssh/
 
-
 ## Disabling and Re-enabling Puppet Runs
 
 Regardless of how you're running Puppet agent, you can prevent it from doing any Puppet runs by running `sudo puppet agent --disable "<MESSAGE>"`. You can re-enable it with `sudo puppet agent --enable`.
 
 If Puppet agent attempts to do a configuration run while disabled --- either a scheduled run or a manually triggered one --- it will log a message like `Notice: Skipping run of Puppet configuration client; administratively disabled (Reason: 'Investigating a problem 5/23/14 -NF'); Use 'puppet agent --enable' to re-enable.`
-
 
 ## Configuring Puppet Agent
 

--- a/source/puppet/4.1/reference/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.1/reference/ssl_attributes_extensions.markdown
@@ -13,33 +13,28 @@ canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
 [trusted_hash]: ./lang_facts_and_builtin_vars.html#trusted-facts
 [oid_map]: ./config_file_oid_map.html
 
-When Puppet agent nodes request their certificates, the certificate signing request (CSR) usually just contains their certname and the necessary cryptographic information. However, agents can also embed more data in their CSR. This extra data can be useful for [policy-based autosigning][autosign_policy] and for adding new [trusted facts.][trusted_hash]
+When Puppet agent nodes request their certificates, the certificate signing request (CSR) usually contains only their certname and the necessary cryptographic information. However, agents can also embed more data in their CSR. This extra data can be useful for [policy-based autosigning][autosign_policy] and adding new [trusted facts][trusted_hash].
 
 Embedding additional data into CSRs is mostly useful when:
 
 * Large numbers of nodes are regularly created and destroyed as part of an elastic scaling system.
 * You are willing to build custom tooling to make certificate autosigning more secure and useful.
 
-It might also be useful in deployments where:
-
-* Puppet is used to deploy private keys or other sensitive information, and you want extra control over which nodes receive this data.
+It might also be useful in deployments where Puppet is used to deploy private keys or other sensitive information, and you want extra control over which nodes receive this data.
 
 If your deployment doesn't match one of these descriptions, you might not need this feature.
 
+## Timing: When Data Can be Added to CSRs and Certificates
 
-Timing: When Data Can be Added to CSRs / Certificates
------
+When Puppet agent starts the process of requesting a catalog, it first checks whether it has a valid signed certificate. If it does not, it generates a key pair, crafts a CSR, and submits it to the certificate authority (CA) Puppet master. The steps are [covered in more detail in the reference page about agent/master HTTPS traffic][cert_request].
 
-When Puppet agent starts the process of requesting a catalog, it first checks whether it has a valid signed certificate. If it does not, it will generate a key pair, craft a CSR, and submit it to the certificate authority (CA) Puppet master. The steps are [covered in more detail in the reference page about agent/master HTTPS traffic][cert_request].
+For all practical purposes, a certificate is locked and immutable as soon as it is signed. For any data to persist in the certificate, it has to be added to the CSR _before_ the CA signs the certificate.
 
-Once a certificate is signed, it is, for all practical purposes, locked and immutable. Thus, for any data to persist in the certificate, it has to be added to the CSR before the CA signs the certificate.
-
-This means **any desired extra data must be present before Puppet agent attempts to request its catalog for the first time.**
+This means **any desired extra data must be present _before_ Puppet agent attempts to request its catalog for the first time.**
 
 Practically speaking, you should populate any extra data when provisioning the node. If you mess up, see [Recovering From Failed Data Embedding](#recovering-from-failed-data-embedding) below.
 
-Data Location and Format
------
+## Data Location and Format
 
 Extra data for the CSR is read from the `csr_attributes.yaml` file in Puppet's [`confdir`][confdir]. (The location of this file can be changed with [the `csr_attributes` setting][csr_attributes].)
 
@@ -55,115 +50,123 @@ The value of each key must also be a hash, where:
 
 See the respective sections below for information about how each hash is used and recommended OIDs for each hash.
 
-Custom Attributes (Transient CSR Data)
------
+## Custom Attributes (Transient CSR Data)
 
-**Custom Attributes** are pieces of data that are _only_ embedded into the CSR. They can be used by the CA when deciding whether or not to sign the certificate, but they are discarded after that and will not be transferred to the final certificate.
+**Custom Attributes** are pieces of data that are _only_ embedded in the CSR. The CA can use them when deciding whether to sign the certificate, but they are discarded after that and aren't transferred to the final certificate.
 
 ### Default Behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command will not display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] will not check them before signing.
+By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable Behavior
 
-If you are using [policy-based autosigning][autosign_policy], your policy executable receives the complete CSR in PEM format. The executable can extract and inspect the custom attributes, and it can use them when deciding whether to sign the certificate.
+If you use [policy-based autosigning][autosign_policy], your policy executable receives the complete CSR in PEM format. The executable can extract and inspect the custom attributes, and use them when deciding whether to sign the certificate.
 
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
-A more complex use might be to embed an instance-specific ID, and write a policy executable that can check it against a list of your recently requested instances on a public cloud like EC2 or GCE.
+A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
 
-### Manually Checking For Custom Attributes in CSRs
+### Manually Checking for Custom Attributes in CSRs
 
 You can check for custom attributes by using OpenSSL to dump a PEM-format CSR to text format. Do this by running:
 
-    $ openssl req -noout -text -in <name>.pem
+~~~ bash
+openssl req -noout -text -in <name>.pem
+~~~
 
 In the output, look for a section called "Attributes," which generally appears below the "Subject Public Key Info" block:
 
-    Attributes:
-        challengePassword        :342thbjkt82094y0uthhor289jnqthpc2290
+~~~
+Attributes:
+    challengePassword        :342thbjkt82094y0uthhor289jnqthpc2290
+~~~
 
 ### Recommended OIDs for Attributes
 
 Custom attributes can use any public or site-specific OID, **with the exception of the OIDs used for core X.509 functionality.** This means you can't re-use existing OIDs for things like subject alternative names.
 
-One useful OID is the "challengePassword" attribute --- `1.2.840.113549.1.9.7`. This is a rarely-used corner of X.509 which can easily be repurposed to hold a pre-shared key. The benefit of using this instead of an arbitrary OID is that it will appear by name when using OpenSSL to dump the CSR to text; OIDs that `openssl req` can't recognize will be displayed as numerical strings.
+One useful OID is the "challengePassword" attribute --- `1.2.840.113549.1.9.7`. This is a rarely-used corner of X.509 that can easily be repurposed to hold a pre-shared key. The benefit of using this instead of an arbitrary OID is that it appears by name when using OpenSSL to dump the CSR to text; OIDs that `openssl req` can't recognize are displayed as numerical strings.
 
 You can also use the Puppet-specific OIDs [referenced below][puppet_oids] in the section on extension requests.
 
-Extension Requests (Permanent Certificate Data)
------
+## Extension Requests (Permanent Certificate Data)
 
-**Extension requests** are pieces of data that will be _transferred to the final certificate_ (as **extensions**) when the CA signs the CSR. They will persist as trusted, immutable data, which cannot be altered after the certificate has been signed.
+**Extension requests** are pieces of data that are _transferred to the final certificate_ (as **extensions**) when the CA signs the CSR. They persist as trusted, immutable data, that cannot be altered after the certificate is signed.
 
 They can also be used by the CA when deciding whether or not to sign the certificate.
 
 ### Default Behavior
 
-When signing a certificate, Puppet's CA tools will transfer any extension requests into the final certificate.
+When signing a certificate, Puppet's CA tools transfer any extension requests into the final certificate.
 
 You can access certificate extensions in manifests as `$trusted[extensions][<EXTENSION OID>]`.
 
-Any OIDs in the ppRegCertExt range ([see below][puppet_oids]) will appear using their short names. By default, any other OIDs will appear as plain dotted numbers, but you can use [the `custom_trusted_oid_mapping.yaml` file][oid_map] to assign short names to any other OIDs you use at your site. If you do, those OIDs will appear in `$trusted` as their short names instead of their full numerical OID.
+Any OIDs in the ppRegCertExt range ([see below][puppet_oids]) appear using their short names. By default, any other OIDs appear as plain dotted numbers, but you can use [the `custom_trusted_oid_mapping.yaml` file][oid_map] to assign short names to any other OIDs you use at your site. If you do, those OIDs will appear in `$trusted` as their short names instead of their full numerical OID.
 
 See [the page on facts and special variables][trusted_hash] for more information about `$trusted`.
 
 Visibility of extensions is somewhat limited:
 
-* The `puppet cert list` command _will not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] will not check them before signing. You'll need to either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
-* The `puppet cert print` command _will_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
+* The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
+* The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (auth.conf) does not use certificate extensions for anything.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions.
 
 ### Configurable Behavior
 
-If you are using [policy-based autosigning][autosign_policy], your policy executable receives the complete CSR in PEM format. The executable can extract and inspect the extension requests, and it can use them when deciding whether to sign the certificate.
+If you use [policy-based autosigning][autosign_policy], your policy executable receives the complete CSR in PEM format. The executable can extract and inspect the extension requests, and use them when deciding whether to sign the certificate.
 
-### Manually Checking For Extensions in CSRs and Certificates
+### Manually Checking for Extensions in CSRs and Certificates
 
 You can check for extension requests in a CSR by using OpenSSL to dump a PEM-format CSR to text format. Do this by running:
 
-    $ openssl req -noout -text -in <name>.pem
+~~~ bash
+openssl req -noout -text -in <name>.pem
+~~~
 
 In the output, look for a section called "Requested Extensions," which generally appears below the "Subject Public Key Info" and "Attributes" blocks:
 
-    Requested Extensions:
-            pp_uuid:
-            .$ED803750-E3C7-44F5-BB08-41A04433FE2E
-            1.3.6.1.4.1.34380.1.1.3:
-            ..my_ami_image
-            1.3.6.1.4.1.34380.1.1.4:
-            .$342thbjkt82094y0uthhor289jnqthpc2290
+~~~
+Requested Extensions:
+    pp_uuid:
+    .$ED803750-E3C7-44F5-BB08-41A04433FE2E
+    1.3.6.1.4.1.34380.1.1.3:
+    ..my_ami_image
+    1.3.6.1.4.1.34380.1.1.4:
+    .$342thbjkt82094y0uthhor289jnqthpc2290
+~~~
 
-Note that every extension is preceded by any combination of two characters (`.$` and `..` in the above example), which contain ASN.1 encoding information. Since OpenSSL is unaware of Puppet's custom extensions OIDs, it's unable to properly display the values.
+Note that every extension is preceded by any combination of two characters (`.$` and `..` in the above example) that contain ASN.1 encoding information. Since OpenSSL is unaware of Puppet's custom extensions OIDs, it's unable to properly display the values.
 
-Any Puppet-specific OIDs (see below) will appear as numeric strings when using OpenSSL.
+Any Puppet-specific OIDs (see below) appear as numeric strings when using OpenSSL.
 
-You can check for extensions in a signed certificate by running `puppet cert print <name>`. In the output, look for the "X509v3 extensions" section. Any of the Puppet-specific registered OIDs (see below) will appear as their descriptive names:
+You can check for extensions in a signed certificate by running `puppet cert print <name>`. In the output, look for the "X509v3 extensions" section. Any of the Puppet-specific registered OIDs (see below) appear as their descriptive names:
 
-        X509v3 extensions:
-            Netscape Comment:
-                Puppet Ruby/OpenSSL Internal Certificate
-            X509v3 Subject Key Identifier:
-                47:BC:D5:14:33:F2:ED:85:B9:52:FD:A2:EA:E4:CC:00:7F:7F:19:7E
-            Puppet Node UUID:
-                ED803750-E3C7-44F5-BB08-41A04433FE2E
-            X509v3 Extended Key Usage: critical
-                TLS Web Server Authentication, TLS Web Client Authentication
-            X509v3 Basic Constraints: critical
-                CA:FALSE
-            Puppet Node Preshared Key:
-                342thbjkt82094y0uthhor289jnqthpc2290
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment
-            Puppet Node Image Name:
-                my_ami_image
+~~~
+X509v3 extensions:
+    Netscape Comment:
+        Puppet Ruby/OpenSSL Internal Certificate
+    X509v3 Subject Key Identifier:
+        47:BC:D5:14:33:F2:ED:85:B9:52:FD:A2:EA:E4:CC:00:7F:7F:19:7E
+    Puppet Node UUID:
+        ED803750-E3C7-44F5-BB08-41A04433FE2E
+    X509v3 Extended Key Usage: critical
+        TLS Web Server Authentication, TLS Web Client Authentication
+    X509v3 Basic Constraints: critical
+        CA:FALSE
+    Puppet Node Preshared Key:
+        342thbjkt82094y0uthhor289jnqthpc2290
+    X509v3 Key Usage: critical
+        Digital Signature, Key Encipherment
+    Puppet Node Image Name:
+        my_ami_image
+~~~
 
 ### Recommended OIDs for Extensions
 
 Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
 
-Puppet Labs provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. The benefits of using the registered OIDs are:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.
@@ -171,42 +174,41 @@ Puppet Labs provides several registered OIDs (under "ppRegCertExt") for the most
 
 The private range is available for any information you want to embed into a certificate that isn't already in wide use elsewhere. It is completely unregulated, and its contents are expected to be different in every Puppet deployment.
 
-You can use [the `custom_trusted_oid_mapping.yaml` file][oid_map] to set short names for any private extension OIDs you're using. Note that this only enables the short names in the `$trusted[extensions]` hash.
+You can use [the `custom_trusted_oid_mapping.yaml` file][oid_map] to set short names for any private extension OIDs you use. Note that this only enables the short names in the `$trusted[extensions]` hash.
 
 #### Puppet-Specific Registered IDs
 
 {% partial ./_registered_oids.md %}
 
-AWS Attributes and Extensions Population Example
------
+## AWS Attributes and Extensions Population Example
 
-Generally, you will want to use an automated script (possibly using cloud-init or a similar tool) to populate the `csr_attributes.yaml` file at the time a node is provisioned.
+You can use an automated script (possibly using cloud-init or a similar tool) to populate the `csr_attributes.yaml` file when you provision a node.
 
-As an example, you could enter the following script into the "Configure Instance Details —> Advanced Details" section when provisioning a new node from the AWS EC2 dashboard:
+As an example, you can enter the following script into the "Configure Instance Details —> Advanced Details" section when provisioning a new node from the AWS EC2 dashboard:
 
-    #!/bin/sh
-    if [ ! -d /etc/puppet ]; then
-       mkdir /etc/puppet
-    fi
-    erb > /etc/puppet/csr_attributes.yaml <<END
-    custom_attributes:
-      1.2.840.113549.1.9.7: mySuperAwesomePassword
-    extension_requests:
-      pp_instance_id: <%= %x{/opt/aws/bin/ec2-metadata -i}.sub(/instance-id: (.*)/,'\1').chomp %>
-      pp_image_name:  <%= %x{/opt/aws/bin/ec2-metadata -a}.sub(/ami-id: (.*)/,'\1').chomp %>
-    END
+~~~ bash
+#!/bin/sh
+if [ ! -d /etc/puppetlabs/puppet ]; then
+   mkdir /etc/puppetlabs/puppet
+fi
+erb > /etc/puppetlabs/puppet/csr_attributes.yaml <<END
+custom_attributes:
+   1.2.840.113549.1.9.7: mySuperAwesomePassword
+extension_requests:
+   pp_instance_id: <%= %x{/opt/aws/bin/ec2-metadata -i}.sub(/instance-id: (.*)/,'\1').chomp %>
+   pp_image_name:  <%= %x{/opt/aws/bin/ec2-metadata -a}.sub(/ami-id: (.*)/,'\1').chomp %>
+END
+~~~
 
-Assuming your image had the `erb` binary available, this would populate the attributes file with the AWS instance ID, image name, and a pre-shared key to use with policy-based autosigning.
+Assuming your image has the `erb` binary available, this populates the attributes file with the AWS instance ID, image name, and a pre-shared key to use with policy-based autosigning.
 
+## Troubleshooting
 
-Troubleshooting
------
+### Recovering from Failed Data Embedding
 
-### Recovering From Failed Data Embedding
+When first testing this feature, you might fail to embed the right information in a CSR or certificate and want to start over for your test nodes. (This is not really a problem once your provisioning system is changed to populate the data, but it can happen pretty easily when doing things manually.)
 
-When first testing this feature, you might fail to embed the right information in a CSR or certificate and want to start over for your test node(s). (This is not really a problem once your provisioning system is changed to populate the data, but it can happen pretty easily when doing things manually.)
-
-In order to start over, you'll need to do the following:
+To start over, do the following:
 
 **On the test node:**
 
@@ -220,4 +222,3 @@ In order to start over, you'll need to do the following:
 * Check whether a CSR for the node exists; it will be in `$ssldir/ca/requests/<name>.pem`. If it exists, delete it.
 
 After you've done that, you can start over.
-

--- a/source/puppet/4.2/reference/config_ssl_external_ca.markdown
+++ b/source/puppet/4.2/reference/config_ssl_external_ca.markdown
@@ -5,25 +5,23 @@ canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: /references/3.8.latest/configuration.html#sslclientverifyheader
-[client_header]: /references/3.8.latest/configuration.html#sslclientheader
-[ca_auth]: /references/3.8.latest/configuration.html#sslclientcaauth
+[verify_header]: /references/4.2.latest/configuration.html#sslclientverifyheader
+[client_header]: /references/4.2.latest/configuration.html#sslclientheader
+[ca_auth]: /references/4.2.latest/configuration.html#sslclientcaauth
 [puppetdb]: /puppetdb/latest
 
-In lieu of its built-in CA and PKI tools, Puppet can use an existing external CA for all of its SSL communications.
+In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
-This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please get in touch with Puppet Labs so we can learn more about it.
+This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet Labs so we can learn more about it.
 
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, MAY.
+> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-
-Supported External CA Configurations
------
+## Supported External CA Configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca)  The intermediate
+2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
    CA directly issues SSL certificates; the root CA doesn't.
 3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
     * One intermediate CA issues SSL certificates for Puppet master servers.
@@ -35,19 +33,17 @@ These are fully supported by Puppet Labs, which means:
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
 
 Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
 
-
-General Notes and Requirements
------
+## General Notes and Requirements
 
 ### Rack Webserver is Required
 
 The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
 
-In practice, this means Apache or Nginx.  We fully support any web server that can:
+In practice, this means Apache or Nginx. We fully support any web server that can:
 
 * Terminate SSL
 * Verify the authenticity of a client SSL certificate
@@ -61,47 +57,36 @@ Puppet always expects its SSL credentials to be in `.pem` format.
 
 ### Normal Puppet Master Certificate Requirements Still Apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject CN or as a Subject Alternative Name (DNS).
+Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ### Format of X-Client-DN Request Header
 
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting](/references/3.8.latest/configuration.html#sslclientheader).
+Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
 
 This header should conform to the following specifications:
 
-* The value of the client certificate DN should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by Apache ≥ 2.2's `mod_ssl`) is fully supported.
+* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
 * Alternatively, the value of this request header may be in "OpenSSL" format.
 
 ### Revocation
 
-Certificate revocation list (CRL) checking works in all three supported
-configurations, so long as the CRL file is distributed to the agents and masters
-using an "out of band" process.  Puppet won't automatically update the CRL on any
-of the components in the system.
+Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
 
 #### If Unused:
 
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent.
-Set `certificate_revocation = false` in the
-`[agent]` section of [puppet.conf][conf] on **every agent node.**
+If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
 
 (If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
 
 #### If Used:
 
-If revocation lists **are** being used by the external CA, then the CRL file must
-be manually distributed to **every agent node** as a PEM encoded bundle.  Puppet will not automatically distribute this file.
+If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
 
 To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
-Option 1: Single CA
------
+## Option 1: Single CA
 
-A single CA is the default configuration of Puppet when the internal CA is
-being used.  A single, externally issued CA may also be used in a similar
-manner.
-
-
+When Puppet uses its internal CA, it defaults to a single CA configuration. A single externally issued CA can also be used in a similar manner.
 
                    +------------------------+
                    |                        |
@@ -118,7 +103,6 @@ manner.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
 ### Puppet Master
 
 {% capture master_basic %}
@@ -131,14 +115,16 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-    [master]
-    ca = false
-    certname = <some static string, e.g. 'puppetmaster'>
+~~~
+[master]
+ca = false
+certname = <some static string, e.g. 'puppetmaster'>
+~~~
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
 
-Once this configuration is set, put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                         | File location
 -----------------------------------|-------------------------------------------
@@ -151,54 +137,54 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 With these files in place, the web server should be configured to:
 
-* Use the root CA certificate, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+* Use the root CA certificate, the master's certificate, and the master's key.
+* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
+* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca.pem"
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 1
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 1
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {% capture master_config_ru %}
-The `config.ru` file for rack has no special configuration when using an
-external CA.  Please follow the standard rack documentation for using Puppet
-with rack.  The following example will work with this version of Puppet:
+The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
 
-    ~~~ ruby
-    $0 = "master"
-    ARGV << "--rack"
-    ARGV << "--confdir=/etc/puppet"
-    ARGV << "--vardir=/var/lib/puppet"
-    require 'puppet/util/command_line'
-    run Puppet::Util::CommandLine.new.execute
+~~~ ruby
+$0 = "master"
+ARGV << "--rack"
+ARGV << "--confdir=/etc/puppetlabs/puppet"
+ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
+require 'puppet/util/command_line'
+run Puppet::Util::CommandLine.new.execute
 ~~~
 {% endcapture %}
 
@@ -208,7 +194,7 @@ with rack.  The following example will work with this version of Puppet:
 
 You don't need to change any settings.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
@@ -216,19 +202,14 @@ Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 
-
-
-Option 2: Single Intermediate CA
------
+## Option 2: Single Intermediate CA
 
 The single intermediate CA configuration builds from the single self-signed CA
 configuration and introduces one additional intermediate CA.
 
-
-
                    +------------------------+
                    |                        |
-                   |  self-signed Root CA   |
+                   |  Root self-signed CA   |
                    |                        |
                    +-----------+------------+
                                |
@@ -249,9 +230,7 @@ configuration and introduces one additional intermediate CA.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
-The Root CA does not issue SSL certificates in this configuration.  The
-intermediate CA issues SSL certificates for clients and servers alike.
+The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
 
 ### Puppet Master
 
@@ -259,7 +238,9 @@ intermediate CA issues SSL certificates for clients and servers alike.
 
 You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
 
-    $ cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+~~~ bash
+cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+~~~
 
 Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
 
@@ -271,57 +252,60 @@ With these files in place, the web server should be configured to:
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca_bundle.pem"
-        SSLCertificateChainFile "/path/to/ca_bundle.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca_bundle.pem"
+    SSLCertificateChainFile "/path/to/ca_bundle.pem"
 
-        # Allow only clients with a SSL certificate issued by the intermediate CA with
-        # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-        # intermediate CA certificate.
-        <Location />
-            SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-        </Location>
+    # Allow only clients with a SSL certificate issued by the intermediate CA with
+    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
+    # intermediate CA certificate.
+    <Location />
+        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
+    </Location>
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 2
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
-
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {{ master_config_ru }}
 
 ### Puppet Agent
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its puppet.conf:
+With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
 
-    [agent]
-    ssl_client_ca_auth = $certdir/issuer.pem
+~~~
+[agent]
+ssl_client_ca_auth = $certdir/issuer.pem
+~~~
 
 The value should point to somewhere in the `$certdir`.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|------------------------------------------------
@@ -330,16 +314,11 @@ Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
 
-
-
-Option 3: Two Intermediate CAs Issued by One Root CA
------
+## Option 3: Two Intermediate CAs Issued by One Root CA
 
 This configuration uses different CAs to issue Puppet master certificates and Puppet agent
 certificates. This makes them easily distinguishable, and prevents any agent certificate from being
 usable for a Puppet master.
-
-
 
                    +------------------------+
                    |                        |
@@ -364,10 +343,7 @@ usable for a Puppet master.
       |                 |                |                |
       +-----------------+                +----------------+
 
-
-In this configuration Puppet agents are configured to only authenticate peer
-certificates issued by the Master CA.  Puppet masters are configured to only
-authenticate peer certificates issued by the Agent CA.
+In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
 
 > **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
 
@@ -377,69 +353,74 @@ authenticate peer certificates issued by the Agent CA.
 
 You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
 
-    $ cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
+~~~ bash
+cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
+~~~
 
 Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
 
 With these files in place, the web server should be configured to:
 
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
+* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
+* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
 
 An example of this configuration for Apache:
 
-    Listen 8140
-    <VirtualHost *:8140>
-        SSLEngine on
-        SSLProtocol ALL -SSLv2
-        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+~~~ apache
+Listen 8140
+<VirtualHost *:8140>
+    SSLEngine on
+    SSLProtocol ALL -SSLv2
+    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-        # Replace with the value of `puppet master --configprint hostcert`
-        SSLCertificateFile "/path/to/master.pem"
-        # Replace with the value of `puppet master --configprint hostprivkey`
-        SSLCertificateKeyFile "/path/to/master.key"
+    # Replace with the value of `puppet master --configprint hostcert`
+    SSLCertificateFile "/path/to/master.pem"
+    # Replace with the value of `puppet master --configprint hostprivkey`
+    SSLCertificateKeyFile "/path/to/master.key"
 
-        # Replace with the value of `puppet master --configprint localcacert`
-        SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-        SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
+    # Replace with the value of `puppet master --configprint localcacert`
+    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
+    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
 
-        # Allow only clients with a SSL certificate issued by the intermediate CA with
-        # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-        # Agent CA certificate.
-        <Location />
-            SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-        </Location>
+    # Allow only clients with a SSL certificate issued by the intermediate CA with
+    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
+    # Agent CA certificate.
+    <Location />
+        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
+    </Location>
 
-        SSLVerifyClient optional
-        SSLVerifyDepth 2
-        SSLOptions +StdEnvVars
-        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+    SSLVerifyClient optional
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars
+    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
 
-        DocumentRoot "/etc/puppet/public"
+    DocumentRoot "/etc/puppetlabs/puppet/public"
 
-        PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-        PassengerRuby /usr/bin/ruby
+    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
+    PassengerRuby /usr/bin/ruby
 
-        RackAutoDetect On
-        RackBaseURI /
-    </VirtualHost>
-
+    RackAutoDetect On
+    RackBaseURI /
+</VirtualHost>
+~~~
 
 {{ master_config_ru }}
 
 ### Puppet Agent
 
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its puppet.conf:
+With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
 
-    [agent]
-    ssl_client_ca_auth = $certdir/ca_master.pem
+~~~
+[agent]
+ssl_client_ca_auth = $certdir/ca_master.pem
+~~~
 
 The value should point to somewhere in the `$certdir`.
 
-Put the external credentials into the correct filesystem locations.  You can run the following commands to find the appropriate locations:
+Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
 
 Credential                        | File location
 ----------------------------------|------------------------------------------------
@@ -447,4 +428,3 @@ Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
 Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
-

--- a/source/puppet/4.2/reference/dirs_confdir.markdown
+++ b/source/puppet/4.2/reference/dirs_confdir.markdown
@@ -6,9 +6,7 @@ canonical: "/puppet/latest/reference/dirs_confdir.html"
 
 [puppetserver_conf]: /puppetserver/2.1/configuration.html#puppetserverconf
 
-
 Puppet's `confdir` is the main directory for Puppet's configuration. It contains config files and SSL data.
-
 
 ## Location
 

--- a/source/puppet/4.2/reference/dirs_modulepath.markdown
+++ b/source/puppet/4.2/reference/dirs_modulepath.markdown
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
+canonical: "/puppet/latest/reference/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html
@@ -14,7 +15,7 @@ title: "Directories: The Modulepath (Default Config)"
 [puppet.conf]: ./config_file_main.html
 [environment.conf]: ./config_file_environment.html
 
-The Puppet master service and the Puppet apply command both load most of their content from modules. (See the page on [module structure and behavior][module_fundamentals] for more details.)
+The Puppet master service and the `puppet apply` command both load most of their content from modules. (See the page on [module structure and behavior][module_fundamentals] for more details.)
 
 Puppet automatically loads modules from one or more directories. The list of directories Puppet will find modules in is called the **modulepath.**
 
@@ -24,35 +25,36 @@ The modulepath is set by the current node's [environment][environments].
 
 `/etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules`
 
-The modulepath is a list of directories separated by the system _path-separator character._ On \*nix systems this is the colon (`:`, as seen above), and on Windows it is the semi-colon (`;`).
+The modulepath is a list of directories separated by the system _path-separator character._ On \*nix systems, this is the colon (`:`, as seen above), and on Windows it is the semi-colon (`;`).
 
 It is an ordered list, with earlier directories having priority over later ones. See ["Loading Content from Modules"][inpage_loading] below.
-
 
 ## Contents
 
 Every directory in the modulepath should only contain valid Puppet modules.
 
-The names of those modules must only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and will cause errors when attempting to use the module.
+The names of those modules must only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and cause errors when attempting to use the module.
 
 For details about module contents and structure, see [the documentation on modules][module_fundamentals].
 
 ## Location
 
-The modulepath is set by the current node's [environment][]. By default, it will usually be something like:
+The modulepath is set by the current node's [environment][environments]. By default, it is usually be something like:
 
 `<ACTIVE ENVIRONMENT'S MODULES DIRECTORY>:$codedir/modules:/opt/puppetlabs/puppet/modules`
 
 You can view the effective modulepath for any environment by specifying the environment when [requesting the setting value][config_print]:
 
-    $ sudo puppet config print modulepath --section master --environment test
-    /etc/puppet/environments/test/modules:/etc/puppet/modules:/usr/share/puppet/modules
+~~~ bash
+sudo puppet config print modulepath --section master --environment test
+/etc/puppetlabs/code/environments/test/modules:/etc/puppetlabs/code/modules:/usr/share/puppet/modules
+~~~
 
 ## Configuration
 
 Each environment can set its full modulepath in [environment.conf][] with the `modulepath` setting. The default value is that environment's `modules` directory followed by the **base modulepath.**
 
-When running Puppet apply, you also have the option of directly setting `--modulepath` on the command line.
+When running `puppet apply` on the command line, you also have the option of directly setting the modulepath with the `--modulepath` flag.
 
 ### The `modulepath` Setting
 
@@ -60,7 +62,7 @@ The `modulepath` setting can only be set in [environment.conf][]. It configures 
 
 The default value of `modulepath` is `./modules:$basemodulepath`.
 
-Note that the modulepath can include relative paths like `./modules` or `./site`. Puppet will look for these paths inside the environment's directory.
+Note that the modulepath can include relative paths, such as `./modules` or `./site`. Puppet looks for these paths inside the environment's directory.
 
 If you want an environment to have access to the global module directories, it should include `$basemodulepath`.
 
@@ -72,24 +74,23 @@ The default value of the `basemodulepath` setting is `$codedir/modules:/opt/pupp
 
 ### Using `--modulepath`
 
-When using Puppet apply, you can supply a full modulepath as a command line option. This will override the modulepath from the current environment.
-
+When running `puppet apply`, you can supply a full modulepath as a command line option. This overrides the modulepath from the current environment.
 
 ## Loading Content from Modules
 
 [inpage_loading]: #loading-content-from-modules
 
-Puppet will use modules from every directory in the modulepath.
+Puppet uses modules from every directory in the modulepath.
 
 ### Empty and Absent Directories
 
-Directories in the modulepath may be empty, and may even be absent. In both cases, this is not an error; it just means no modules will be loaded from that directory.
+Directories in the modulepath can be empty, and might even be absent. In both cases, this is not an error; it just means Puppet does not load modules from those directories.
 
 If no modules are present across the entire modulepath, or if modules are present but none of them contains a `lib` directory, then Puppet agent will log an error when attempting to sync plugins from the Puppet master. This error is benign and will not prevent the rest of the Puppet run.
 
 ### Duplicate or Conflicting Modules and Content
 
-If the modulepath contains multiple modules with the same name, Puppet will use the version from the directory that comes _earliest_ in the modulepath. This allows directories earlier in the modulepath to override the later directories.
+If the modulepath contains multiple modules with the same name, Puppet uses the version from the directory that comes _earliest_ in the modulepath. This allows directories earlier in the modulepath to override later directories.
 
 For most content, this earliest-module-wins behavior is on an all-or-nothing, **per-module** basis --- **all** of the manifests, files, and templates in the winning version will be available for use, and **none* of that content from any subsequent versions will be available. This behavior covers:
 
@@ -102,12 +103,11 @@ For most content, this earliest-module-wins behavior is on an all-or-nothing, **
 > **However,** Puppet occasionally shows problematic behavior with **Ruby plugins loaded directly from modules.** This includes:
 >
 > - Plugins used by the Puppet master (custom resource types, custom functions)
-> - Plugins used by Puppet apply
+> - Plugins used by `puppet apply`
 > - Plugins that happen to be present in Puppet agent's modulepath (which should generally be empty, but may not be when running Puppet agent on a node that is also a Puppet master server)
 >
 > With these plugins, the earlier module still wins, but the plugins are handled on a **per-file** basis instead of per-module. This means that if a duplicate module in a later directory has **additional** plugin files that don't exist in the winning module, those extra files will be loaded, and Puppet will use a mixture of files from the winning and duplicate modules.
 >
-> The upshot is, if you do a major refactor of the Ruby plugins in some module and then maintain two versions of that module in your modulepath, it can sometimes result in weirdness.
+> The upshot is, if you refactor a module's Ruby plugins and then maintain two versions of that module in your modulepath, it can sometimes result in weirdness.
 >
-> This is essentially the same Ruby loading problem that environments have, [as described elsewhere in this manual.](./environments_limitations.html#plugins-running-on-the-puppet-master-are-weird) It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.
-
+> This is essentially the same Ruby loading problem that environments have, [as described elsewhere in this manual](./environments_limitations.html#plugins-running-on-the-puppet-master-are-weird). It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.

--- a/source/puppet/4.2/reference/lang_classes.markdown
+++ b/source/puppet/4.2/reference/lang_classes.markdown
@@ -36,20 +36,17 @@ canonical: "/puppet/latest/reference/lang_classes.html"
 [declare]: #declaring-classes
 [setting_parameters]: #include-like-vs-resource-like
 [override]: #using-resource-like-declarations
-[ldap_nodes]: http://projects.puppetlabs.com/projects/1/wiki/Ldap_Nodes
+[ldap_nodes]: /guides/ldap_nodes.html
 [hiera]: /hiera/latest
 [external_data]: /hiera/latest/puppet.html
 [array_search]: /hiera/latest/lookup_types.html#array-merge
 [hiera_hierarchy]: /hiera/latest/hierarchy.html
 
-
-
-**Classes** are named blocks of Puppet code, which are stored in [modules][] for later use and are not applied until they are invoked by name. They can be added to a node's [catalog][] by either **declaring** them in your manifests or by **assigning** them from an [ENC][].
+**Classes** are named blocks of Puppet code that are stored in [modules][] for later use and are not applied until they are invoked by name. They can be added to a node's [catalog][] by either **declaring** them in your manifests or **assigning** them from an [ENC][].
 
 Classes generally configure large or medium-sized chunks of functionality, such as all of the packages, config files, and services needed to run an application.
 
-Defining Classes
------
+## Defining Classes
 
 Defining a class makes it available for later use. It doesn't yet add any resources to the catalog; to do that, you must [declare it (see below)][declare] or [assign it from an ENC][enc].
 
@@ -108,15 +105,13 @@ The general form of a class definition is:
 * A block of arbitrary Puppet code, which generally contains at least one [resource declaration][resource_declaration]
 * A closing curly brace
 
-
 ### Class Parameters and Variables
-
 
 **Parameters** allow a class to request external data. If a class needs to configure itself with data other than [facts][], that data should usually enter the class via a parameter.
 
 Each class parameter can be used as a normal [variable][] inside the class definition. The values of these variables are not set with [normal assignment statements][variable_assignment] or looked up from top or node scope; instead, they are [set based on user input when the class is declared][setting_parameters].
 
-Note that if a class parameter lacks a default value, the user of the module **must** set a value themselves (either in their [external data][external_data] or an [override][]). As such, you should supply defaults wherever possible.
+Note that if a class parameter lacks a default value, the module's user **must** set a value themselves (either in their [external data][external_data] or an [override][]). As such, you should supply defaults wherever possible.
 
 Each parameter can be preceeded by an optional [**data type**][literal_types]. If you include one, Puppet will check the parameter's value at runtime to make sure that it has the right data type, and raise an error if the value is illegal. If no data type is provided, the parameter will accept values of any data type.
 
@@ -128,7 +123,7 @@ Class definitions should be stored in [modules][]. Puppet is **automatically awa
 
 Classes should be stored in their module's `manifests/` directory as one class per file, and each filename should reflect the name of its class; see [Module Fundamentals][modules] and [Namespaces and Autoloading][namespace] for more details.
 
-A class definition statement isn't an expression, and can't be used where a value is expected.
+A class definition statement isn't an expression and can't be used where a value is expected.
 
 > #### Other Locations
 >
@@ -138,21 +133,19 @@ A class definition statement isn't an expression, and can't be used where a valu
 > * A file in the same module whose corresponding class name is a truncated version of this class's name. That is, the class `first::second::third` could be put in `first::second`'s file, `first/manifests/second.pp`.
 > * Lexically inside another class definition. This puts the interior class under the exterior class's [namespace][], causing its real name to be something other than the name with which it was defined. (For example: in `class first { class second { ... } }`, the interior class's real name is `first::second`.) Note that this doesn't cause the interior class to be automatically declared along with the exterior class.
 >
-> Again: You should basically never do these.
-
-
+> Again: You should never do these.
 
 ### Containment
 
 A class [contains][] all of its resources. This means any [relationships][] formed with the class as a whole will be extended to every resource in the class.
 
-Classes can also contain other classes, but _you must manually specify that a class should be contained._ For details, [see the "Containing Classes" section of the Containment page.][contain_classes]
+Classes can also contain other classes, but _you must manually specify that a class should be contained._ For details, [see the "Containing Classes" section of the Containment page][contain_classes].
 
 A contained class is automatically [tagged][tags] with the name of its container.
 
 ### Auto-Tagging
 
-Every resource in a class gets automatically [tagged][tags] with the class's name (and each of its [namespace segments][namespace]).
+Every resource in a class gets automatically [tagged][tags] with the class's name and each of its [namespace segments][namespace].
 
 ### Inheritance
 
@@ -166,14 +159,14 @@ Inheritance causes three things to happen:
 * The base class becomes the [parent scope][parent_scope] of the derived class, so that the new class receives a copy of all of the base class's variables and resource defaults.
 * Code in the derived class is given special permission to override any resource attributes that were set in the base class.
 
-> #### Aside: When to Inherit
+> **Aside: When to Inherit**
 >
 > Class inheritance should be used **very sparingly,** generally only in the following situations:
 >
 > * When you need to override resource attributes in the base class.
 > * To let a "params class" provide default values for another class's parameters:
 >
->       class example (String $my_param = $example::params::myparam) inherits example::params { ... }
+> `class example (String $my_param = $example::params::myparam) inherits example::params { ... }`
 >
 >   This pattern works by guaranteeing that the params class is evaluated before Puppet attempts to evaluate the main class's parameter list. It is especially useful when you want your default values to change based on system facts and other data, since it lets you isolate and encapsulate all that conditional logic.
 >
@@ -214,7 +207,7 @@ This causes the attribute to be unmanaged by Puppet.
 
 #### Appending to Resource Attributes
 
-Some resource attributes (such as the [relationship metaparameters][relationships]) can accept multiple values in an array. When overriding attributes in a derived class, you can add to the existing values instead of replacing them by using the `+>` ("plusignment") keyword instead of the standard `=>` hash rocket:
+Some resource attributes, such as the [relationship metaparameters][relationships], can accept multiple values in an array. When overriding attributes in a derived class, you can add to the existing values instead of replacing them by using the `+>` ("plusignment") keyword instead of the standard `=>` hash rocket:
 
 ~~~ ruby
 class apache {
@@ -233,10 +226,7 @@ class apache::ssl inherits apache {
 }
 ~~~
 
-
-
-Declaring Classes
------
+## Declaring Classes
 
 **Declaring** a class in a Puppet manifest adds all of its resources to the catalog. You can declare classes in [node definitions][node], at top scope in the [site manifest][sitedotpp], and in other classes or [defined types][definedtype]. Declaring classes isn't the only way to add them to the catalog; you can also [assign classes to nodes with an ENC](#assigning-classes-from-an-enc).
 
@@ -276,7 +266,6 @@ Resource-like class declarations require that you **only declare a given class o
 > This is necessary to avoid paradoxical or conflicting parameter values. Since overridden values from the class declaration always win, are computed at compile-time, and do not have a built-in hierarchy for resolving conflicts, allowing repeated overrides would cause catalog compilation to be unreliable and evaluation-order dependent.
 >
 > This was the original reason for adding external data bindings to include-like declarations: since external data is set **before** compile-time and has a **fixed hierarchy,** the compiler can safely rely on it without risk of conflicts.
-
 
 ### Using `include`
 
@@ -350,31 +339,31 @@ The `contain` function uses [include-like behavior][include-like]. (Multiple dec
 The `hiera_include` function requests a list of class names from [Hiera][], then declares all of them. Since it uses the [array lookup type][array_search], it will get a combined list that includes classes from **every level** of the [hierarchy][hiera_hierarchy]. This allows you to abandon [node definitions][node] and use Hiera like a lightweight ENC.
 
 ~~~ yaml
-# /etc/puppetlabs/puppet/hiera.yaml
+# /etc/puppetlabs/code/hiera.yaml
 ...
 hierarchy:
   - "%{::clientcert}"
   - common
 
-# /etc/puppetlabs/puppet/hieradata/web01.example.com.yaml
+# /etc/puppetlabs/code/hieradata/web01.example.com.yaml
 ---
 classes:
   - apache
   - memcached
   - wordpress
 
-# /etc/puppetlabs/puppet/hieradata/common.yaml
+# /etc/puppetlabs/code/hieradata/common.yaml
 ---
 classes:
   - base::linux
 ~~~
 
 ~~~ ruby
-# /etc/puppetlabs/puppet/manifests/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 hiera_include(classes)
 ~~~
 
-On the node `web01.example.com`, the example above would declare the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only declare `base::linux`.
+On the node `web01.example.com` in the production environment, the example above would declare the classes `apache`, `memcached`, `wordpress`, and `base::linux`. On other nodes, it would only declare `base::linux`.
 
 The `hiera_include` function uses [include-like behavior][include-like]. (Multiple declarations OK; relies on external data for parameters.) It accepts a single lookup key.
 
@@ -407,22 +396,16 @@ However, note that:
 * Any resource can specifically override metaparameter values received from its container.
 * Metaparameters which can take more than one value (like the [relationship][relationships] metaparameters) will merge the values from the container and any resource-specific values.
 
-
-
-Assigning Classes From an ENC
------
+## Assigning Classes From an ENC
 
 Classes can also be assigned to nodes by [external node classifiers][enc] and [LDAP node data][ldap_nodes]. Note that most ENCs assign classes with include-like behavior, and some ENCs assign them with resource-like behavior. See the [documentation of the ENC interface][enc] or the documentation of your specific ENC for complete details.
 
-
-
-Appendix: Smart Parameter Defaults
-------------------------------------
+## Appendix: Smart Parameter Defaults
 
 This design pattern can make for significantly cleaner code while enabling some really sophisticated behavior around default values.
 
 ~~~ ruby
-# /etc/puppet/modules/webserver/manifests/params.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/params.pp
 
 class webserver::params {
   $packages = $operatingsystem ? {
@@ -435,7 +418,7 @@ class webserver::params {
   }
 }
 
-# /etc/puppet/modules/webserver/manifests/init.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/init.pp
 
 class webserver(
   String $packages  = $webserver::params::packages,
@@ -459,40 +442,40 @@ To summarize what's happening here: When a class inherits from another class, it
 This is functionally equivalent to doing the following:
 
 ~~~ ruby
-# /etc/puppet/modules/webserver/manifests/init.pp
+# /etc/puppetlabs/code/modules/webserver/manifests/init.pp
 
 class webserver(String $packages = 'UNSET', String $vhost_dir = 'UNSET' ) {
 
- if $packages == 'UNSET' {
-   $real_packages = $operatingsystem ? {
-     /(?i-mx:ubuntu|debian)/        => 'apache2',
-     /(?i-mx:centos|fedora|redhat)/ => 'httpd',
-   }
- }
- else {
-    $real_packages = $packages
- }
+  if $packages == 'UNSET' {
+    $real_packages = $operatingsystem ? {
+      /(?i-mx:ubuntu|debian)/        => 'apache2',
+      /(?i-mx:centos|fedora|redhat)/ => 'httpd',
+    }
+  }
+  else {
+     $real_packages = $packages
+  }
 
- if $vhost_dir == 'UNSET' {
-   $real_vhost_dir = $operatingsystem ? {
-     /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
-     /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
-   }
- }
- else {
-    $real_vhost_dir = $vhost_dir
-}
+  if $vhost_dir == 'UNSET' {
+    $real_vhost_dir = $operatingsystem ? {
+      /(?i-mx:ubuntu|debian)/        => '/etc/apache2/sites-enabled',
+      /(?i-mx:centos|fedora|redhat)/ => '/etc/httpd/conf.d',
+    }
+  }
+  else {
+     $real_vhost_dir = $vhost_dir
+  }
 
- package { $real_packages: ensure => present }
+  package { $real_packages: ensure => present }
 
- file { 'vhost_dir':
-   path   => $real_vhost_dir,
-   ensure => directory,
-   mode   => '0750',
-   owner  => 'www-data',
-   group  => 'root',
- }
+  file { 'vhost_dir':
+    path   => $real_vhost_dir,
+    ensure => directory,
+    mode   => '0750',
+    owner  => 'www-data',
+    group  => 'root',
+  }
 }
 ~~~
 
-... but it's a significant readability win, especially if the amount of logic or the number of parameters gets any higher than what's shown in the example.
+This is a significant readability win, especially if the amount of logic or the number of parameters grows beyond what's shown in the example.

--- a/source/puppet/4.2/reference/lang_scope.markdown
+++ b/source/puppet/4.2/reference/lang_scope.markdown
@@ -20,12 +20,11 @@ canonical: "/puppet/latest/reference/lang_scope.html"
 [diagram]: ./images/scope-euler-diagram.png
 [lambda]: ./lang_lambdas.html
 
-Scope Basics
------
+## Scope Basics
 
-A **scope** is a specific **area of code,** which is partially isolated from other areas of code. Scopes limit the reach of:
+A **scope** is a specific **area of code** that is partially isolated from other areas of code. Scopes limit the reach of:
 
-* [Variables][]
+* [Variables][variables]
 * [Resource defaults][resourcedefaults]
 
 Scopes **do not** limit the reach of:
@@ -37,7 +36,7 @@ Scopes **do not** limit the reach of:
 
 ![An Euler diagram of several scopes. Top scope contains node scope, which contains the example::other, example::four, and example::parent scopes. Example::parent contains the example::child scope.][diagram]
 
-Any given scope has access to its own contents, and also receives additional contents from its **parent scope,** from node scope, and from top scope. (The rules for how Puppet determines a local scope's parent are described below in [Scope Lookup Rules.][scope_lookup_rules])
+Any given scope has access to its own contents, and also receives additional contents from its **parent scope,** node scope, and top scope. (The rules for how Puppet determines a local scope's parent are described below in [Scope Lookup Rules][scope_lookup_rules].)
 
 In the diagram above:
 
@@ -45,7 +44,6 @@ In the diagram above:
 * Node scope can access variables and defaults from its own scope **and** top scope.
 * Each of the `example::parent, example::other`, and `example::four` classes can access variables and defaults from their own scope, node scope, and top scope.
 * The `example::child` class can access variables and defaults from its own scope, `example::parent`'s scope, node scope, and top scope.
-
 
 ### Top Scope
 
@@ -62,8 +60,10 @@ class example {
 include example
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from elsewhere: Hi!
+~~~
+$ puppet apply site.pp
+notice: Message from elsewhere: Hi!
+~~~
 
 ### Node Scope
 
@@ -71,7 +71,7 @@ Code inside a [node definition][node] exists at **node scope.** Note that since 
 
 Variables and defaults declared at node scope are available **everywhere except top scope.**
 
-> Note: Classes and resources declared at top scope **bypass node scope entirely,** and so cannot access variables or defaults from node scope.
+> **Note:** Classes and resources declared at top scope **bypass node scope entirely,** and so cannot access variables or defaults from node scope.
 
 ~~~ ruby
 # site.pp
@@ -84,10 +84,12 @@ node 'puppet.example.com' {
 notify {"Message from top scope: $variable":}
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi!
-    notice: Top scope: Available!
-    notice: Message from top scope:
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi!
+notice: Top scope: Available!
+notice: Message from top scope:
+~~~
 
 In this example, node scope can access top scope variables, but not vice-versa.
 
@@ -98,14 +100,14 @@ Code inside a [class definition][class], [defined type][definedtype], or [lambda
 Variables and defaults declared in a local scope are only available in **that scope and its children.** There are two different sets of rules for when scopes are considered related; see "[scope lookup rules](#scope-lookup-rules)" below.
 
 ~~~ ruby
-# /etc/puppet/modules/scope_example/manifests/init.pp
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
 class scope_example {
   $variable = "Hi!"
   notify {"Message from here: $variable":}
   notify {"Node scope: $node_variable Top scope: $top_variable":}
 }
 
-# /etc/puppet/manifests/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 $top_variable = "Available!"
 node 'puppet.example.com' {
   $node_variable = "Available!"
@@ -115,27 +117,28 @@ node 'puppet.example.com' {
 notify {"Message from top scope: $variable":}
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi!
-    notice: Node scope: Available! Top scope: Available!
-    notice: Message from node scope:
-    notice: Message from top scope:
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi!
+notice: Node scope: Available! Top scope: Available!
+notice: Message from node scope:
+notice: Message from top scope:
+~~~
 
 In this example, a local scope can see "out" into node and top scope, but outer scopes cannot see "in."
-
 
 ### Overriding Received Values
 
 Variables and defaults declared at node scope can override those received from top scope. Those declared at local scope can override those received from node and top scope, as well as any parent scopes. That is: if multiple variables with the same name are available, **Puppet will use the "most local" one.**
 
 ~~~ ruby
-# /etc/puppet/modules/scope_example/manifests/init.pp
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
 class scope_example {
   $variable = "Hi, I'm local!"
   notify {"Message from here: $variable":}
 }
 
-# /etc/puppet/manifests/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 $variable = "Hi, I'm top!"
 
 node 'puppet.example.com' {
@@ -144,20 +147,22 @@ node 'puppet.example.com' {
 }
 ~~~
 
-    $ puppet apply site.pp
-    notice: Message from here: Hi, I'm local!
+~~~
+$ puppet apply site.pp
+notice: Message from here: Hi, I'm local!
+~~~
 
 Resource defaults are processed **by attribute** rather than as a block. Thus, defaults that declare different attributes will be merged, and only the attributes that conflict will be overridden.
 
 ~~~ ruby
-# /etc/puppet/modules/scope_example/manifests/init.pp
+# /etc/puppetlabs/code/modules/scope_example/manifests/init.pp
 class scope_example {
   File { ensure => directory, }
 
   file {'/tmp/example':}
 }
 
-# /etc/puppet/manifests/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 File {
   ensure => file,
   owner  => 'puppet',
@@ -168,8 +173,7 @@ include scope_example
 
 In this example, `/tmp/example` would be a directory owned by the `puppet` user, and would combine the defaults from top and local scope.
 
-More Details
------
+## More Details
 
 ### Scope of External Node Classifier Data
 
@@ -178,7 +182,7 @@ More Details
 
 This gives approximately the best and most-expected behavior --- variables from an ENC are available everywhere, and classes may use node-specific variables.
 
-> Note: this means compilation will fail if the site manifest tries to set a variable that was already set at top scope by an ENC.
+> **Note:** this means compilation will fail if the site manifest tries to set a variable that was already set at top scope by an ENC.
 
 ### Named Scopes and Anonymous Scopes
 
@@ -201,18 +205,16 @@ $local_copy = $apache::params::confdir
 
 This example would set the variable `$local_copy` to the value of the `$confdir` variable from the `apache::params` class.
 
-> Notes:
+> **Notes:**
 >
 > * Remember that top scope's name is the empty string. Thus, `$::my_variable` would always refer to the top-scope value of `$my_variable`, even if `$my_variable` has a different value in local scope.
 > * Note that a class must be [declared][declare_class] in order to access its variables; simply having the class available in your modules is insufficient.
 >
->   This means the availability of out-of-scope variables is **evaluation order dependent.** You should only access out-of-scope variables if the class accessing them can guarantee that the other class is already declared, usually by explicitly declaring it with `include` before trying to read its variables.
+> This means the availability of out-of-scope variables is **evaluation order dependent.** You should only access out-of-scope variables if the class accessing them can guarantee that the other class is already declared, usually by explicitly declaring it with `include` before trying to read its variables.
 
 Variables declared in **anonymous scopes** can only be accessed normally and do not have global qualified names.
 
-
-Scope Lookup Rules
------
+## Scope Lookup Rules
 
 [scope_lookup_rules]: #scope-lookup-rules
 
@@ -228,7 +230,7 @@ There are two different sets of scope lookup rules: **static scope** and **dynam
 In **static scope,** parent scopes are only assigned in the following ways:
 
 * Classes can receive parent scopes by [class inheritance][inheritance], using the `inherits` keyword. Any derived class receives the contents of its base class in addition to the contents of node and top scope.
-* A [lambda][]'s parent scope is the local scope in which the lambda is written. It can access variables in that scope by their short names.
+* A [lambda's][lambda] parent scope is the local scope in which the lambda is written. It can access variables in that scope by their short names.
 
 **All other** local scopes have no parents --- they only receive their own contents, and the contents of node scope (if applicable) and top scope.
 
@@ -256,8 +258,7 @@ In **dynamic scope,** parent scopes are assigned by both **inheritance** and **d
 
 This version of Puppet uses dynamic scope only for resource defaults.
 
-Messy Under-the-Hood Details
------
+## Messy Under-the-Hood Details
 
 * Node scope only exists if there is at least one node definition in the main manifest. If no node definitions exist, then ENC classes get declared at top scope.
 * Although top scope and node scope are described above as being special scopes, they are actually implemented as part of the chain of parent scopes, with node scope being a child of top scope and the parent of any classes declared inside the node definition. However, since the move to static scoping causes them to behave as little islands of dynamic scoping in a statically scoped world, it's simpler to think of them as special cases.

--- a/source/puppet/4.2/reference/lang_summary.markdown
+++ b/source/puppet/4.2/reference/lang_summary.markdown
@@ -34,8 +34,7 @@ Puppet uses its own configuration language, which was designed to be accessible 
 
 > To see how the Puppet language's features have evolved over time, see [History of the Puppet Language](/guides/language_history.html).
 
-Resources, Classes, and Nodes
------
+## Resources, Classes, and Nodes
 
 The core of the Puppet language is **declaring [resources][].** Every other part of the language exists to add flexibility and convenience to the way resources are declared.
 
@@ -43,16 +42,13 @@ Groups of resources can be organized into **[classes][],** which are larger unit
 
 Nodes that serve different roles will generally get different sets of classes. The task of configuring which classes will be applied to a given node is called **node classification.**  Nodes can be classified in the Puppet language using [node definitions][node]; they can also be classified using node-specific data from outside your manifests, such as that from an [ENC][] or [Hiera][].
 
-
-Ordering
------
+## Ordering
 
 Although Puppet's language is built around describing resources (and the relationships between them) in a declarative way, several parts of the language do depend on evaluation order. The most notable of these are variables, which must be set before they are referenced.
 
 In the rest of this document, we try to call out areas where the order of statements matters.
 
-Files
------
+## Files
 
 Puppet language files are called **manifests,** and are named with the `.pp` file extension. Manifest files:
 
@@ -73,11 +69,9 @@ Windows uses CRLF line endings instead of \*nix's LF line endings.
 * If a file is being downloaded to a Windows node with the `source` attribute, Puppet will transfer the file in "binary" mode, leaving the original newlines untouched.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](/references/4.2.latest/type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
-    > Note: When writing your own resource types, you can get this behavior by using the `flat` filetype.
+> **Note:** When writing your own resource types, you can get this behavior by using the `flat` filetype.
 
-
-Compilation and Catalogs
------
+## Compilation and Catalogs
 
 Puppet manifests can use conditional logic to describe many nodes' configurations at once. Before configuring a node, Puppet compiles manifests into a **catalog,** which is only valid for a single node and which contains no ambiguous logic.
 
@@ -89,9 +83,7 @@ Agent nodes cache their most recent catalog. If they request a catalog and the m
 
 For more information, see [the reference page on catalog compilation][compilation].
 
-
-Example
------
+## Example
 
 The following short manifest manages NTP. It uses [package][], [file][], and [service][] resources; a [case statement][case] based on a [fact][]; [variables][]; [ordering][] and [notification][] relationships; and [file contents being served from a module][fileserve].
 
@@ -118,10 +110,6 @@ file { 'ntp.conf':
   require => Package['ntp'],
   source  => "puppet:///modules/ntp/ntp.conf",
   # This source file would be located on the Puppet master at
-  # /etc/puppetlabs/puppet/modules/ntp/files/ntp.conf (in Puppet Enterprise)
-  # or
-  # /etc/puppet/modules/ntp/files/ntp.conf (in open source Puppet)
+  # /etc/puppetlabs/code/modules/ntp/files/ntp.conf
 }
 ~~~
-
-

--- a/source/puppet/4.2/reference/modules_installing.markdown
+++ b/source/puppet/4.2/reference/modules_installing.markdown
@@ -4,7 +4,7 @@ title: "Installing Modules"
 canonical: "/puppet/latest/reference/modules_installing.html"
 ---
 
-[forge]: http://forge.puppetlabs.com
+[forge]: https://forge.puppetlabs.com
 [module_man]: /references/4.2.latest/man/module.html
 [modulepath]: /references/4.2.latest/configuration.html#modulepath
 
@@ -12,22 +12,20 @@ canonical: "/puppet/latest/reference/modules_installing.html"
 [fundamentals]: ./modules_fundamentals.html
 [plugins]: /guides/plugins_in_modules.html
 [documentation]: ./modules_documentation.html
-[errors]: https://docs.puppetlabs.com/windows/troubleshooting.html#error-messages
+[errors]: /windows/troubleshooting.html#error-messages
 
-Installing Modules
-=====
->**Puppet Enterprise Users Note**
->For a complete guide to installing and managing modules, you'll need to go to the [Installing Modules page](https://docs.puppetlabs.com/pe/3.8/modules_installing.html)
+> **Puppet Enterprise Users Note**
 >
+> For a complete guide to installing and managing modules, please see the [Installing Modules page](/pe/2015.2/modules_installing.html).
 
 ![Windows note](/images/windows-logo-small.jpg)
 
 * Windows nodes that pull configurations from a Linux or Unix Puppet master can use any Forge modules installed on the master. Continue reading to learn how to use the module tool on your Puppet master.
 * If you are getting SSL errors or cannot get the Puppet module tool to work, check out our [error messages documentation][errors].
 
->**Solaris Note**
+> **Solaris Note**
 >
->To use the Puppet module tool on Solaris systems, you must first install gtar.
+> To use the Puppet module tool on Solaris systems, you must first install gtar.
 
 The [Puppet Forge][forge] (Forge) is a repository of pre-existing modules, written and contributed by users. These modules solve a wide variety of problems, so using them can save you time and effort.
 
@@ -39,11 +37,9 @@ The `puppet module` subcommand is a tool for finding and managing new modules fr
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
+## Using the Module Tool
 
-Using the Module Tool
------
-
-The `puppet module` subcommand has several *actions.* The main actions used for managing modules are `install`, `list`, `search`, `uninstall`, and `upgrade`.
+The `puppet module` subcommand has several _actions._ The main actions used for managing modules are `install`, `list`, `search`, `uninstall`, and `upgrade`.
 
 If you have used a command line package manager tool (like `gem`, `apt-get`, or `yum`) before, these actions will generally do what you expect. You can view a full description of each action with `puppet man module` or by [viewing the man page here][module_man]. In short:
 
@@ -51,130 +47,137 @@ If you have used a command line package manager tool (like `gem`, `apt-get`, or 
 
 Install a module from the Forge or a release archive.
 
-    # puppet module install puppetlabs-apache --version 0.0.2
+~~~ bash
+sudo puppet module install puppetlabs-apache --version 0.0.2
+~~~
 
 #### `list`
 
 List installed modules.
 
-    # puppet module list
+~~~ bash
+sudo puppet module list
+~~~
 
 #### `search`
 
 Search the Forge for a module.
 
-    # puppet module search apache
+~~~ bash
+sudo puppet module search apache
+~~~
 
 #### `uninstall`
 
 Uninstall a Puppet module.
 
-    # puppet module uninstall puppetlabs-apache
+~~~ bash
+sudo puppet module uninstall puppetlabs-apache
+~~~
 
 #### `upgrade`
 
 Upgrade a Puppet module.
 
-    # puppet module upgrade puppetlabs-apache --version 0.0.3
-
+~~~ bash
+sudo puppet module upgrade puppetlabs-apache --version 0.0.3
+~~~
 
 ## Using the Module Tool Behind a Proxy
 
 In order to use the Puppet module tool behind a proxy, you need to set the following:
 
-	export http_proxy=http://10.187.255.9:8080
-	export https_proxy=http://10.187.255.9:8080
+~~~
+export http_proxy=http://10.187.255.9:8080
+export https_proxy=http://10.187.255.9:8080
+~~~
 
 Alternatively, you can set these two proxy settings inside the `user` config section in the `puppet.conf` file: `http_proxy_host` and `http_proxy_port`. For more information, see [Configuration Reference](/references/4.2.latest/configuration.html).
 
-**Note:** Make sure to set these two proxy settings in the `user` section only. Otherwise, there can be adverse effects.
+> **Note:** Make sure to set these two proxy settings in the `user` section only. Otherwise, there can be adverse effects.
 
-Installing Modules
------
+## Installing Modules
 
-The `puppet module install` action will install a module and all of its dependencies. By default, it will install into the first directory in Puppet's modulepath.
+The `puppet module install` action will install a module and all of its dependencies. By default, it installs into the first directory in Puppet's [modulepath][].
 
 * Use the `--version` option to specify a version. You can use an exact version or a requirement string like `>=1.0.3`.
-* Use the `--force` option to forcibly install a module or re-install an existing module (**note:** does not install dependencies).
+* Use the `--force` option to forcibly install a module or re-install an existing module. (**Note:** Does not install dependencies.)
 * Use the `--environment` option to install into a different environment.
-* Use the `--modulepath` option to manually specify which directory to install into. **Note:** To avoid duplicating modules installed as dependencies, you may need to specify the modulepath as a list of directories; see [the documentation for setting the modulepath][modulepath] for details.
+* Use the `--modulepath` option to manually specify which directory to install into. (**Note:** To avoid duplicating modules installed as dependencies, you may need to specify the modulepath as a list of directories; see [the documentation for setting the modulepath][modulepath] for details.)
 * Use the `--ignore-dependencies` option to skip installing any modules required by this module.
 * Use the `--debug` option to see additional information about what the Puppet module tool is doing.
 
-
->**A note about installing**
+> **A note about installing**
 >
->As of Puppet 3.6, if any module in your /etc/puppetlabs/puppet/modules directory has incorrect versioning (anything other than major.minor.patch), attempting to install a module will result in this warning.
+> As of Puppet 3.6, if any module in your `modules` directory (`/etc/puppetlabs/code/modules` in Puppet 4) has incorrect versioning (anything other than major.minor.patch), attempting to install a module will result in this warning:
 >
->~~~
->Warning: module (/Users/youtheuser/.puppet/modules/module) has an invalid version number (0.1). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).
-~~~
+> `Warning: module (/Users/youtheuser/.puppet/modules/module) has an invalid version number (0.1). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).`
 >
->Despite the warning, your module will still be downloaded. The metadata of the offending module will not be altered. The versioning information has only been changed in memory during the run of the program.
-
+> Despite the warning, Puppet still downloads your module and does not permanently change the offending module's metadata. The versioning information has only been changed in memory during the run of the program.
 
 ### Installing From the Puppet Forge
 
 To install a module from the Puppet Forge, simply identify the desired module by its full name. The full name of a Forge module is formatted as username-modulename.
 
-    # puppet module install puppetlabs-apache
+~~~ bash
+sudo puppet module install puppetlabs-apache
+~~~
 
-### Installing From Another Module Repository
+### Installing from Another Module Repository
 
-The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/4.2.latest/configuration.html#modulerepository) setting in [`puppet.conf`](/guides/configuring.html), or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `https://forgeapi.puppetlabs.com`.
+The module tool can install modules from other repositories that mimic the Forge's interface. To do this, change the [`module_repository`](/references/4.2.latest/configuration.html#modulerepository) setting in [`puppet.conf`](./config_file_main.html) or specify a repository on the command line with the `--module_repository` option. The value of this setting should be the base URL of the repository; the default value, which uses the Forge, is `https://forgeapi.puppetlabs.com`.
 
 After setting the repository, follow the instructions above for installing from the Forge.
 
-    # puppet module install --module_repository http://dev-forge.example.com puppetlabs-apache
+~~~ bash
+sudo puppet module install --module_repository http://dev-forge.example.com puppetlabs-apache
+~~~
 
-### Installing From a Release Tarball
+### Installing from a Release Tarball
 
 To install a module from a release tarball, specify the path to the tarball instead of the module name.
 
 Make sure to use the `--ignore-dependencies` flag if you cannot currently reach the Puppet Forge or are installing modules that have not yet been published to the Forge. This flag will tell the Puppet module tool not to try to resolve dependencies by connecting to the Forge. Be aware that in this case you must manually install any dependencies.
 
-    # puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependencies
+~~~ bash
+sudo puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependencies
+~~~
 
+> **Note:** You can manually install modules without the `puppet module` tool. If you do, you must name your module's directory appropriately. Module directory names can only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and cause errors when attempting to use the module.
 
- >**Note:**
- >
- >It is possible to install modules manually without the assistance of the Puppet module tool. If you choose to do so, you must make sure that your module's directory is appropriately named. Module directory names can only contain letters, numbers, and underscores. Dashes and periods are **no longer valid** and will cause errors when attempting to use the module.
+## Finding Modules
 
+You can find modules by browsing the Forge's [web interface][forge] or using the module tool's `search` action. The search action accepts a single search term and returns a list of modules whose names, descriptions, or keywords match the search term.
 
-Finding Modules
------
-
-Modules can be found by browsing the Forge's [web interface][forge] or by using the module tool's `search` action. The search action accepts a single search term and returns a list of modules whose names, descriptions, or keywords match the search term.
-
-    $ puppet module search apache
-    Searching http://forge.puppetlabs.com ...
-    NAME                           DESCRIPTION            AUTHOR          KEYWORDS
-    puppetlabs-apache              This is a generic ...  @puppetlabs     apache web
-    puppetlabs-passenger           Module to manage P...  @puppetlabs     apache
-    DavidSchmitt-apache            Manages apache, mo...  @DavidSchmitt   apache
-    jamtur01-httpauth              Puppet HTTP Authen...  @jamtur01       apache
-    jamtur01-apachemodules         Puppet Apache Modu...  @jamtur01       apache
-    adobe-hadoop                   Puppet module to d...  @adobe          apache
-    adobe-hbase                    Puppet module to d...  @adobe          apache
-    adobe-zookeeper                Puppet module to d...  @adobe          apache
-    adobe-highavailability         Puppet module to c...  @adobe          apache mon
-    adobe-mon                      Puppet module to d...  @adobe          apache mon
-    puppetmanaged-webserver        Apache webserver m...  @puppetmanaged  apache
-    ghoneycutt-apache              Manages apache ser...  @ghoneycutt     apache web
-    ghoneycutt-sites               This module manage...  @ghoneycutt     apache web
-    fliplap-apache_modules_sles11  Exactly the same a...  @fliplap
-    mstanislav-puppet_yum          Puppet 2.              @mstanislav     apache
-    mstanislav-apache_yum          Puppet 2.              @mstanislav     apache
-    jonhadfield-wordpress          Puppet module to s...  @jonhadfield    apache php
-    saz-php                        Manage cli, apache...  @saz            apache php
-    pmtacceptance-apache           This is a dummy ap...  @pmtacceptance  apache php
-    pmtacceptance-php              This is a dummy ph...  @pmtacceptance  apache php
+~~~
+$ puppet module search apache
+Searching http://forge.puppetlabs.com ...
+NAME                           DESCRIPTION            AUTHOR          KEYWORDS
+puppetlabs-apache              This is a generic ...  @puppetlabs     apache web
+puppetlabs-passenger           Module to manage P...  @puppetlabs     apache
+DavidSchmitt-apache            Manages apache, mo...  @DavidSchmitt   apache
+jamtur01-httpauth              Puppet HTTP Authen...  @jamtur01       apache
+jamtur01-apachemodules         Puppet Apache Modu...  @jamtur01       apache
+adobe-hadoop                   Puppet module to d...  @adobe          apache
+adobe-hbase                    Puppet module to d...  @adobe          apache
+adobe-zookeeper                Puppet module to d...  @adobe          apache
+adobe-highavailability         Puppet module to c...  @adobe          apache mon
+adobe-mon                      Puppet module to d...  @adobe          apache mon
+puppetmanaged-webserver        Apache webserver m...  @puppetmanaged  apache
+ghoneycutt-apache              Manages apache ser...  @ghoneycutt     apache web
+ghoneycutt-sites               This module manage...  @ghoneycutt     apache web
+fliplap-apache_modules_sles11  Exactly the same a...  @fliplap
+mstanislav-puppet_yum          Puppet 2.              @mstanislav     apache
+mstanislav-apache_yum          Puppet 2.              @mstanislav     apache
+jonhadfield-wordpress          Puppet module to s...  @jonhadfield    apache php
+saz-php                        Manage cli, apache...  @saz            apache php
+pmtacceptance-apache           This is a dummy ap...  @pmtacceptance  apache php
+pmtacceptance-php              This is a dummy ph...  @pmtacceptance  apache php
+~~~
 
 Once you've identified the module you need, you can install it by name as described above.
 
-
-Managing Modules
------
+## Managing Modules
 
 ### Listing Installed Modules
 
@@ -184,7 +187,7 @@ Use the module tool's `list` action to see which modules you have installed (and
 
 ### Upgrading Modules
 
-Use the module tool's `upgrade` action to upgrade an installed module to the latest version. The target module must be identified by its full name (username-modulename).
+Use the module tool's `upgrade` action to upgrade an installed module to the latest version. You must identify the target module by its full name (username-modulename).
 
 * Use the `--version` option to specify a version.
 * Use the `--ignore-changes` option to upgrade the module while ignoring and overwriting any local changes that may have been made.
@@ -192,16 +195,18 @@ Use the module tool's `upgrade` action to upgrade an installed module to the lat
 
 ### Uninstalling Modules
 
-Use the module tool's `uninstall` action to remove an installed module. The target module must be identified by its full name:
+Use the module tool's `uninstall` action to remove an installed module. You must identify the target module by its full name  (username-modulename).
 
-    # puppet module uninstall apache
-    Error: Could not uninstall module 'apache':
-      Module 'apache' is not installed
-          You may have meant `puppet module uninstall puppetlabs-apache`
-    # puppet module uninstall puppetlabs-apache
-    Removed /etc/puppet/modules/apache (v0.0.3)
+~~~
+$ sudo puppet module uninstall apache
+Error: Could not uninstall module 'apache':
+  Module 'apache' is not installed
+      You may have meant `puppet module uninstall puppetlabs-apache`
+$ sudo puppet module uninstall puppetlabs-apache
+Removed /etc/puppetlabs/code/modules/apache (v0.0.3)
+~~~
 
-By default, the tool won't uninstall a module which other modules depend on or whose files have been edited since it was installed.
+By default, the tool won't uninstall a module that other modules depend on, or whose files have been edited since it was installed.
 
 * Use the `--force` option to uninstall even if the module is depended upon or has been manually edited.
 
@@ -211,24 +216,24 @@ By default, the tool won't uninstall a module which other modules depend on or w
 
 The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
-If you see an error similar to the following when upgrading or uninstalling,
+You might see an error similar to the following when upgrading or uninstalling:
 
 ~~~
 Notice: Preparing to upgrade 'puppetlabs-motd' ...
-Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/puppet/modules ...
+Notice: Found 'puppetlabs-motd' (v1.0.0) in /etc/puppetlabs/code/modules ...
 Error: Could not upgrade module 'puppetlabs-motd' (v1.0.0 -> latest)
   Installed module has had changes made locally
 ~~~
 
-you can workaround it by upgrading or uninstalling using the `--ignore-changes` option.
+You can workaround it by upgrading or uninstalling using the `--ignore-changes` option.
 
 #### PE-only modules
 
-If you received an error while attempting to install a module from the Forge that looks like:
+You might see an error while attempting to install a module from the Forge that looks like:
 
 ~~~
- # puppet module install puppetlabs-mssql
-Notice: Preparing to install into /etc/puppetlabs/puppet/modules ...
+$ sudo puppet module install puppetlabs-mssql
+Notice: Preparing to install into /etc/puppetlabs/code/modules ...
 Notice: Downloading from https://forgeapi.puppetlabs.com ...
 Error: Request to Puppet Forge failed.
   The server being queried was https://forgeapi.puppetlabs.com/v3/releases?module=puppetlabs-mssql&module_groups=base+pe_only
@@ -236,6 +241,6 @@ Error: Request to Puppet Forge failed.
   The message we received said 'You must have a valid Puppet Enterprise license on this node in order to download puppetlabs-mssql. If you have a Puppet Enterprise license, please see https://docs.puppetlabs.com/forge/pe-only-modules for more information.'
 ~~~
 
-it is because the module you are trying to download is only available to Puppet Enterprise users. To use this module, download [Puppet Enterprise](http://puppetlabs.com/puppet/puppet-enterprise).
+It is because the module you are trying to download is only available to Puppet Enterprise users. To use this module, download [Puppet Enterprise](https://puppetlabs.com/puppet/puppet-enterprise).
 
-If you are a Puppet Enterprise user, use the [troubleshooting guide](https://docs.puppetlabs.com/pe/latest/modules_installing.html#errors).
+If you are a Puppet Enterprise user, use the [troubleshooting guide](/pe/2015.2/modules_installing.html#errors).

--- a/source/puppet/4.2/reference/services_agent_unix.markdown
+++ b/source/puppet/4.2/reference/services_agent_unix.markdown
@@ -32,7 +32,6 @@ This page describes how Puppet agent behaves on \*nix systems. For information a
 
 Not all operating systems can manage the same resources with Puppet; some resource types are OS-specific, and others may have OS-specific features. See the [resource type reference][] for details.
 
-
 ## Puppet Agent's Run Environment
 
 Puppet agent runs as a specific user (usually `root`) and initiates outbound connections on port 8140.
@@ -109,22 +108,27 @@ In Puppet Enterprise, the agent service is automatically configured and started;
 
 In open source Puppet, you can enable the service with:
 
-    $ sudo puppet resource service puppet ensure=running enable=true
+~~~ bash
+sudo puppet resource service puppet ensure=running enable=true
+~~~
 
 Alternately, you can run `sudo puppet agent` on the command line with no additional options; this will cause Puppet agent to start running and daemonize, but you won't have an easy interface for restarting or stopping it. To stop the daemon, use the process ID from the agent's [`pidfile`][pidfile]:
 
-    $ sudo kill $(puppet config print pidfile --section agent)
+~~~ bash
+sudo kill $(puppet config print pidfile --section agent)
+~~~
 
 #### Configuring the Run Interval
 
 The Puppet agent service defaults to doing a configuration run every 30 minutes. You can configure this with [the `runinterval` setting][runinterval] in [puppet.conf][]:
 
-    # /etc/puppet/puppet.conf
-    [agent]
-      runinterval = 2h
+~~~
+# /etc/puppetlabs/puppet/puppet.conf
+[agent]
+  runinterval = 2h
+~~~
 
 If you don't need an aggressive schedule of configuration runs, a longer run interval will let your Puppet master server(s) handle many more agent nodes.
-
 
 ### Running Puppet Agent as a Cron Job
 
@@ -134,7 +138,9 @@ This behavior is good for building a cron job that does configuration runs. You 
 
 You can use the Puppet resource command to set up this cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
-    $ sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+~~~ bash
+sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+~~~
 
 ### Running Puppet Agent On Demand
 
@@ -148,11 +154,15 @@ If you are currently logged into the machine that needs to run Puppet agent, you
 
 **Run in the foreground, with verbose logging to the terminal:**
 
-    $ sudo puppet agent --test
+~~~ bash
+sudo puppet agent --test
+~~~
 
 **Run once in the background:**
 
-    $ sudo puppet agent --onetime
+~~~ bash
+sudo puppet agent --onetime
+~~~
 
 Note that this won't notify you when the run is completed.
 
@@ -160,7 +170,9 @@ Note that this won't notify you when the run is completed.
 
 To run Puppet agent remotely on one machine, you can simply use ssh:
 
-    $ ssh ops@magpie.example.com sudo puppet agent --test
+~~~ bash
+ssh ops@magpie.example.com sudo puppet agent --test
+~~~
 
 To run remotely on _many_ machines, you will need some form of orchestration or parallel execution tool.
 
@@ -172,13 +184,11 @@ Alternately, [parallel SSH][pssh] can be a more lightweight solution for doing P
 
 [pssh]: https://code.google.com/p/parallel-ssh/
 
-
 ## Disabling and Re-enabling Puppet Runs
 
 Regardless of how you're running Puppet agent, you can prevent it from doing any Puppet runs by running `sudo puppet agent --disable "<MESSAGE>"`. You can re-enable it with `sudo puppet agent --enable`.
 
 If Puppet agent attempts to do a configuration run while disabled --- either a scheduled run or a manually triggered one --- it will log a message like `Notice: Skipping run of Puppet configuration client; administratively disabled (Reason: 'Investigating a problem 5/23/14 -NF'); Use 'puppet agent --enable' to re-enable.`
-
 
 ## Configuring Puppet Agent
 

--- a/source/puppet/4.2/reference/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.2/reference/ssl_attributes_extensions.markdown
@@ -24,13 +24,13 @@ It might also be useful in deployments where Puppet is used to deploy private ke
 
 If your deployment doesn't match one of these descriptions, you might not need this feature.
 
-## Timing: When Data Can be Added to CSRs / Certificates
+## Timing: When Data Can be Added to CSRs and Certificates
 
 When Puppet agent starts the process of requesting a catalog, it first checks whether it has a valid signed certificate. If it does not, it generates a key pair, crafts a CSR, and submits it to the certificate authority (CA) Puppet master. The steps are [covered in more detail in the reference page about agent/master HTTPS traffic][cert_request].
 
 For all practical purposes, a certificate is locked and immutable as soon as it is signed. For any data to persist in the certificate, it has to be added to the CSR _before_ the CA signs the certificate.
 
-This means **any desired extra data must be present _before_ Puppet agent attempts to request its catalog for the first time**.
+This means **any desired extra data must be present _before_ Puppet agent attempts to request its catalog for the first time.**
 
 Practically speaking, you should populate any extra data when provisioning the node. If you mess up, see [Recovering From Failed Data Embedding](#recovering-from-failed-data-embedding) below.
 
@@ -83,7 +83,7 @@ Attributes:
 
 ### Recommended OIDs for Attributes
 
-Custom attributes can use any public or site-specific OID, **with the exception of the OIDs used for core X.509 functionality**. This means you can't re-use existing OIDs for things like subject alternative names.
+Custom attributes can use any public or site-specific OID, **with the exception of the OIDs used for core X.509 functionality.** This means you can't re-use existing OIDs for things like subject alternative names.
 
 One useful OID is the "challengePassword" attribute --- `1.2.840.113549.1.9.7`. This is a rarely-used corner of X.509 that can easily be repurposed to hold a pre-shared key. The benefit of using this instead of an arbitrary OID is that it appears by name when using OpenSSL to dump the CSR to text; OIDs that `openssl req` can't recognize are displayed as numerical strings.
 
@@ -128,12 +128,12 @@ In the output, look for a section called "Requested Extensions," which generally
 
 ~~~
 Requested Extensions:
-        pp_uuid:
-        .$ED803750-E3C7-44F5-BB08-41A04433FE2E
-        1.3.6.1.4.1.34380.1.1.3:
-        ..my_ami_image
-        1.3.6.1.4.1.34380.1.1.4:
-        .$342thbjkt82094y0uthhor289jnqthpc2290
+    pp_uuid:
+    .$ED803750-E3C7-44F5-BB08-41A04433FE2E
+    1.3.6.1.4.1.34380.1.1.3:
+    ..my_ami_image
+    1.3.6.1.4.1.34380.1.1.4:
+    .$342thbjkt82094y0uthhor289jnqthpc2290
 ~~~
 
 Note that every extension is preceded by any combination of two characters (`.$` and `..` in the above example) that contain ASN.1 encoding information. Since OpenSSL is unaware of Puppet's custom extensions OIDs, it's unable to properly display the values.
@@ -193,10 +193,10 @@ if [ ! -d /etc/puppetlabs/puppet ]; then
 fi
 erb > /etc/puppetlabs/puppet/csr_attributes.yaml <<END
 custom_attributes:
-  1.2.840.113549.1.9.7: mySuperAwesomePassword
+    1.2.840.113549.1.9.7: mySuperAwesomePassword
 extension_requests:
-  pp_instance_id: <%= %x{/opt/aws/bin/ec2-metadata -i}.sub(/instance-id: (.*)/,'\1').chomp %>
-  pp_image_name:  <%= %x{/opt/aws/bin/ec2-metadata -a}.sub(/ami-id: (.*)/,'\1').chomp %>
+    pp_instance_id: <%= %x{/opt/aws/bin/ec2-metadata -i}.sub(/instance-id: (.*)/,'\1').chomp %>
+    pp_image_name:  <%= %x{/opt/aws/bin/ec2-metadata -a}.sub(/ami-id: (.*)/,'\1').chomp %>
 END
 ~~~
 
@@ -210,13 +210,13 @@ When first testing this feature, you might fail to embed the right information i
 
 To start over, do the following:
 
-**On the test node**:
+**On the test node:**
 
 * Turn off Puppet agent, if it's running.
 * Check whether a CSR is present; it will be at `$ssldir/certificate_requests/<name>.pem`. If it exists, delete it.
 * Check whether a certificate is present; it will be at `$ssldir/certs/<name>.pem`. If it exists, delete it.
 
-**On the CA Puppet master**:
+**On the CA Puppet master:**
 
 * Check whether a signed certificate exists; use `puppet cert list --all` to see the complete list. If it exists, revoke and delete it with `puppet cert clean <name>`.
 * Check whether a CSR for the node exists; it will be in `$ssldir/ca/requests/<name>.pem`. If it exists, delete it.

--- a/source/puppet/4.2/reference/upgrade_major_agent.markdown
+++ b/source/puppet/4.2/reference/upgrade_major_agent.markdown
@@ -72,7 +72,7 @@ In Puppet 3, the default `ssldir` is `/etc/puppet/ssl`; some systems might also 
 Locate your [`ssldir`](./dirs_ssldir.html) in `/etc/puppet/puppet.conf` and move that directory's contents to `/etc/puppetlabs/puppet/ssl` without changing the files' permissions. For example, run:
 
 ~~~ bash
-# cp -rp /var/lib/puppet/ssl /etc/puppetlabs/puppet/ssl
+sudo cp -rp /var/lib/puppet/ssl /etc/puppetlabs/puppet/ssl
 ~~~
 
 ### Reconcile `puppet.conf`

--- a/source/puppet/4.2/reference/upgrade_major_server.markdown
+++ b/source/puppet/4.2/reference/upgrade_major_server.markdown
@@ -129,7 +129,7 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move Code
 
-> **Note**: You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 


### PR DESCRIPTION
Several parts of the open source Puppet documentation continue to refer to the Puppet 3 `confdir` path `/etc/puppet/` instead of Puppet 4's `/etc/puppetlabs/puppet`. This commit resolves this in several articles.

This commit also includes copy edits, content style updates, link updates, YAML updates, and markdown and formatting style updates for the affected articles.