### PR TITLE
(docs) Remove references to cfacter

### DIFF
--- a/source/puppet/4.3/reference/lang_functions.markdown
+++ b/source/puppet/4.3/reference/lang_functions.markdown
@@ -72,7 +72,6 @@ file {"/etc/ntp.conf":
 include apache # function call; modifies catalog
 
 $binaries = [
-  "cfacter",
   "facter",
   "hiera",
   "mco",
@@ -122,7 +121,6 @@ file {"/etc/ntp.conf":
 apache.include # function call; modifies catalog
 
 $binaries = [
-  "cfacter",
   "facter",
   "hiera",
   "mco",

--- a/source/puppet/4.3/reference/lang_iteration.md
+++ b/source/puppet/4.3/reference/lang_iteration.md
@@ -81,7 +81,7 @@ Examples
 Since the focus of the Puppet language is declaring resources, most people will want to use iteration to declare many similar resources at once:
 
 ~~~ ruby
-$binaries = ["cfacter", "facter", "hiera", "mco", "puppet", "puppetserver"]
+$binaries = ["facter", "hiera", "mco", "puppet", "puppetserver"]
 
 # function call with lambda:
 $binaries.each |String $binary| {
@@ -109,7 +109,7 @@ define puppet::binary::symlink ($binary = $title) {
 }
 
 # using defined type for iteration, somewhere else in your manifests
-$binaries = ["cfacter", "facter", "hiera", "mco", "puppet", "puppetserver"]
+$binaries = ["facter", "hiera", "mco", "puppet", "puppetserver"]
 
 puppet::binary::symlink { $binaries: }
 ~~~

--- a/source/puppet/4.3/reference/lang_lambdas.md
+++ b/source/puppet/4.3/reference/lang_lambdas.md
@@ -30,7 +30,7 @@ Lambdas are not valid in any other place in the Puppet language, and cannot be a
 Lambdas are written as a list of parameters surrounded by pipe (`|`) characters, followed by a block of arbitrary Puppet code in curly braces. They must be used as part of a [function call.][functions]
 
 ~~~ ruby
-$binaries = ["cfacter", "facter", "hiera", "mco", "puppet", "puppetserver"]
+$binaries = ["facter", "hiera", "mco", "puppet", "puppetserver"]
 
 # function call with lambda:
 $binaries.each |String $binary| {

--- a/source/puppet/4.3/reference/whered_it_go.markdown
+++ b/source/puppet/4.3/reference/whered_it_go.markdown
@@ -22,7 +22,7 @@ On managed \*nix systems, you'll now install `puppet-agent` instead of `puppet`.
 
 This is a new name for a new thing. Instead of using package dependencies to bring in tools like Facter, Hiera, and Ruby, it includes private versions of all of them.
 
-It also includes cfacter and MCollective. (You can start using cfacter by setting `cfacter = true` in puppet.conf.)
+It also includes MCollective.
 
 On Windows, you'll use the same package as before, but the open source package now includes MCollective.
 


### PR DESCRIPTION
We're not shipping cfacter any more, so remove references to it.