### PR TITLE
Fix FACTERLIB examples, update style, and fix typos in Facter 1.x/2.x docs

### DIFF
--- a/source/facter/1.6/custom_facts.markdown
+++ b/source/facter/1.6/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 1.6: Custom Facts"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
-You can use these methods of loading facts do to things like test files locally
+You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,100 +45,101 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
-Custom facts can be distributed to clients using the [Plugins In Modules](/guides/plugins_in_modules.html) method.
+Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
 ## Two Parts of Every Fact
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you two ways to
+output from those commands using standard Ruby code. The Facter API gives you two ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode "uname --hardware-platform"`
-  * if your fact is any more complicated than that, you'll have to call `Facter::Util::Resolution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode "uname --hardware-platform"`.
+* If your fact is any more complicated than that, you can call `Facter::Util::Resolution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Util::Resolution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Util::Resolution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
 > **Note:** Prior to Facter 1.5.8, values returned by `Facter::Util::Resolution.exec` often had trailing newlines. If your custom fact will also be used by older versions of Facter, you may need to call `chomp` on these values. (In the example above, this would look like `Facter::Util::Resolution.exec('/bin/uname --hardware-platform').chomp`.)
 
-You can then use the instructions in [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value('somefact')`.
+You can write a fact that uses other facts by accessing `Facter.value('somefact')`.
 
 For example:
 
 ~~~ ruby
-    Facter.add('osfamily') do
-      setcode do
-        distid = Facter.value('lsbdistid')
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add('osfamily') do
+  setcode do
+    distid = Facter.value('lsbdistid')
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -160,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Util::Resolution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Util::Resolution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
-Once Facter rules out any resolutions that are excluded because of `confine` statments,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+Facter decides the issue of precedence using the weight property.
+Once Facter rules out any resolutions that are excluded because of `confine` statements,
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -232,12 +226,12 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Viewing Fact Values
@@ -245,4 +239,4 @@ that fact and move on.
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.

--- a/source/facter/1.7/custom_facts.markdown
+++ b/source/facter/1.7/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 1.7: Custom Facts"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
-You can use these methods of loading facts do to things like test files locally
+You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,98 +45,99 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
-Custom facts can be distributed to clients using the [Plugins In Modules](/guides/plugins_in_modules.html) method.
+Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
 ## Two Parts of Every Fact
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you two ways to
+output from those commands using standard Ruby code. The Facter API gives you two ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode "uname --hardware-platform"`
-  * if your fact is any more complicated than that, you'll have to call `Facter::Util::Resolution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode "uname --hardware-platform"`.
+* If your fact is any more complicated than that, you can call `Facter::Util::Resolution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Util::Resolution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Util::Resolution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in [Plugins in Modules](/guides/plugins_in_modules.html) page to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value('somefact')`.
+You can write a fact that uses other facts by accessing `Facter.value('somefact')`.
 
 For example:
 
 ~~~ ruby
-    Facter.add('osfamily') do
-      setcode do
-        distid = Facter.value('lsbdistid')
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add('osfamily') do
+  setcode do
+    distid = Facter.value('lsbdistid')
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -158,71 +152,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Util::Resolution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Util::Resolution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
+Facter decides the issue of precedence using the weight property.
 Once Facter rules out any resolutions that are excluded because of `confine` statments,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -230,12 +224,12 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Viewing Fact Values
@@ -243,22 +237,19 @@ that fact and move on.
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-External facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+External facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 On Unix/Linux/Mac OS X:
 
@@ -273,32 +264,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user: (Facter 1.7.4 or later, on both \*nix and Windows)
+When running as a non-root or non-Administrator user: (Facter 1.7.4 or later, on both \*nix and Windows)
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-            print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -306,46 +296,50 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-> **Note:** Executable facts on Windows are supported in Facter 1.7.3 and later; if you are using 1.7.0 through 1.7.2, you must upgrade in order to use them.
+> **Note:** Executable facts on Windows are supported in Facter 1.7.3 and later. If you use Facter 1.7.0 through 1.7.2, you must upgrade to use them.
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 1.7 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in the format:
 
     key1=value1
     key2=value2
     key3=value3
 
-Using this format, a single script can return multiple facts in one return.
+Using this format, a single script can return multiple facts at once.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -358,50 +352,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-An example would be in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -409,13 +406,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -427,14 +422,12 @@ The output should look similar to the timing for ruby facts, but will name exter
 
 #### External Facts and stdlib
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Although we plan to allow distribution of external facts through Puppet's pluginsync capability, this is not yet supported. See [ticket #9546](https://projects.puppetlabs.com/issues/9546)
+* Although we plan to allow distribution of external facts through Puppet's pluginsync capability, this was not supported in Facter 1.7. See [ticket #9546](https://projects.puppetlabs.com/issues/9546).

--- a/source/facter/2.0/custom_facts.markdown
+++ b/source/facter/2.0/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 2.0: Custom Facts Walkthrough"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](./plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
-You can use these methods of loading facts do to things like test files locally
+You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,26 +45,28 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
 Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
@@ -79,72 +74,72 @@ Custom facts can be distributed to clients using the [Plugins in Modules](/guide
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you a few ways to
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-  * if your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
-  * in any case, remember that your shell command is also a ruby string, so you'll need to escape special characters if you want to pass them through.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`.
+* If your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
+* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in [Plugins In Modules](./plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` will return `nil`; but if the fact can't be found at all, it will throw an error.
+You can write a fact that uses other facts by accessing
+`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` returns `nil`; but if the fact can't be found at all, Facter throws an error.
 
 For example:
 
 ~~~ ruby
-    Facter.add(:osfamily) do
-      setcode do
-        distid = Facter.value(:lsbdistid)
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -159,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Core::Execution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
-Once Facter rules out any resolutions that are excluded because of `confine` statments,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+Facter decides the issue of precedence using the weight property.
+Once Facter rules out any resolutions that are excluded because of `confine` statements,
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -231,59 +226,59 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Structured Facts
 
-While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. All you need to do to create a structured fact is return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. To create a structured fact, simply return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
 
 ## Aggregate Resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks," each one responsible for resolving one piece of the fact. After all of the chunks hae been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it might make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks are resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, you'll need to add the `:type => :aggregate` parameter:
 
 ~~~ ruby
-    Facter.add(:fact_name, :type => :aggregate) do
-        #chunks go here
-        #aggregate block goes here
-    end
+Facter.add(:fact_name, :type => :aggregate) do
+    # Chunks go here.
+    # Aggregate block goes here.
+end
 ~~~
 
 Each step in the resolution then gets its own `chunk` statement with an arbitrary name:
 
 ~~~ ruby
-    chunk(:one) do
-        'Chunk one returns this. '
-    end
-    
-    chunk(:two) do
-        'Chunk two returns this.'
-    end
+chunk(:one) do
+    'Chunk one returns this.'
+end
+
+chunk(:two) do
+    'Chunk two returns this.'
+end
 ~~~
 
 In a simple resolution, the code always includes a `setcode` statement that determines the fact's value. Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns will be the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ~~~ ruby
-    aggregate do |chunks|
-      result = ''
+aggregate do |chunks|
+  result = ''
 
-      chunks.each_value do |str|
-        result += str
-      end
+  chunks.each_value do |str|
+    result += str
+  end
 
-      result
-    end
-    # Returns "Chunk one returns this. Chunk two returns this."
+  result
+end
+# Returns "Chunk one returns this. Chunk two returns this."
 ~~~
 
-If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter will automatically merge all of your data into one array or hash and use that as the fact's value.
+If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
 
 For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
 
@@ -292,27 +287,24 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](fact
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](release_notes.html#pluginsync-for-external-facts). To add external facts to your puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](./release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 In a module (recommended):
-    
+
     <MODULEPATH>/<MODULE>/facts.d/
 
 On Unix/Linux/Mac OS X:
@@ -328,32 +320,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user:
+When running as a non-root or non-Administrator user:
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-        print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -361,44 +352,48 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 2.0 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in this format:
 
     key1=value1
     key2=value2
     key3=value3
 
-Using this format, a single script can return multiple facts in one return.
+Using this format, a single script can return multiple facts at once.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -411,50 +406,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-One example of when this might happen is in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -462,13 +460,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for Ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -478,16 +474,14 @@ The output should look similar to the timing for Ruby facts, but will name exter
     /usr/lib/facter/ext/sample.txt: 0.65ms
     ....
 
-#### External Facts and stdlib
+#### External Facts and `stdlib`
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires puppet 3.4.0 or greater.
+* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/2.1/custom_facts.markdown
+++ b/source/facter/2.1/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 2.1: Custom Facts Walkthrough"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
-You can use these methods of loading facts do to things like test files locally
+You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,26 +45,28 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
 Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
@@ -79,72 +74,72 @@ Custom facts can be distributed to clients using the [Plugins in Modules](/guide
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you a few ways to
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-  * if your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
-  * in any case, remember that your shell command is also a ruby string, so you'll need to escape special characters if you want to pass them through.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`.
+* If your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
+* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in the [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` will return `nil`; but if the fact can't be found at all, it will throw an error.
+You can write a fact that uses other facts by accessing
+`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` returns `nil`; but if the fact can't be found at all, Facter throws an error.
 
 For example:
 
 ~~~ ruby
-    Facter.add(:osfamily) do
-      setcode do
-        distid = Facter.value(:lsbdistid)
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -159,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Core::Execution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
-Once Facter rules out any resolutions that are excluded because of `confine` statments,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+Facter decides the issue of precedence using the weight property.
+Once Facter rules out any resolutions that are excluded because of `confine` statements,
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -231,59 +226,59 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Structured Facts
 
-While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. All you need to do to create a structured fact is return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. To create a structured fact, simply return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
 
 ## Aggregate Resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks," each one responsible for resolving one piece of the fact. After all of the chunks hae been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it might make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks are resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, you'll need to add the `:type => :aggregate` parameter:
 
 ~~~ ruby
-    Facter.add(:fact_name, :type => :aggregate) do
-        #chunks go here
-        #aggregate block goes here
-    end
+Facter.add(:fact_name, :type => :aggregate) do
+    # Chunks go here.
+    # Aggregate block goes here.
+end
 ~~~
 
 Each step in the resolution then gets its own `chunk` statement with an arbitrary name:
 
 ~~~ ruby
-    chunk(:one) do
-        'Chunk one returns this. '
-    end
-    
-    chunk(:two) do
-        'Chunk two returns this.'
-    end
+chunk(:one) do
+    'Chunk one returns this.'
+end
+
+chunk(:two) do
+    'Chunk two returns this.'
+end
 ~~~
 
 In a simple resolution, the code always includes a `setcode` statement that determines the fact's value. Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns will be the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ~~~ ruby
-    aggregate do |chunks|
-      result = ''
+aggregate do |chunks|
+  result = ''
 
-      chunks.each_value do |str|
-        result += str
-      end
+  chunks.each_value do |str|
+    result += str
+  end
 
-      result
-    end
-    # Returns "Chunk one returns this. Chunk two returns this."
+  result
+end
+# Returns "Chunk one returns this. Chunk two returns this."
 ~~~
 
-If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter will automatically merge all of your data into one array or hash and use that as the fact's value.
+If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
 
 For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
 
@@ -292,27 +287,24 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](fact
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 In a module (recommended):
-    
+
     <MODULEPATH>/<MODULE>/facts.d/
 
 On Unix/Linux/Mac OS X:
@@ -328,32 +320,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user:
+When running as a non-root or non-Administrator user:
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-        print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -361,44 +352,48 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 2.1 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in this format:
 
     key1=value1
     key2=value2
     key3=value3
 
-Using this format, a single script can return multiple facts in one return.
+Using this format, a single script can return multiple facts at once.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -411,50 +406,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-One example of when this might happen is in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -462,13 +460,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for Ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -478,16 +474,14 @@ The output should look similar to the timing for Ruby facts, but will name exter
     /usr/lib/facter/ext/sample.txt: 0.65ms
     ....
 
-#### External Facts and stdlib
+#### External Facts and `stdlib`
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires puppet 3.4.0 or greater.
+* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/2.2/custom_facts.markdown
+++ b/source/facter/2.2/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 2.2: Custom Facts Walkthrough"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
-You can use these methods of loading facts do to things like test files locally
+You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,26 +45,28 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
 Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
@@ -79,72 +74,72 @@ Custom facts can be distributed to clients using the [Plugins in Modules](/guide
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you a few ways to
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-  * if your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
-  * in any case, remember that your shell command is also a ruby string, so you'll need to escape special characters if you want to pass them through.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`.
+* If your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
+* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in the [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` will return `nil`; but if the fact can't be found at all, it will throw an error.
+You can write a fact that uses other facts by accessing
+`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` returns `nil`; but if the fact can't be found at all, Facter throws an error.
 
 For example:
 
 ~~~ ruby
-    Facter.add(:osfamily) do
-      setcode do
-        distid = Facter.value(:lsbdistid)
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -159,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Core::Execution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
-Once Facter rules out any resolutions that are excluded because of `confine` statments,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+Facter decides the issue of precedence using the weight property.
+Once Facter rules out any resolutions that are excluded because of `confine` statements,
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -231,59 +226,59 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Structured Facts
 
-While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. All you need to do to create a structured fact is return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. To create a structured fact, simply return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
 
 ## Aggregate Resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks," each one responsible for resolving one piece of the fact. After all of the chunks hae been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it might make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks are resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, you'll need to add the `:type => :aggregate` parameter:
 
 ~~~ ruby
-    Facter.add(:fact_name, :type => :aggregate) do
-        #chunks go here
-        #aggregate block goes here
-    end
+Facter.add(:fact_name, :type => :aggregate) do
+    # Chunks go here.
+    # Aggregate block goes here.
+end
 ~~~
 
 Each step in the resolution then gets its own `chunk` statement with an arbitrary name:
 
 ~~~ ruby
-    chunk(:one) do
-        'Chunk one returns this. '
-    end
-    
-    chunk(:two) do
-        'Chunk two returns this.'
-    end
+chunk(:one) do
+    'Chunk one returns this.'
+end
+
+chunk(:two) do
+    'Chunk two returns this.'
+end
 ~~~
 
 In a simple resolution, the code always includes a `setcode` statement that determines the fact's value. Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns will be the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ~~~ ruby
-    aggregate do |chunks|
-      result = ''
+aggregate do |chunks|
+  result = ''
 
-      chunks.each_value do |str|
-        result += str
-      end
+  chunks.each_value do |str|
+    result += str
+  end
 
-      result
-    end
-    # Returns "Chunk one returns this. Chunk two returns this."
+  result
+end
+# Returns "Chunk one returns this. Chunk two returns this."
 ~~~
 
-If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter will automatically merge all of your data into one array or hash and use that as the fact's value.
+If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
 
 For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
 
@@ -292,27 +287,24 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](fact
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 In a module (recommended):
-    
+
     <MODULEPATH>/<MODULE>/facts.d/
 
 On Unix/Linux/Mac OS X:
@@ -328,32 +320,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user:
+When running as a non-root or non-Administrator user:
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-        print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -361,44 +352,48 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 2.2 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in this format:
 
     key1=value1
     key2=value2
     key3=value3
 
-Using this format, a single script can return multiple facts in one return.
+Using this format, a single script can return multiple facts at once.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -411,50 +406,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-One example of when this might happen is in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -462,13 +460,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for Ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -478,16 +474,14 @@ The output should look similar to the timing for Ruby facts, but will name exter
     /usr/lib/facter/ext/sample.txt: 0.65ms
     ....
 
-#### External Facts and stdlib
+#### External Facts and `stdlib`
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires puppet 3.4.0 or greater.
+* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/2.3/custom_facts.markdown
+++ b/source/facter/2.3/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 2.3: Custom Facts Walkthrough"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
 You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,26 +45,28 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
 Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
@@ -79,72 +74,72 @@ Custom facts can be distributed to clients using the [Plugins in Modules](/guide
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you a few ways to
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-  * if your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
-  * in any case, remember that your shell command is also a ruby string, so you'll need to escape special characters if you want to pass them through.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`.
+* If your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
+* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in the [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` will return `nil`; but if the fact can't be found at all, it will throw an error.
+You can write a fact that uses other facts by accessing
+`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` returns `nil`; but if the fact can't be found at all, Facter throws an error.
 
 For example:
 
 ~~~ ruby
-    Facter.add(:osfamily) do
-      setcode do
-        distid = Facter.value(:lsbdistid)
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -159,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Core::Execution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
+Facter decides the issue of precedence using the weight property.
 Once Facter rules out any resolutions that are excluded because of `confine` statements,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -231,59 +226,59 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Structured Facts
 
-While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. All you need to do to create a structured fact is return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. To create a structured fact, simply return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
 
 ## Aggregate Resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks have been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it might make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks are resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, you'll need to add the `:type => :aggregate` parameter:
 
 ~~~ ruby
-    Facter.add(:fact_name, :type => :aggregate) do
-        #chunks go here
-        #aggregate block goes here
-    end
+Facter.add(:fact_name, :type => :aggregate) do
+    # Chunks go here.
+    # Aggregate block goes here.
+end
 ~~~
 
 Each step in the resolution then gets its own `chunk` statement with an arbitrary name:
 
 ~~~ ruby
-    chunk(:one) do
-        'Chunk one returns this. '
-    end
+chunk(:one) do
+    'Chunk one returns this.'
+end
 
-    chunk(:two) do
-        'Chunk two returns this.'
-    end
+chunk(:two) do
+    'Chunk two returns this.'
+end
 ~~~
 
 In a simple resolution, the code always includes a `setcode` statement that determines the fact's value. Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns will be the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ~~~ ruby
-    aggregate do |chunks|
-      result = ''
+aggregate do |chunks|
+  result = ''
 
-      chunks.each_value do |str|
-        result += str
-      end
+  chunks.each_value do |str|
+    result += str
+  end
 
-      result
-    end
-    # Returns "Chunk one returns this. Chunk two returns this."
+  result
+end
+# Returns "Chunk one returns this. Chunk two returns this."
 ~~~
 
-If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter will automatically merge all of your data into one array or hash and use that as the fact's value.
+If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
 
 For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
 
@@ -292,24 +287,21 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](fact
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 In a module (recommended):
 
@@ -328,32 +320,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user:
+When running as a non-root or non-Administrator user:
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-        print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -361,44 +352,48 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 2.3 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in this format:
 
     key1=value1
     key2=value2
     key3=value3
 
-Using this format, a single script can return multiple facts in one return.
+Using this format, a single script can return multiple facts at once.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -411,50 +406,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-One example of when this might happen is in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -462,13 +460,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for Ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -478,16 +474,14 @@ The output should look similar to the timing for Ruby facts, but will name exter
     /usr/lib/facter/ext/sample.txt: 0.65ms
     ....
 
-#### External Facts and stdlib
+#### External Facts and `stdlib`
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires puppet 3.4.0 or greater.
+* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/2.4/custom_facts.markdown
+++ b/source/facter/2.4/custom_facts.markdown
@@ -3,14 +3,7 @@ layout: default
 title: "Facter 2.4: Custom Facts Walkthrough"
 ---
 
-Custom Facts
-============
-
-Extend facter by writing your own custom facts to provide information to Puppet.
-
-* * *
-
-[executionpolicy]: http://technet.microsoft.com/en-us/library/ee176949.aspx
+Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
 
@@ -18,32 +11,32 @@ Sometimes you need to be able to write conditional expressions
 based on site-specific data that just isn't available via Facter,
 or perhaps you'd like to include it in a template.
 
-Since you can't include arbitrary ruby code in your manifests,
+Since you can't include arbitrary Ruby code in your manifests,
 the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
 ## The Concept
 
-You can add new facts by writing snippets of ruby code on the
-Puppet master. Puppet will then use [Plugins in Modules](/guides/plugins_in_modules.html)
+You can add new facts by writing snippets of Ruby code on the
+Puppet master. Puppet then uses [Plugins in Modules](/guides/plugins_in_modules.html)
 to distribute the facts to the client.
 
 ## Loading Custom Facts
 
 Facter offers a few methods of loading facts:
 
- * $LOAD\_PATH, or the ruby library load path
- * The environment variable 'FACTERLIB'
- * Facts distributed using pluginsync
+* `$LOAD_PATH`, or the Ruby library load path
+* The environment variable `FACTERLIB`
+* Facts distributed using pluginsync
 
 You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
 machines.
 
-Facter will search all directories in the ruby $LOAD\_PATH variable for
-subdirectories named 'facter', and will load all ruby files in those directories.
-If you had some directory in your $LOAD\_PATH like ~/lib/ruby, set up like
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named 'facter', and loads all Ruby files in those directories.
+If you had some directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
     #~/lib/ruby
@@ -52,26 +45,28 @@ this:
         ├── system_load.rb
         └── users.rb
 
-Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
+Facter tries to load 'facter/system_load.rb', 'facter/users.rb', and
 'facter/rackspace.rb'.
 
-Facter also will check the environment variable `FACTERLIB` for a colon-delimited
-set of directories, and will try to load all ruby files in those directories.
-This allows you to do something like this:
+Facter also checks the environment variable `FACTERLIB` for a colon-delimited
+set of absolute paths to directories, then tries to load all Ruby files in those
+directories. This allows you to do something like this:
 
+    $ pwd
+    /home/user
     $ ls my_facts
     system_load.rb
     $ ls my_other_facts
     users.rb
-    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ export FACTERLIB="/home/user/my_facts:/home/user/my_other_facts"
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
 
 Facter can also easily load fact files distributed using pluginsync. Running
-`facter -p` will load all the facts that have been distributed via pluginsync,
-so if you're using a lot of custom facts inside puppet, you can easily use
-these facts with standalone facter.
+`facter -p` loads all the facts that have been distributed via pluginsync,
+so if you're using a lot of custom facts inside Puppet, you can easily use
+these facts with standalone Facter.
 
 Custom facts can be distributed to clients using the [Plugins in Modules](/guides/plugins_in_modules.html) method.
 
@@ -79,72 +74,72 @@ Custom facts can be distributed to clients using the [Plugins in Modules](/guide
 
 Setting aside external facts for now, every fact has at least two elements:
 
- 1. a call to `Facter.add('fact_name')`, which determines the name of the fact
- 2. a `setcode` statement, which will be evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement, which Facter evaluates to determine the fact's value.
 
-Facts *can* get a lot more complicated than that, but those two together are the
-minimum that you will see in every fact.
+Facts *can* get a lot more complicated than that, but every fact contains at least
+those two parts.
 
 ## Executing Shell Commands in Facts
 
 Puppet gets information about a system from Facter, and the most common way for Facter to
 get that information is by executing shell commands. You can then parse and manipulate the
-output from those commands using standard ruby code. The Facter API gives you a few ways to
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-  * if all you want to do is run the command and use the output, verbatim, as your fact's value,
-  you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-  * if your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
-  from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns will be used as the fact's value.
-  * in any case, remember that your shell command is also a ruby string, so you'll need to escape special characters if you want to pass them through.
+* If all you want to do is run the command and use the verbatim output as your fact's value,
+you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`.
+* If your fact is any more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+from within the `setcode do`...`end` block. As always, Facter uses whatever the `setcode` statement returns as the fact's value.
+* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
-It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in ruby.
+It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators just as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### An Example
 
 Let's say you need to get the output of `uname --hardware-platform` to single out a
-specific type of workstation. To do this, you would create a new custom
-fact. Start by giving the fact a name, in this case, `hardware_platform`,
+specific type of workstation. To do this, create a new custom
+fact. Start by giving the fact a name, in this case `hardware_platform`,
 and create your new fact in a file, `hardware_platform.rb`, on the
 Puppet master server:
 
 ~~~ ruby
-    # hardware_platform.rb
+# hardware_platform.rb
 
-    Facter.add('hardware_platform') do
-      setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
-      end
-    end
+Facter.add('hardware_platform') do
+  setcode do
+    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+  end
+end
 ~~~
 
-You can then use the instructions in the [Plugins In Modules](/guides/plugins_in_modules.html) page to copy
-the new fact to a module and distribute it. During your next Puppet run, the value of the new fact
-will be available to use in your manifests and templates.
+You can then use the instructions in the [Plugins in Modules](/guides/plugins_in_modules.html) guide to copy
+the new fact to a module and distribute it. The value of the new fact is then available 
+to use in your manifests and templates during your next Puppet run.
 
-The best place to get ideas about how to write your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib/facter). There you will find a wealth of examples of how to retrieve different types of system data and return useful facts.
+The best place to find ideas on writing your own custom facts is to look at the [code for Facter's core facts](https://github.com/puppetlabs/facter/tree/master/lib), which contains a wealth of examples of how to retrieve different types of system data and return useful facts.
 
-## Using other facts
+## Using Other Facts
 
-You can write a fact which uses other facts by accessing
-`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` will return `nil`; but if the fact can't be found at all, it will throw an error.
+You can write a fact that uses other facts by accessing
+`Facter.value(:somefact)`. If the named fact is unresolved, `Facter.value` returns `nil`; but if the fact can't be found at all, Facter throws an error.
 
 For example:
 
 ~~~ ruby
-    Facter.add(:osfamily) do
-      setcode do
-        distid = Facter.value(:lsbdistid)
-        case distid
-        when /RedHatEnterprise|CentOS|Fedora/
-          'redhat'
-        when 'ubuntu'
-          'debian'
-        else
-          distid
-        end
-      end
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
     end
+  end
+end
 ~~~
 
 ## Configuring Facts
@@ -159,71 +154,71 @@ restricts the fact to only run on systems that matches another given fact.
 An example of the confine statement would be something like the following:
 
 ~~~ ruby
-    Facter.add(:powerstates) do
-      confine :kernel => 'Linux'
-      setcode do
-        Facter::Core::Execution.exec('cat /sys/power/states')
-      end
-    end
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
 ~~~
 
-This fact uses sysfs on linux to get a list of the power states that are
+This fact uses sysfs on Linux to get a list of the power states that are
 available on the given system. Since this is only available on Linux systems,
 we use the confine statement to ensure that this fact isn't needlessly run on
 systems that don't support this type of enumeration.
 
-### Fact precedence
+### Fact Precedence
 
-A single fact can have multiple **resolutions**, each of which is a different way
+A single fact can have multiple **resolutions,** each of which is a different way
 of ascertaining what the value of the fact should be. It's very common to have
 different resolutions for different operating systems, for example. It's easy to
 confuse facts and resolutions because they are superficially identical --- to add
 a new resolution to a fact, you simply add the fact again, only with a different
 `setcode` statement.
 
-When a fact does have more than one resolution, you'll want to make sure that only one of them
-gets executed. Otherwise, each subsequent resolution would override the one before it,
+When a fact has more than one resolution, make sure that Facter executes only one of them.
+Otherwise, each subsequent resolution overrides the one before it,
 and you might not get the value that you want.
 
-The way that Facter decides the issue of precedence is the weight property.
+Facter decides the issue of precedence using the weight property.
 Once Facter rules out any resolutions that are excluded because of `confine` statements,
-the resolution with the highest weight will be executed. If that resolution doesn't return
-a value, Facter will move on to the next resolution (by descending weight) until it gets
+it executes the resolution with the highest weight. If that resolution doesn't return
+a value, Facter moves on to the next resolution (by descending weight) until it gets
 a suitable value for the fact.
 
 By default, the weight of a fact is the number of confines for that resolution, so
-that more specific resolutions will take priority over less specific resolutions.
+more specific resolutions take priority over less specific resolutions.
 
 ~~~ ruby
-    # Check to see if this server has been marked as a postgres server
-    Facter.add(:role) do
-      has_weight 100
-      setcode do
-        if File.exist? '/etc/postgres_server'
-          'postgres_server'
-        end
-      end
+# Check to see if this server has been marked as a postgres server.
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
     end
+  end
+end
 
-    # Guess if this is a server by the presence of the pg_create binary
-    Facter.add(:role) do
-      has_weight 50
-      setcode do
-        if File.exist? '/usr/sbin/pg_create'
-          'postgres_server'
-        end
-      end
+# Guess if this is a server by the presence of the pg_create binary.
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
     end
+  end
+end
 
-    # If this server doesn't look like a server, it must be a desktop
-    Facter.add(:role) do
-      setcode do
-        'desktop'
-      end
-    end
+# If this server doesn't look like a server, it must be a desktop.
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
 ~~~
 
-### Timing out
+### Timing Out
 
 If you have facts that are unreliable and may not finish running, you can use
 the `timeout` property. If a fact is defined with a timeout and the evaluation
@@ -231,59 +226,59 @@ of the setcode block exceeds the timeout, Facter will halt the resolution of
 that fact and move on.
 
 ~~~ ruby
-    # Sleep
-    Facter.add(:sleep, :timeout => 10) do
-      setcode do
-          sleep 999999
-      end
-    end
+# Sleep
+Facter.add(:sleep, :timeout => 10) do
+  setcode do
+      sleep 999999
+  end
+end
 ~~~
 
 ## Structured Facts
 
-While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. All you need to do to create a structured fact is return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+While the norm is for a fact to return a single string, Facter 2.0 introduced **structured facts**, which take the form of either a hash or an array. To create a structured fact, simply return a hash or an array from the `setcode` statement. You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
 
 ## Aggregate Resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks have been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it might make sense to use **aggregate resolutions**. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks are resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, you'll need to add the `:type => :aggregate` parameter:
 
 ~~~ ruby
-    Facter.add(:fact_name, :type => :aggregate) do
-        #chunks go here
-        #aggregate block goes here
-    end
+Facter.add(:fact_name, :type => :aggregate) do
+    # Chunks go here.
+    # Aggregate block goes here.
+end
 ~~~
 
 Each step in the resolution then gets its own `chunk` statement with an arbitrary name:
 
 ~~~ ruby
-    chunk(:one) do
-        'Chunk one returns this. '
-    end
+chunk(:one) do
+    'Chunk one returns this.'
+end
 
-    chunk(:two) do
-        'Chunk two returns this.'
-    end
+chunk(:two) do
+    'Chunk two returns this.'
+end
 ~~~
 
 In a simple resolution, the code always includes a `setcode` statement that determines the fact's value. Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns will be the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ~~~ ruby
-    aggregate do |chunks|
-      result = ''
+aggregate do |chunks|
+  result = ''
 
-      chunks.each_value do |str|
-        result += str
-      end
+  chunks.each_value do |str|
+    result += str
+  end
 
-      result
-    end
-    # Returns "Chunk one returns this. Chunk two returns this."
+  result
+end
+# Returns "Chunk one returns this. Chunk two returns this."
 ~~~
 
-If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter will automatically merge all of your data into one array or hash and use that as the fact's value.
+If the `chunk` blocks either all return arrays or all return hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
 
 For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
 
@@ -292,24 +287,21 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](fact
 [inventory]: /guides/inventory_service.html
 [puppetdb]: /puppetdb/latest
 
-If your puppet master(s) are configured to use [PuppetDB][] and/or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service docs for more info.
+If your Puppet masters are configured to use [PuppetDB][] or the [inventory service][inventory], you can view and search all of the facts for any node, including custom facts. See the PuppetDB or inventory service documentation for more information.
 
-External Facts
---------------
+## External Facts
 
-### What are external facts?
+### What Are External Facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Fact Locations
 
-The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source Puppet, and whether you are running as root/Administrator. When calling Facter from the command line, you can specify the external facts directory with the `--external-dir` option.
 
-> **Note:** These directories will not necessarily exist by default; you may need to create them. If you create the directory, make sure
-to restrict access so that only Administrators can write to the
-directory.
+> **Note:** These directories do not necessarily exist by default; you might need to create them. If you create the directory, restrict access so that only Administrators can write to it.
 
 In a module (recommended):
 
@@ -328,32 +320,31 @@ On other supported Windows Operating Systems (Windows Vista, 7, 8, 2008, 2012):
 
     C:\ProgramData\PuppetLabs\facter\facts.d\
 
-When running as a non-root / non-Administrator user:
+When running as a non-root or non-Administrator user:
 
     <HOME DIRECTORY>/.facter/facts.d/
 
-### Executable facts --- Unix
+### Executable Facts --- \*nix
 
-Executable facts on Unix work by dropping an executable file into the standard
+Executable facts on \*nix work by dropping an executable file into the standard
 external fact path above.
 
 An example external fact written in Python:
 
 ~~~ python
-    #!/usr/bin/env python
-    data = {"key1" : "value1", "key2" : "value2" }
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
 
-    for k in data:
-        print "%s=%s" % (k,data[k])
+for k in data:
+    print "%s=%s" % (k,data[k])
 ~~~
-
 
 You must ensure that the script has its execute bit set:
 
     chmod +x /etc/facter/facts.d/my_fact_script.py
 
-For Facter to parse the output, the script must return key/value pairs on
-STDOUT in the format:
+For Facter to parse the output, the script must return key-value pairs on
+STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -361,15 +352,15 @@ STDOUT in the format:
 
 Using this format, a single script can return multiple facts.
 
-### Executable facts --- Windows
+### Executable Facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
+Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike \*nix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. Facter 2.4 supports the following extensions:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+* `.com` and `.exe`: binary executables
+* `.bat` and `.cmd`: batch scripts
+* `.ps1`: PowerShell scripts
 
-As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+As with \*nix facts, each script must return key-value pairs on STDOUT in this format:
 
     key1=value1
     key2=value2
@@ -379,26 +370,30 @@ Using this format, a single script can return multiple facts in one return.
 
 #### Batch Scripts
 
-The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+For consistently usable output, the file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
-Here is a sample batch script which outputs facts using the required format:
+Here is a sample batch script that outputs facts using the required format:
 
-    @echo off
-    echo key1=val1
-    echo key2=val2
-    echo key3=val3
-    REM Invalid - echo 'key4=val4'
-    REM Invalid - echo "key5=val5"
+~~~ batch
+@echo off
+echo key1=val1
+echo key2=val2
+echo key3=val3
+REM Invalid - echo 'key4=val4'
+REM Invalid - echo "key5=val5"
+~~~
 
 #### PowerShell Scripts
 
-The encoding that should be used with `.ps1` files is pretty open. PowerShell will determine the encoding of the file at run time.
+The encoding options for `.ps1` files are relatively open. PowerShell determines the encoding of the file at runtime.
 
-Here is a sample PowerShell script which outputs facts using the required format:
+Here is a sample PowerShell script that outputs facts using the required format:
 
-    Write-Host "key1=val1"
-    Write-Host 'key2=val2'
-    Write-Host key3=val3
+~~~ powershell
+Write-Host "key1=val1"
+Write-Host 'key2=val2'
+Write-Host key3=val3
+~~~
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -411,50 +406,53 @@ Structured data files must use one of the supported data types and must have the
 * `.yaml`: YAML data, in the following format:
 
 ~~~ yaml
-        ---
-        key1: val1
-        key2: val2
-        key3: val3
+---
+key1: val1
+key2: val2
+key3: val3
 ~~~
 
 * `.json`: JSON data, in the following format:
 
 ~~~ javascript
-        {
-            "key1": "val1",
-            "key2": "val2",
-            "key3": "val3"
-        }
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
 ~~~
 
 * `.txt`: Key value pairs, in the following format:
 
-        key1=value1
-        key2=value2
-        key3=value3
+~~~
+key1=value1
+key2=value2
+key3=value3
+~~~
 
 As with executable facts, structured data files can set multiple facts at once.
 
 #### Structured Data Facts on Windows
 
-All of the above types are supported on Windows with the following caveats:
+Facter supports all of the above types on Windows with the following caveats:
 
 * The line endings can be either `LF` or `CRLF`.
 * The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
-If your external fact is not appearing in Facter's output, running
+If your external fact doesn't appear in Facter's output, running
 Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
-    # facter --debug
+    sudo facter --debug
 
-One example of when this might happen is in cases where a fact returns invalid characters.
-Let say you used a hyphen instead of an equals sign in your script `test.sh`:
+For instance, let's say you used an invalid hyphen instead of an equals sign in your script `test.sh`:
 
-    #!/bin/bash
+~~~ bash
+#!/bin/bash
 
-    echo "key1-value1"
+echo "key1-value1"
+~~~
 
 Running `facter --debug` should yield a useful error message:
 
@@ -462,13 +460,11 @@ Running `facter --debug` should yield a useful error message:
     Fact file /etc/facter/facts.d/sample.txt was parsed but returned an empty data set
     ...
 
-If you are interested in finding out where any bottlenecks are, you can run
-Facter in timing mode and it will reflect how long it takes to parse your
-external facts:
+To find performance bottlenecks, you can run Facter in timing mode, which outputs how long it takes to parse your external facts:
 
     facter --timing
 
-The output should look similar to the timing for Ruby facts, but will name external facts with their full paths. For example:
+The output should look similar to the timing for Ruby facts, but names external facts with their full paths. For example:
 
     $ facter --timing
     kernel: 14.81ms
@@ -478,16 +474,14 @@ The output should look similar to the timing for Ruby facts, but will name exter
     /usr/lib/facter/ext/sample.txt: 0.65ms
     ....
 
-#### External Facts and stdlib
+#### External Facts and `stdlib`
 
-If you find that an external fact does not match what you have configured in your `facts.d`
-directory, make sure you have not defined the same fact using the external facts capabilities
-found in the stdlib module.
+If you find that an external fact does not match what you have configured in your `facts.d` directory, make sure you have not defined the same fact using the external facts capabilities found in the stdlib module.
 
 ### Drawbacks
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a ruby fact.
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
 * External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires puppet 3.4.0 or greater.
+* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.


### PR DESCRIPTION
Resolve the discrepancy pointed out in [FACT-1234](https://tickets.puppetlabs.com/browse/FACT-1234).

Also, fix several typos and apply style and formatting consistently across the Facter 1.x and 2.x docs.

(Attn @kylog @peterhuene @nfagerlund)