### PR TITLE
(DOCUMENT-458) Fix site.pp paths

### DIFF
--- a/source/puppet/2.7/reference/modules_fundamentals.markdown
+++ b/source/puppet/2.7/reference/modules_fundamentals.markdown
@@ -11,16 +11,12 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [plugins]: /guides/plugins_in_modules.html
 [documentation]: ./modules_documentation.html
 
-
 [classes]: ./lang_classes.html
 [defined_types]: ./lang_defined_types.html
 [enc]: /guides/external_nodes.html
 [conf]: /puppet/3.6/reference/config_file_main.html
 [environment]: /puppet/latest/reference/environments_classic.html
 [templates]: /guides/templating.html
-
-Puppet Modules
-=====
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from Puppet Labs' online collection, the Puppet Forge.
 
@@ -34,27 +30,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -74,9 +69,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -87,7 +80,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * lib
     * tests
     * spec
-
 
 ### Example
 
@@ -144,13 +136,11 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory are automatically served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
 
 Puppet URLs work transparently in both agent/master mode and standalone mode; in either case, they will retrieve the correct file from a module.
-
 
 [file]: /references/stable/type.html#file
 
@@ -174,18 +164,14 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, simply write classes and defined types and place them in properly named manifest files as described above.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Best Practices
------
+## Best Practices
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/3.5/reference/modules_fundamentals.markdown
+++ b/source/puppet/3.5/reference/modules_fundamentals.markdown
@@ -18,10 +18,7 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [enc]: /guides/external_nodes.html
 [environment]: ./environments.html
 [templates]: /guides/templating.html
-[forge]: http://forge.puppetlabs.com
-
-Puppet Modules
-=====
+[forge]: https://forge.puppetlabs.com
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from [the Puppet Forge][forge].
 
@@ -35,27 +32,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -64,9 +60,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -78,7 +72,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * `facts.d`
     * `tests`
     * `spec`
-
 
 ### Example
 
@@ -136,13 +129,11 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory are automatically served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
 
 Puppet URLs work transparently in both agent/master mode and standalone mode; in either case, they will retrieve the correct file from a module.
-
 
 [file]: /references/stable/type.html#file
 
@@ -166,18 +157,14 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, simply write classes and defined types and place them in properly named manifest files as described above.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Best Practices
------
+## Best Practices
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/3.6/reference/modules_fundamentals.markdown
+++ b/source/puppet/3.6/reference/modules_fundamentals.markdown
@@ -18,10 +18,7 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [enc]: /guides/external_nodes.html
 [environment]: ./environments.html
 [templates]: /guides/templating.html
-[forge]: http://forge.puppetlabs.com
-
-Puppet Modules
-=====
+[forge]: https://forge.puppetlabs.com
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from [the Puppet Forge][forge].
 
@@ -35,27 +32,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -64,9 +60,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -78,7 +72,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * `facts.d`
     * `tests`
     * `spec`
-
 
 ### Example
 
@@ -136,15 +129,13 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory are automatically served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
 
 Puppet URLs work transparently in both agent/master mode and standalone mode; in either case, they will retrieve the correct file from a module.
 
-
-[file]: /references/stable/type.html#file
+[file]: /references/3.6.latest/type.html#file
 
 Puppet URLs are formatted as follows:
 
@@ -158,7 +149,7 @@ So `puppet:///modules/my_module/service.conf` would map to `my_module/files/serv
 
 Any ERB template (see ["Templates"][templates] for more details) can be rendered in a manifest with the `template` function. The output of the template is a simple string, which can be used as the content attribute of a [`file`][file] resource or as the value of a variable.
 
-**The template function can look up templates identified by shorthand:**
+**The `template` function can look up templates identified by shorthand:**
 
 Template function | (' | Name of module/ | Name of template | ')
 ------------------|----|-----------------|------------------|----
@@ -166,13 +157,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -248,9 +237,7 @@ You also have the option of writing classes and defined types by hand and placin
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Tips
------
+## Tips
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/3.7/reference/modules_fundamentals.markdown
+++ b/source/puppet/3.7/reference/modules_fundamentals.markdown
@@ -18,11 +18,8 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [enc]: /guides/external_nodes.html
 [environment]: ./environments.html
 [templates]: /guides/templating.html
-[forge]: http://forge.puppetlabs.com
+[forge]: https://forge.puppetlabs.com
 [file_function]: /references/3.7.latest/function.html#file
-
-Puppet Modules
-=====
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from [the Puppet Forge][forge].
 
@@ -36,27 +33,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and defined types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or defined types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -65,9 +61,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -79,7 +73,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * `facts.d`
     * `tests`
     * `spec`
-
 
 ### Example
 
@@ -138,7 +131,6 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory can be served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
@@ -170,13 +162,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp('my_module/component.epp')` would render `my_module/templates/component.epp`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -252,9 +242,7 @@ You also have the option of writing classes and defined types by hand and placin
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Tips
------
+## Tips
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/3.8/reference/modules_fundamentals.markdown
+++ b/source/puppet/3.8/reference/modules_fundamentals.markdown
@@ -18,11 +18,8 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [enc]: /guides/external_nodes.html
 [environment]: ./environments.html
 [templates]: /guides/templating.html
