### PR TITLE
(DOC-2335) Add new OIDs to the documentation

### DIFF
--- a/source/puppet/4.3/reference/_registered_oids.md
+++ b/source/puppet/4.3/reference/_registered_oids.md
@@ -19,4 +19,11 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.15 | `pp_department`   | Puppet Node Department Name
 1.3.6.1.4.1.34380.1.1.16 | `pp_cluster`      | Puppet Node Cluster Name
 1.3.6.1.4.1.34380.1.1.17 | `pp_provisioner`  | Puppet Node Provisioner Name
-
+1.3.6.1.4.1.34380.1.1.18 | `pp_region`       | Puppet Node Region Name
+1.3.6.1.4.1.34380.1.1.19 | `pp_datacenter`   | Puppet Node Datacenter Name
+1.3.6.1.4.1.34380.1.1.20 | `pp_zone`         | Puppet Node Zone Name
+1.3.6.1.4.1.34380.1.1.21 | `pp_network`      | Puppet Node Network Name
+1.3.6.1.4.1.34380.1.1.22 | `pp_securitypolicy` | Puppet Node Security Policy Name
+1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
+1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
+1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname


### PR DESCRIPTION
Before this, we didn't include the new OIDs shipping in Puppet 4.3, this
brings the documentation up to date with the release.