### PR TITLE
Agent 1.3.1 release notes

### DIFF
--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -3,15 +3,33 @@ layout: default
 title: "Facter 3.1: Release Notes"
 ---
 
-[puppet-agent]: /puppet/4.2/reference/about_agent.html
+[puppet-agent 1.2.x]: /puppet/4.2/reference/about_agent.html
+[puppet-agent 1.3.x]: /puppet/4.3/reference/about_agent.html
 
 This page documents the history of the Facter 3.1 series. (Previous version: [Facter 3.0 release notes](../3.0/release_notes.html).)
+
+## Facter 3.1.3
+
+Released November 30, 2015.
+
+Shipped in [`puppet-agent` 1.3.1][puppet-agent 1.3.x].
+
+Facter 3.1.3 is a bug-fix release in the Facter 3.1 series.
+
+* [Fixed in Facter 3.1.3](https://tickets.puppetlabs.com/issues/?filter=16212)
+* [Introduced in Facter 3.1.3](https://tickets.puppetlabs.com/issues/?filter=16213)
+
+### REGRESSION FIX: Report `puppetversion` Fact
+
+We didn't report the `puppetversion` fact when when we restored `facter -p` functionality to Facter 3.0.2. This release restores the fact.
+
+* [FACT-1277](https://tickets.puppetlabs.com/browse/FACT-1277)
 
 ## Facter 3.1.2
 
 Released November 17, 2015.
 
-Shipped in [puppet-agent][] version 1.3.0.
+Shipped in [`puppet-agent` 1.3.0][puppet-agent 1.3.x].
 
 Facter 3.1.2 is a bug fix release in the Facter 3.1 series.
 
@@ -46,7 +64,7 @@ On older Linux kernels, Facter falls back to executing dmidecode to retrieve cer
 
 Released October 29, 2015.
 
-Shipped in [puppet-agent][] version 1.2.7.
+Shipped in [`puppet-agent` 1.2.7][puppet-agent 1.2.x].
 
 Facter 3.1.1 fixes several bugs and adds functionality for AIX 5.3, 6.1, and 7.1, and Solaris 11.
 
@@ -96,7 +114,7 @@ Previous versions of Facter 3 would halt if Windows Management Instrumentation (
 
 Released September 14, 2015.
 
-Shipped in [puppet-agent][] version 1.2.4.
+Shipped in [`puppet-agent` 1.2.4][puppet-agent 1.2.x].
 
 Facter 3.1.0 fixes several bugs and introduces support for OpenBSD and Solaris 10.
 

--- a/source/puppet/4.3/reference/release_notes.markdown
+++ b/source/puppet/4.3/reference/release_notes.markdown
@@ -17,6 +17,19 @@ Make sure you also read the [Puppet 4.0 release notes](/puppet/4.0/reference/rel
 
 Also of interest: the [Puppet 4.2 release notes](/puppet/4.2/reference/release_notes.html) and [Puppet 4.1 release notes](/puppet/4.1/reference/release_notes.html).
 
+## Puppet 4.3.1
+
+Released November 30, 2015.
+
+Puppet 4.3.1 is a bug fix release.
+
+* [Fixed in Puppet 4.3.1](https://tickets.puppetlabs.com/issues/?filter=16211)
+* [Introduced in Puppet 4.3.1](https://tickets.puppetlabs.com/issues/?filter=16210)
+
+### Bug Fixes: Miscellaneous
+
+* [PUP-5525: Hiera special pseudo-variables breaking with Puppet 4.3](https://tickets.puppetlabs.com/browse/PUP-5525): Puppet 4.3.0 does not initialize Hiera for use with data bindings in the correct order, and does not correctly set special pseudovariables like `calling_module`. This led to lookups not finding values when the special variables were interpolated in hierarchy data paths.
+
 ## Puppet 4.3.0
 
 Released November 17, 2015.

--- a/source/puppet/4.3/reference/release_notes_agent.md
+++ b/source/puppet/4.3/reference/release_notes_agent.md
@@ -5,9 +5,16 @@ canonical: "/puppet/latest/reference/release_notes_agent.html"
 ---
 
 [Puppet 4.3.0]: /puppet/4.3/reference/release_notes.html#puppet-430
+[Puppet 4.3.1]: /puppet/4.3/reference/release_notes.html#puppet-431
+
 [Facter 3.1.2]: /facter/3.1/release_notes.html#facter-312
+[Facter 3.1.3]: /facter/3.1/release_notes.html#facter-313
+
 [Hiera 3.0.5]: /hiera/3.0/release_notes.html#hiera-305
+
 [MCollective 2.8.6]: /mcollective/releasenotes.html#2_8_6
+
+[pxp-agent]: https://github.com/puppetlabs/pxp-agent
 
 This page lists changes to the `puppet-agent` package. For details about changes to components in a `puppet-agent` release, follow the links to those components in the package release's notes.
 
@@ -22,6 +29,19 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](/puppet/4.3/reference/about_agent.html) and the [Puppet 4.3 release notes](/puppet/4.3/reference/release_notes.html).
+
+## Puppet Agent 1.3.1
+
+Released November 30, 2015.
+
+Includes [Puppet 4.3.1][], [Facter 3.1.3][], and [`pxp-agent` 1.0.1][pxp-agent], each with bug or regression fixes and no new functionality. No other components are updated.
+
+This release also closes a race condition in `pxp-agent` between the completion of an action command and the corresponding metadata file being updated.
+
+### All Changes
+
+* [Fixed in `puppet-agent` 1.3.1](https://tickets.puppetlabs.com/issues/?filter=16106)
+* [Introduced in `puppet-agent` 1.3.1](https://tickets.puppetlabs.com/issues/?filter=16209)
 
 ## Puppet Agent 1.3.0
 


### PR DESCRIPTION
Add release notes for Puppet 4.3.1, Facter 3.1.3, and `puppet-agent` 1.3.1, and adds or updates links to `puppet-agent` notes and content to older release notes for Puppet and Facter.