-[forge]: http://forge.puppetlabs.com
+[forge]: https://forge.puppetlabs.com
 [file_function]: /references/3.8.latest/function.html#file
-
-Puppet Modules
-=====
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from [the Puppet Forge][forge].
 
@@ -36,27 +33,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and defined types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or defined types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -65,9 +61,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -79,7 +73,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * `facts.d`
     * `tests`
     * `spec`
-
 
 ### Example
 
@@ -138,7 +131,6 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory can be served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
@@ -170,13 +162,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp('my_module/component.epp')` would render `my_module/templates/component.epp`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -252,9 +242,7 @@ You also have the option of writing classes and defined types by hand and placin
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Tips
------
+## Tips
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/3/reference/modules_fundamentals.markdown
+++ b/source/puppet/3/reference/modules_fundamentals.markdown
@@ -11,16 +11,12 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 
 [plugins]: /guides/plugins_in_modules.html
 
-
 [classes]: ./lang_classes.html
 [defined_types]: ./lang_defined_types.html
 [enc]: /guides/external_nodes.html
 [conf]: /puppet/3.6/reference/config_file_main.html
 [environment]: /puppet/latest/reference/environments_classic.html
 [templates]: /guides/templating.html
-
-Puppet Modules
-=====
 
 **Modules** are self-contained bundles of code and data. You can write your own modules or you can download pre-built modules from Puppet Labs' online collection, the Puppet Forge.
 
@@ -34,27 +30,26 @@ Puppet Modules
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 **Modules are how Puppet finds the classes and types it can use** --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Within a manifest or from an [external node classifier (ENC)][enc], any of these classes or types can be declared by name:
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppet/manifests/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -74,9 +69,7 @@ To make a module available to Puppet, **place it in one of the directories in Pu
 
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
-
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply **a directory tree with a specific, predictable structure:**
 
@@ -87,7 +80,6 @@ On disk, a module is simply **a directory tree with a specific, predictable stru
     * lib
     * tests
     * spec
-
 
 ### Example
 
@@ -144,13 +136,11 @@ Certain module names are disallowed:
 * main
 * settings
 
-
 ### Files
 
 Files in a module's `files` directory are automatically served to agent nodes. They can be downloaded by using **puppet:/// URLs** in the `source` attribute of a [`file`][file] resource.
 
 Puppet URLs work transparently in both agent/master mode and standalone mode; in either case, they will retrieve the correct file from a module.
-
 
 [file]: /references/stable/type.html#file
 
@@ -174,18 +164,14 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, simply write classes and defined types and place them in properly named manifest files as described above.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
-
-Best Practices
------
+## Best Practices
 
 The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
 

--- a/source/puppet/4.1/reference/dirs_manifest.markdown
+++ b/source/puppet/4.1/reference/dirs_manifest.markdown
@@ -17,23 +17,21 @@ canonical: "/puppet/latest/reference/dirs_manifest.html"
 [configuring environments]: ./environments_configuring.html
 [creating environments]: ./environments_creating.html
 
-
 Puppet always starts compiling with either a single manifest file or a directory of manifests that get treated like a single file. This main starting point is called the **main manifest** or **site manifest.**
 
-For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation.][catalog_compilation]
+For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation][catalog_compilation].
 
-Location
------
+## Location
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/puppet/manifests/site.pp`.) It may be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
 
