### PR TITLE
Unlock latest for PuppetDB 3.2 release

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -224,7 +224,6 @@ symlink_latest:
   - facter
   - pe
 lock_latest: {
-  puppetdb: "3.1",
   puppet: "4.2"
 }
 version_notes:


### PR DESCRIPTION
@kbarber can assign a PuppetDB engineer to merge this once they're ready for today's (or tomorrow's) release. 