### PR TITLE
DOCUMENT-437: Correct external facts directories for Facter 3.x

### DIFF
--- a/source/facter/3.0/custom_facts.md
+++ b/source/facter/3.0/custom_facts.md
@@ -329,8 +329,9 @@ In a module (recommended):
 
     <MODULEPATH>/<MODULE>/facts.d/
 
-On Unix/Linux/Mac OS X, there are two directories:
+On Unix/Linux/Mac OS X, there are three directories:
 
+    /opt/puppetlabs/facter/facts.d/
     /etc/puppetlabs/facter/facts.d/
     /etc/facter/facts.d/
 

--- a/source/facter/3.1/custom_facts.md
+++ b/source/facter/3.1/custom_facts.md
@@ -329,8 +329,9 @@ In a module (recommended):
 
     <MODULEPATH>/<MODULE>/facts.d/
 
-On Unix/Linux/Mac OS X, there are two directories:
+On Unix/Linux/Mac OS X, there are three directories:
 
+    /opt/puppetlabs/facter/facts.d/
     /etc/puppetlabs/facter/facts.d/
     /etc/facter/facts.d/
 


### PR DESCRIPTION
This PR adds the `/opt/puppetlabs/facter/facts.d` directory to the Unix/Linux/MacOS X list of external facts directories.