-Puppet apply does not use the manifest from an environment; it always uses the manifest given on the CLI.
+The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 
 ### With Puppet Master
 
-Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest may be a single file or a directory of `.pp` files.
+Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest can be a single file or a directory of `.pp` files.
 
 Each environment can configure its own main manifest with the `manifest` setting in [environment.conf][]. (You can disable this ability with [the `disable_per_environment_manifest` setting][disable_per_environment_manifest].)
 
@@ -46,14 +44,10 @@ For more details, see:
 * [Configuring Environments][]
 * [Creating Environments][]
 
-To check the actual manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
+To check the manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
 
+## Directory Behavior (vs. Single File)
 
+If the main manifest is a directory, Puppet parses every `.pp` file in the directory in alphabetical order and evaluate the combined manifest. It descends into all subdirectories of the manifest directory and loads files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
 
-Directory Behavior (vs. Single File)
------
-
-If the main manifest is a directory, Puppet will parse every `.pp` file in the directory in alphabetical order and then evaluate the combined manifest. It will descend into all subdirectories of the manifest dir, and load files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
-
-Puppet will act as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.
-
+Puppet acts as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.

--- a/source/puppet/4.1/reference/dirs_manifest.markdown
+++ b/source/puppet/4.1/reference/dirs_manifest.markdown
@@ -25,7 +25,7 @@ For more information on how the site manifest is used in catalog compilation, se
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/manifests/site.pp`.) It can be a single file or a directory of files.
 
 The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 

--- a/source/puppet/4.1/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.1/reference/modules_fundamentals.markdown
@@ -22,9 +22,6 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [file_function]: /references/4.1.latest/function.html#file
 [reserved names]: ./lang_reserved.html
 
-Puppet Modules
-=====
-
 **Modules** are self-contained bundles of code and data. You can download pre-built modules from [the Puppet Forge][forge] or you can write your own modules.
 
 **Nearly all Puppet manifests belong in modules.** The sole exception is the main `site.pp` manifest, which contains site-wide and node-specific code.
@@ -37,27 +34,26 @@ Every Puppet user should expect to write at least some of their own modules.
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppetlabs/code/environments/production/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -67,8 +63,7 @@ To make a module available to Puppet, place it in one of the directories in Pupp
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
 
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply a directory tree with a specific, predictable structure:
 
@@ -81,9 +76,7 @@ On disk, a module is simply a directory tree with a specific, predictable struct
     * `examples`
     * `spec`
 
->**Deprecation Warning:**
->
->The `tests` directory is being DEPRECATED in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, please rename your directory to `examples`.
+> **Deprecation Note:** The `tests` directory is deprecated in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, rename the `tests` directory to `examples`.
 
 ### Example
 
@@ -115,7 +108,7 @@ Each of the module's subdirectories has a specific function, as follows.
 
 Each manifest in a module's `manifests` folder should contain one class or defined type. The file names of manifests map predictably to the names of the classes and defined types they contain.
 
-`init.pp` is special and always contains a class with the same name as the module. You may not have a class named init.
+`init.pp` is special and always contains a class with the same name as the module. You cannot have a class named `init`.
 
 Every other manifest contains a class or defined type named as follows:
 
@@ -135,7 +128,7 @@ The double colon that divides the sections of a class's name is called the *name
 
 Module names should only contain lowercase letters, numbers, and underscores, and should begin with a lowercase letter; that is, they should match the expression `[a-z][a-z0-9_]*`. Note that these are the same restrictions that apply to class names, but with the added restriction that module names cannot contain the namespace separator (`::`) as modules cannot be nested.
 
-Certain module names are disallowed, see the list of [reserved words and names][reserved names].
+Certain module names are disallowed; see the list of [reserved words and names][reserved names].
 
 ### Files
 
@@ -168,13 +161,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp('my_module/component.epp')` would render `my_module/templates/component.epp`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will ask a series of questions to gather metadata about your module, and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -243,23 +234,21 @@ mymodule/tests
 mymodule/tests/init.pp
 ~~~
 
->**NOTE:** The `tests` directory is being deprecated in favor of `examples`. If you've just generated your module, you should rename the directory to `examples`.
+> **Note:** The `tests` directory is deprecated in favor of `examples`. If you've just generated your module, rename the directory to `examples`.
 
