### PR TITLE
On modules parameters and reusability

### DIFF
--- a/source/guides/module_guides/bgtm.md
+++ b/source/guides/module_guides/bgtm.md
@@ -190,15 +190,6 @@ If you have a parameter that toggles an entire function on and off, the naming c
 
 Consistent naming across modules helps with the readability and usability of your code. While Puppet Labs doesn't have a set of standards for parameters to conform to, there's a community project working to establish one. If you care about name standardization, offer issues and pull requests [here](https://github.com/stdmod/puppet-modules/blob/master/Parameters_List.md).
 
-####Number
-
-If you want to maximize the usability of your module without requiring users to modify it, you should make it more flexible through the addition of parameters. Adding parameters enables more customized use of your module. While this can feel frustrating as an author, best practice is to embrace parameters rather than avoid them.
-
-You must not hardcode data in your modules, and having more parameters is the best alternative. Hardcoded data results in an inflexible module that requires manifest changes in order for it to be used in slightly different circumstances.
-
-Adding parameters that allow you to override templates is an anti-pattern to avoid. Parameters that allow overriding templates lead to end users overriding your template with a custom template that contains hardcoded additional parameters. Hardcoding parameters in a template should be avoided, as it leads to stagnation and inhibits flexibility over time. It is far better to create more parameters and modify the original template, or have a parameter which accepts an arbitrary chunk of text added to the template, than it is to override the template with a customized one.
-
-For an example of a module that capitalizes on offering many parameters, please see [puppetlabs/apache](http://forge.puppetlabs.com/puppetlabs/apache).
 
 ###2c: Ordering
 


### PR DESCRIPTION
I wouldn't  actually remove the whole paragraph, this PR is not intended to be merged as is, consider it an attempt to raise a discussion with what is written in this page (and removed in this PR):
- Is it really an antipattern to have a parameter that allows customisation of templates? IMHO it is a **necessary** reusability feature, allowing users to have their own configurations for cases not covered by the module
- Is it really a good thing to expose parameters for any possible configuration entry of an application? What happens when a new version of that application is released and new parameters are added? If you can't provide a custom template and don't have parameters to configure the new settings of the application you have to wait for a module update to be able to configure the new version of the application: not a great deal, imho.
- Do we do a favour to the module user if, in order to configure an application in the needed way he has to study all the parameters of the relevant classes/defines and find the right combination that matches the wanted output?
- What are the performance effects due to [Hiera] data bindings on a class that has a huge number of parameters (one for each possible configuration entry of the managed application)? 

Some rationale behind my stance on this matter is here:
http://www.example42.com/2014/10/29/reusability-features-every-module-should-have/

which we can sum up with:
custom (or default) template + generic options_hash + default options
can do with 2 parameters and more flexibility what is done with:
dozens of parameters + a forced template
(and with Puppet 4 we can validate also each entry in the generic options_hash)
This doesn't necessarily mean that we should not have any parameter at all, for the application configurations.

my2c