-For help getting started writing your module, please see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
+For help getting started writing your module, see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
 
-You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described above](#module_layout). If you take this route, you **must** ensure that your metadata.json file is properly formatted or your module **will not work**.
+You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described in the "Module Layout" section above](#module_layout). If you take this route, you **must** ensure that your `metadata.json` file is properly formatted or your module **will not work**.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
+## Tips
 
-Tips
------
-
-The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
+A module's [classes][], [defined types][defined_types], and [plugins][] **should all be related,** and the module should aim to be **as self-contained as possible.**
 
 Manifests in one module should never reference files or templates stored in another module.
 
 Be wary of having classes declare classes from other modules, as this makes modules harder to redistribute. When possible, it's best to isolate "super-classes" that declare many other classes in a local "site" module.
 
-For more best practices, please see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).
+For more best practices, see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).

--- a/source/puppet/4.1/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.1/reference/modules_fundamentals.markdown
@@ -39,7 +39,7 @@ Every Puppet user should expect to write at least some of their own modules.
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-# /etc/puppetlabs/code/environments/production/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 
 node default {
   include apache

--- a/source/puppet/4.2/reference/dirs_manifest.markdown
+++ b/source/puppet/4.2/reference/dirs_manifest.markdown
@@ -25,7 +25,7 @@ For more information on how the site manifest is used in catalog compilation, se
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/manifests/site.pp`.) It can be a single file or a directory of files.
 
 The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 

--- a/source/puppet/4.2/reference/dirs_manifest.markdown
+++ b/source/puppet/4.2/reference/dirs_manifest.markdown
@@ -17,23 +17,21 @@ canonical: "/puppet/latest/reference/dirs_manifest.html"
 [configuring environments]: ./environments_configuring.html
 [creating environments]: ./environments_creating.html
 
-
 Puppet always starts compiling with either a single manifest file or a directory of manifests that get treated like a single file. This main starting point is called the **main manifest** or **site manifest.**
 
-For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation.][catalog_compilation]
+For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation][catalog_compilation].
 
-Location
------
+## Location
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/puppet/manifests/site.pp`.) It may be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
 
-Puppet apply does not use the manifest from an environment; it always uses the manifest given on the CLI.
+The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 
 ### With Puppet Master
 
-Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest may be a single file or a directory of `.pp` files.
+Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest can be a single file or a directory of `.pp` files.
 
 By default, the main manifest for a given environment is `<ENVIRONMENTS DIRECTORY>/<ENVIRONMENT>/manifests`. (For example: `/etc/puppetlabs/code/environments/production/manifests`.) You can configure the manifest per-environment, and you can also configure the default for all environments.
 
@@ -46,14 +44,10 @@ For more details, see:
 * [Configuring Environments][]
 * [Creating Environments][]
 
-To check the actual manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
+To check the manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
 
+## Directory Behavior (vs. Single File)
 
+If the main manifest is a directory, Puppet parses every `.pp` file in the directory in alphabetical order and evaluate the combined manifest. It descends into all subdirectories of the manifest directory and loads files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
 
-Directory Behavior (vs. Single File)
------
-
-If the main manifest is a directory, Puppet will parse every `.pp` file in the directory in alphabetical order and then evaluate the combined manifest. It will descend into all subdirectories of the manifest dir, and load files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
-
-Puppet will act as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.
-
+Puppet acts as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.

--- a/source/puppet/4.2/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.2/reference/modules_fundamentals.markdown
@@ -22,9 +22,6 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [file_function]: /references/4.2.latest/function.html#file
 [reserved names]: ./lang_reserved.html
 
-Puppet Modules
-=====
-
 **Modules** are self-contained bundles of code and data. You can download pre-built modules from [the Puppet Forge][forge] or you can write your own modules.
 
 **Nearly all Puppet manifests belong in modules.** The sole exception is the main `site.pp` manifest, which contains site-wide and node-specific code.
@@ -37,27 +34,26 @@ Every Puppet user should expect to write at least some of their own modules.
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppetlabs/code/environments/production/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -67,8 +63,7 @@ To make a module available to Puppet, place it in one of the directories in Pupp
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
 
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply a directory tree with a specific, predictable structure:
 
@@ -81,9 +76,7 @@ On disk, a module is simply a directory tree with a specific, predictable struct
     * `examples`
     * `spec`
 
->**Deprecation Warning:**
->
->The `tests` directory is being DEPRECATED in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, please rename your directory to `examples`.
+> **Deprecation Note:** The `tests` directory is deprecated in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, rename the `tests` directory to `examples`.
 
 ### Example
 
@@ -115,7 +108,7 @@ Each of the module's subdirectories has a specific function, as follows.
 
 Each manifest in a module's `manifests` folder should contain one class or defined type. The file names of manifests map predictably to the names of the classes and defined types they contain.
 
-`init.pp` is special and always contains a class with the same name as the module. You may not have a class named init.
+`init.pp` is special and always contains a class with the same name as the module. You cannot have a class named `init`.
 
 Every other manifest contains a class or defined type named as follows:
 
@@ -135,7 +128,7 @@ The double colon that divides the sections of a class's name is called the *name
 
 Module names should only contain lowercase letters, numbers, and underscores, and should begin with a lowercase letter; that is, they should match the expression `[a-z][a-z0-9_]*`. Note that these are the same restrictions that apply to class names, but with the added restriction that module names cannot contain the namespace separator (`::`) as modules cannot be nested.
 
-Certain module names are disallowed, see the list of [reserved words and names][reserved names].
+Certain module names are disallowed; see the list of [reserved words and names][reserved names].
 
 ### Files
 
@@ -168,13 +161,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp('my_module/component.epp')` would render `my_module/templates/component.epp`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will ask a series of questions to gather metadata about your module, and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -243,23 +234,21 @@ mymodule/tests
 mymodule/tests/init.pp
 ~~~
 
->**NOTE:** The `tests` directory is being deprecated in favor of `examples`. If you've just generated your module, you should rename the directory to `examples`.
+> **Note:** The `tests` directory is deprecated in favor of `examples`. If you've just generated your module, rename the directory to `examples`.
 
-For help getting started writing your module, please see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
+For help getting started writing your module, see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
 
-You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described above](#module_layout). If you take this route, you **must** ensure that your metadata.json file is properly formatted or your module **will not work**.
+You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described in the "Module Layout" section above](#module_layout). If you take this route, you **must** ensure that your `metadata.json` file is properly formatted or your module **will not work**.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
+## Tips
 
-Tips
------
-
-The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
+A module's [classes][], [defined types][defined_types], and [plugins][] **should all be related,** and the module should aim to be **as self-contained as possible.**
 
 Manifests in one module should never reference files or templates stored in another module.
 
 Be wary of having classes declare classes from other modules, as this makes modules harder to redistribute. When possible, it's best to isolate "super-classes" that declare many other classes in a local "site" module.
 
-For more best practices, please see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).
+For more best practices, see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).

--- a/source/puppet/4.2/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.2/reference/modules_fundamentals.markdown
@@ -39,7 +39,7 @@ Every Puppet user should expect to write at least some of their own modules.
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-# /etc/puppetlabs/code/environments/production/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 
 node default {
   include apache

--- a/source/puppet/4.3/reference/dirs_manifest.markdown
+++ b/source/puppet/4.3/reference/dirs_manifest.markdown
@@ -25,7 +25,7 @@ For more information on how the site manifest is used in catalog compilation, se
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/manifests/site.pp`.) It can be a single file or a directory of files.
 
 The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 

--- a/source/puppet/4.3/reference/dirs_manifest.markdown
+++ b/source/puppet/4.3/reference/dirs_manifest.markdown
@@ -17,23 +17,21 @@ canonical: "/puppet/latest/reference/dirs_manifest.html"
 [configuring environments]: ./environments_configuring.html
 [creating environments]: ./environments_creating.html
 
-
 Puppet always starts compiling with either a single manifest file or a directory of manifests that get treated like a single file. This main starting point is called the **main manifest** or **site manifest.**
 
-For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation.][catalog_compilation]
+For more information on how the site manifest is used in catalog compilation, see [the reference page on catalog compilation][catalog_compilation].
 
-Location
------
+## Location
 
 ### With Puppet Apply
 
-The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/puppet/manifests/site.pp`.) It may be a single file or a directory of files.
+The `puppet apply` command requires a manifest as an argument on the command line. (For example: `puppet apply /etc/puppetlabs/code/environments/production/site.pp`.) It can be a single file or a directory of files.
 
-Puppet apply does not use the manifest from an environment; it always uses the manifest given on the CLI.
+The `puppet apply` command does not automatically use an environment's manifest. Instead, it always uses the manifest you pass to it.
 
 ### With Puppet Master
 
-Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest may be a single file or a directory of `.pp` files.
+Puppet master always uses the main manifest set by the current node's [environment][]. The main manifest can be a single file or a directory of `.pp` files.
 
 By default, the main manifest for a given environment is `<ENVIRONMENTS DIRECTORY>/<ENVIRONMENT>/manifests`. (For example: `/etc/puppetlabs/code/environments/production/manifests`.) You can configure the manifest per-environment, and you can also configure the default for all environments.
 
@@ -46,14 +44,10 @@ For more details, see:
 * [Configuring Environments][]
 * [Creating Environments][]
 
-To check the actual manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
+To check the manifest your Puppet master will use for a given environment, [run `puppet config print manifest --section master --environment <ENVIRONMENT>`][print_settings].
 
+## Directory Behavior (vs. Single File)
 
+If the main manifest is a directory, Puppet parses every `.pp` file in the directory in alphabetical order and evaluate the combined manifest. It descends into all subdirectories of the manifest directory and loads files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
 
-Directory Behavior (vs. Single File)
------
-
-If the main manifest is a directory, Puppet will parse every `.pp` file in the directory in alphabetical order and then evaluate the combined manifest. It will descend into all subdirectories of the manifest dir, and load files in depth-first order. (For example, if the manifest directory contains a directory named `01` and a file named `02.pp`, it will parse all the files in `01` before `02`.)
-
-Puppet will act as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.
-
+Puppet acts as though the whole directory were just one big manifest; for example, a variable assigned in the file `01_all_nodes.pp` would be accessible in `node_web01.pp`.

--- a/source/puppet/4.3/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.3/reference/modules_fundamentals.markdown
@@ -39,7 +39,7 @@ Every Puppet user should expect to write at least some of their own modules.
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-# /etc/puppetlabs/code/environments/production/site.pp
+# /etc/puppetlabs/code/environments/production/manifests/site.pp
 
 node default {
   include apache

--- a/source/puppet/4.3/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.3/reference/modules_fundamentals.markdown
@@ -22,9 +22,6 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [file_function]: /references/4.3.latest/function.html#file
 [reserved names]: ./lang_reserved.html
 
-Puppet Modules
-=====
-
 **Modules** are self-contained bundles of code and data. You can download pre-built modules from [the Puppet Forge][forge] or you can write your own modules.
 
 **Nearly all Puppet manifests belong in modules.** The sole exception is the main `site.pp` manifest, which contains site-wide and node-specific code.
@@ -37,27 +34,26 @@ Every Puppet user should expect to write at least some of their own modules.
 * [See "Using Plugins"][plugins] for how to arrange plugins (like custom facts and custom resource types) in modules and sync them to agent nodes.
 * [See "Documenting Modules"][documentation] for a README template and information on providing directions for your module.
 
-Using Modules
------
+## Using Modules
 
 Modules are how Puppet finds the classes and types it can use --- it automatically loads any [class][classes] or [defined type][defined_types] stored in its modules. Any of these classes or defines can be declared by name within a manifest or from an [external node classifier (ENC)][enc].
 
 ~~~ ruby
-    # /etc/puppetlabs/puppet/site.pp
+# /etc/puppetlabs/code/environments/production/site.pp
 
-    node default {
-      include apache
+node default {
+  include apache
 
-      class {'ntp':
-        enable => false;
-      }
+  class {'ntp':
+    enable => false;
+  }
 
-      apache::vhost {'personal_site':
-        port    => 80,
-        docroot => '/var/www/personal',
-        options => 'Indexes MultiViews',
-      }
-    }
+  apache::vhost {'personal_site':
+    port    => 80,
+    docroot => '/var/www/personal',
+    options => 'Indexes MultiViews',
+  }
+}
 ~~~
 
 Likewise, Puppet can automatically load plugins (like custom native resource types or custom facts) from modules; see ["Using Plugins"][plugins] for more details.
@@ -67,8 +63,7 @@ To make a module available to Puppet, place it in one of the directories in Pupp
 You can easily install modules written by other users with the `puppet module` subcommand. [See "Installing Modules"][installing] for details.
 
 
-Module Layout
------
+## Module Layout
 
 On disk, a module is simply a directory tree with a specific, predictable structure:
 
@@ -81,9 +76,7 @@ On disk, a module is simply a directory tree with a specific, predictable struct
     * `examples`
     * `spec`
 
->**Deprecation Warning:**
->
->The `tests` directory is being DEPRECATED in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, please rename your directory to `examples`.
+> **Deprecation Note:** The `tests` directory is deprecated in favor of the `examples` directory. If you use [`puppet module generate`](#writing-modules) to create your module skeleton, rename the `tests` directory to `examples`.
 
 ### Example
 
@@ -115,7 +108,7 @@ Each of the module's subdirectories has a specific function, as follows.
 
 Each manifest in a module's `manifests` folder should contain one class or defined type. The file names of manifests map predictably to the names of the classes and defined types they contain.
 
-`init.pp` is special and always contains a class with the same name as the module. You may not have a class named init.
+`init.pp` is special and always contains a class with the same name as the module. You cannot have a class named `init`.
 
 Every other manifest contains a class or defined type named as follows:
 
@@ -135,7 +128,7 @@ The double colon that divides the sections of a class's name is called the *name
 
 Module names should only contain lowercase letters, numbers, and underscores, and should begin with a lowercase letter; that is, they should match the expression `[a-z][a-z0-9_]*`. Note that these are the same restrictions that apply to class names, but with the added restriction that module names cannot contain the namespace separator (`::`) as modules cannot be nested.
 
-Certain module names are disallowed, see the list of [reserved words and names][reserved names].
+Certain module names are disallowed; see the list of [reserved words and names][reserved names].
 
 ### Files
 
@@ -168,13 +161,11 @@ Template function | (' | Name of module/ | Name of template | ')
 
 So `template('my_module/component.erb')` would render the template `my_module/templates/component.erb`, and `epp('my_module/component.epp')` would render `my_module/templates/component.epp`.
 
-
-Writing Modules
------
+## Writing Modules
 
 To write a module, we strongly suggest running `puppet module generate <USERNAME>-<MODULE NAME>`.
 
-When you run the above command, the Puppet module tool (PMT) will run a series of questions to gather metadata about your module and will create a basic module structure for you.
+When you run the above command, the Puppet module tool (PMT) will ask a series of questions to gather metadata about your module, and creates a basic module structure for you.
 
 ~~~
 $ puppet module generate examplecorp-mymodule
@@ -243,23 +234,21 @@ mymodule/tests
 mymodule/tests/init.pp
 ~~~
 
->**NOTE:** The `tests` directory is being deprecated in favor of `examples`. If you've just generated your module, you should rename the directory to `examples`.
+> **Note:** The `tests` directory is deprecated in favor of `examples`. If you've just generated your module, rename the directory to `examples`.
 
-For help getting started writing your module, please see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
+For help getting started writing your module, see the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html).
 
-You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described above](#module_layout). If you take this route, you **must** ensure that your metadata.json file is properly formatted or your module **will not work**.
+You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as [described in the "Module Layout" section above](#module_layout). If you take this route, you **must** ensure that your `metadata.json` file is properly formatted or your module **will not work**.
 
 * [See here][classes] for more information on classes
 * [See here][defined_types] for more information on defined types
 
+## Tips
 
-Tips
------
-
-The [classes][], [defined types][defined_types], and [plugins][] in a module **should all be related,** and the module should aim to be **as self-contained as possible.**
+A module's [classes][], [defined types][defined_types], and [plugins][] **should all be related,** and the module should aim to be **as self-contained as possible.**
 
 Manifests in one module should never reference files or templates stored in another module.
 
 Be wary of having classes declare classes from other modules, as this makes modules harder to redistribute. When possible, it's best to isolate "super-classes" that declare many other classes in a local "site" module.
 
-For more best practices, please see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).
+For more best practices, see the [Puppet Labs Modules Style Guide](/guides/style_guide.html).


### PR DESCRIPTION
Paths to `site.pp` files are incorrect in examples across versions of the Puppet docs. Fix these paths to the appropriate locations for each version.