### PR TITLE
Update Agent and Facter notes.

### DIFF
--- a/source/facter/3.0/release_notes.md
+++ b/source/facter/3.0/release_notes.md
@@ -3,89 +3,90 @@ layout: default
 title: "Facter 3.0: Release Notes"
 ---
 
+[puppet-agent 1.2.x]: /puppet/4.2/reference/about_agent.html
+
 This page documents the history of the Facter 3.0 series. (Previous version: [Facter 2.4 release notes](../2.4/release_notes.html).)
 
-Facter 3.0.2
------
+## Facter 3.0.2
 
 Released July 22, 2015.
 
-Shipped in puppet-agent version: 1.2.2.
+Shipped in [`puppet-agent` 1.2.2][puppet-agent 1.2.x].
 
 Facter 3.0.2 fixes several regressions in Facter 3.0.0 and implements new features to support legacy workflows.
 
 For JIRA issues related to Facter 3.0.2, see:
 
-- [Fixes for Facter 3.0.2](https://tickets.puppetlabs.com/issues/?filter=15119)
-- [Introduced in Facter 3.0.2](https://tickets.puppetlabs.com/issues/?filter=15118)
+* [Fixes for Facter 3.0.2](https://tickets.puppetlabs.com/issues/?filter=15119)
+* [Introduced in Facter 3.0.2](https://tickets.puppetlabs.com/issues/?filter=15118)
 
 ### Feature: `--show-legacy` Flag Outputs Unstructured Facts
 
 Facter 3 reports new, structured versions of many facts, such as `os`, and hides the equivalent unstructured legacy facts when run from the command line. Facter still tracks these legacy facts---they're only hidden from command-line output. In Facter 3.0.2, you can force Facter to output legacy facts by running it with the `--show-legacy` flag, providing a way to maintain legacy workflows while you convert them to use structured facts.
 
-- [FACT-1075](https://tickets.puppetlabs.com/browse/FACT-1075)
+* [FACT-1075](https://tickets.puppetlabs.com/browse/FACT-1075)
 
 ### FIX: Improved Memory Usage on Launch
 
 Facter 3.0.0 consumes more memory than is necessary when starting `puppetserver`. Facter 3.0.2 significantly improves memory usage on launch, making `puppetserver` easier to start on low-spec systems.
 
-- [FACT-1083](https://tickets.puppetlabs.com/browse/FACT-1083)
+* [FACT-1083](https://tickets.puppetlabs.com/browse/FACT-1083)
 
 ### FIX: Improved Parsing of Kernel-derived Major and Minor Operating System Version Facts
 
 Facter 3.0.0 couldn't parse major and minor kernel release versions (`os.release.major` and `os.release.minor`) on OS X, or on operating systems that do not formally report OS release versions, such as Arch Linux. We've fixed this in Facter 3.0.2.
 
-- [FACT-1056: Operatingsystem major release not resolved in OSX](https://tickets.puppetlabs.com/browse/FACT-1056)
-- [FACT-1073: Operatingsystem release facts not properly resolved in Arch Linux](https://tickets.puppetlabs.com/browse/FACT-1073)
+* [FACT-1056: Operatingsystem major release not resolved in OSX](https://tickets.puppetlabs.com/browse/FACT-1056)
+* [FACT-1073: Operatingsystem release facts not properly resolved in Arch Linux](https://tickets.puppetlabs.com/browse/FACT-1073)
 
 ### REGRESSION FIX: Corrected `operatingsystem` Fact Reporting on Oracle Linux
 
 Facter 3.0.0 incorrectly reports Oracle Linux's `operatingsystem` fact as `RedHat`. Facter 3.0.2 correctly reports `OracleLinux`.
 
-- [FACT-1134](https://tickets.puppetlabs.com/browse/FACT-1134)
+* [FACT-1134](https://tickets.puppetlabs.com/browse/FACT-1134)
 
 ### REGRESSION FIX: Restored `xendomains` Fact
 
 Facter 3.0.2 reports the `xendomains` fact, which was unintentionally omitted from Facter 3.0.0.
 
-- [FACT-867](https://tickets.puppetlabs.com/browse/FACT-867)
+* [FACT-867](https://tickets.puppetlabs.com/browse/FACT-867)
 
 ### REGRESSION FIX: `fqdn` Fact Always Reports the Host's Domain Name
 
 On some systems, Facter 3.0.0 doesn't report the domain name as part of the `fqdn` fact. We've fixed this in Facter 3.0.2.
 
-- [FACT-1077](https://tickets.puppetlabs.com/browse/FACT-1077)
-- [FACT-1078](https://tickets.puppetlabs.com/browse/FACT-1078)
+* [FACT-1077](https://tickets.puppetlabs.com/browse/FACT-1077)
+* [FACT-1078](https://tickets.puppetlabs.com/browse/FACT-1078)
 
 ### REGRESSION FIX: Fixed Crash on Windows Systems with Network Interfaces Lacking DHCP Assignments
 
 Facter 3.0.0 can crash with an "unhandled exception" error when reporting facts on a Windows system where DHCP-configured network interfaces aren't assigned IP addresses. Facter 3.0.2 resolves this issue.
 
-- [FACT-1084](https://tickets.puppetlabs.com/browse/FACT-1084)
+* [FACT-1084](https://tickets.puppetlabs.com/browse/FACT-1084)
 
 ### REGRESSION FIX: Localized Time Zones on Windows No Longer Report Invalid UTF-8 Sequences
 
 When Windows is configured to use a timezone that has a localized name, like "Mitteleuropäische Sommerzeit", Facter 3.0.0 reports the timezone as "Mitteleurop‰ische Sommerzeit" in its output. Facter 3.0.2 resolves this issue.
 
-- [FACT-1126](https://tickets.puppetlabs.com/browse/FACT-1126)
+* [FACT-1126](https://tickets.puppetlabs.com/browse/FACT-1126)
 
 ### REGRESSION FIX: Facter Works on Windows under MCollective
 
 When running the MCollective agent plugin on Windows, Facter could report a missing `libfacter.so` shared object due to an unset environment variable. Facter 3.0.2 loads this object differently to avoid this error.
 
-- [FACT-1125](https://tickets.puppetlabs.com/browse/FACT-1125)
+* [FACT-1125](https://tickets.puppetlabs.com/browse/FACT-1125)
 
 ### REGRESSION FIX: Resolved an OLE COM Initialization Issue When Reporting Windows Facts 
 
 Facter 3.0.0 can fail when reporting Windows facts that require `win32ole`, resulting in a "fail: OLE initialize" error. Facter 3.0.2 resolves this issue.
 
-- [FACT-1082](https://tickets.puppetlabs.com/browse/FACT-1082)
+* [FACT-1082](https://tickets.puppetlabs.com/browse/FACT-1082)
 
 ### REGRESSION FIX: Restored Output on Non-zero Exit Codes
 
 If a command returns a non-zero exit code or can't be found, Facter 3.0.0 returns `nil`, instead of a String as in Facter 2. This causes problems with facts that rely on exit codes or error messages. Facter 3.0.2 restores this functionality.
 
-- [FACT-1115](https://tickets.puppetlabs.com/browse/FACT-1115)
+* [FACT-1115](https://tickets.puppetlabs.com/browse/FACT-1115)
 
 ### REGRESSION FIX: Fixed `stderr` Redirection
 
@@ -93,7 +94,7 @@ When Facter 3.0.0 invokes commands to report facts that result in `stderr` outpu
 
 Facter 3.0.2 correctly reports facts in these situations. To view additional diagnostic information, including the invoked commands' `stderr` output, run Facter with the `--debug` flag.
 
-- [FACT-1085](https://tickets.puppetlabs.com/browse/FACT-1085)
+* [FACT-1085](https://tickets.puppetlabs.com/browse/FACT-1085)
 
 ### `facter -p` Restored
 
@@ -101,14 +102,13 @@ In Facter 2.4, we deprecated `facter -p` as a means of accessing Puppet facts in
 
 `puppet facts` is still the most direct source for Puppet facts, and we recommend moving to it to future-proof your Puppet workflow.
 
-- [FACT-1111](https://tickets.puppetlabs.com/browse/FACT-1111)
+* [FACT-1111](https://tickets.puppetlabs.com/browse/FACT-1111)
 
-Facter 3.0.1
------
+## Facter 3.0.1
 
 Released June 25, 2015.
 
-Shipped in puppet-agent version: 1.2.1.
+Shipped in [`puppet-agent` 1.2.1][puppet-agent 1.2.x].
 
 Facter 3.0.1 fixes an external facts regression that shipped in 3.0.0.
 
@@ -118,12 +118,11 @@ Facter 3.0.0 accidentally breaks manually installed external facts when running 
 
 * [FACT-1055: External facts not working with cfacter](https://tickets.puppetlabs.com/browse/FACT-1055)
 
-Facter 3.0.0
------
+## Facter 3.0.0
 
 Released June 24, 2015.
 
-Shipped in puppet-agent version: 1.2.0.
+Shipped in [`puppet-agent` 1.2.0][puppet-agent 1.2.x].
 
 Facter 3.0.0 is a complete rewrite of Facter in C++. Prior to this release, it was available separately as `cfacter` and could be enabled in Puppet by setting `cfacter = true` in puppet.conf.
 
@@ -144,7 +143,7 @@ Facts that no longer appear in command-line output are documented as such in [th
 
 To display legacy facts on the command line with Facter 3, we recommend either using `puppet facts` or modifying Facter workflows to instead use the equivalent structured facts. Facter 3.0.2 provides a flag that forces Facter to output legacy facts as an interim solution for affected workflows.
 
-- [FACT-1075](https://tickets.puppetlabs.com/browse/FACT-1075)
+* [FACT-1075](https://tickets.puppetlabs.com/browse/FACT-1075)
 
 ### REGRESSION / BREAK (Fixed in 3.0.1): Can't Find Manually Installed External Facts
 
@@ -167,19 +166,19 @@ Pluginsynced external facts (that is, facts synced from your Puppet modules) sti
 
 Facter 3.0.0 incorrectly reports Oracle Linux's `operatingsystem` fact as `RedHat`. Facter 3.0.2 correctly reports `OracleLinux`.
 
-- [FACT-1134](https://tickets.puppetlabs.com/browse/FACT-1134)
+* [FACT-1134](https://tickets.puppetlabs.com/browse/FACT-1134)
 
 ### REGRESSION (fixed in 3.0.2): Facter Outputs `nil` When It Can't Find a Command, or When a Command Returns a Non-zero Exit Code
 
 Facter 2 returns a String if a command returns a non-zero exit code or can't be found, but Facter 3.0.0 returns `nil`, which causes problems with facts that rely on exit codes or error messages. This behavior is reverted in Facter 3.0.2.
 
-- [FACT-1115](https://tickets.puppetlabs.com/browse/FACT-1115)
+* [FACT-1115](https://tickets.puppetlabs.com/browse/FACT-1115)
 
 ### REGRESSION (fixed in 3.0.2): Facter Redirects `stderr` to `stdout`
 
 When Facter 3.0.0 executes commands, it incorrectly redirects the stderr output from those commands to stdout, causing any affected facts to appear to contain the stderr output instead of the fact's value. This can also result in a fact appearing to have an unexpectedly null value if the first command that Facter executes when reporting that fact cannot be found. We resolved this in Facter 3.0.2, and you can view the commands' `stderr` output by running Facter with the `--debug` flag.
 
-- [FACT-1085](https://tickets.puppetlabs.com/browse/FACT-1085)
+* [FACT-1085](https://tickets.puppetlabs.com/browse/FACT-1085)
 
 ### BREAK: Facter Doesn't Pass Commands' `stderr` to Puppet's `stderr`
 
@@ -198,14 +197,14 @@ The following facts are not supported in Facter 3:
 * `uniqueid`: This fact was neither widely used nor necessarily unique in non-Solaris OSs. Puppet prefers `hostid`.
 * `vlans`: This fact was not widely used and removed.
 
-- [FACT-1013](https://tickets.puppetlabs.com/browse/FACT-1013)
-- [CFACT-151](https://tickets.puppetlabs.com/browse/CFACT-151)
+* [FACT-1013](https://tickets.puppetlabs.com/browse/FACT-1013)
+* [CFACT-151](https://tickets.puppetlabs.com/browse/CFACT-151)
 
 ### REGRESSION (fixed in 3.0.2): `xendomains` Fact Removed
 
 We unintentionally removed the `xendomains` fact in Facter 3.0.0. It's restored in Facter 3.0.2.
 
-- [FACT-867](https://tickets.puppetlabs.com/browse/FACT-867)
+* [FACT-867](https://tickets.puppetlabs.com/browse/FACT-867)
 
 ### REGRESSION / BREAK (fixed in 3.0.2): `fqdn` Fact Might Omit Domain Name
 
@@ -234,20 +233,20 @@ We reversed this decision in Facter 3.0.2.
 
 We changed the value of the hardware fact (`os.hardware`) from "x64" to "x86_64" for 64-bit Windows editions to make Windows consistent with other operating systems. The `architecture` fact is still "x64" as it represents the platform-specific name for the system architecture.
 
-- [FACT-610](https://tickets.puppetlabs.com/browse/FACT-610)
+* [FACT-610](https://tickets.puppetlabs.com/browse/FACT-610)
 
 ### REGRESSION / BREAK (fixed in 3.0.2): Hostname missing from the `fqdn` fact
 
 When reporting the `fqdn` fact, Facter 3.0.0 doesn't report the hostname. We resolved this in Facter 3.0.2.
 
-- [FACT-1077](https://tickets.puppetlabs.com/browse/FACT-1077)
-- [FACT-1078](https://tickets.puppetlabs.com/browse/FACT-1078)
+* [FACT-1077](https://tickets.puppetlabs.com/browse/FACT-1077)
+* [FACT-1078](https://tickets.puppetlabs.com/browse/FACT-1078)
 
 ### REGRESSION (fixed in 3.0.2): Facter Uses Too Much Memory
 
 Facter 3.0.0 consumes more memory than necessary when starting `puppetserver`, causing stability or performance issues on systems with little RAM. We resolved this in Facter 3.0.2.
 
-- [FACT-1083](https://tickets.puppetlabs.com/browse/FACT-1083)
+* [FACT-1083](https://tickets.puppetlabs.com/browse/FACT-1083)
 
 ### Enhanced Fact: `os` Fact Includes New and Renamed Keys
 
@@ -275,7 +274,7 @@ The following facts are new to the 3.0.0 release:
 
 Some of these facts contain new information about the node, and some are structured improvements on facts that were already present in Facter 2. Please see the [core facts reference](./core_facts.html) for details.
 
-- [CFACT-154](https://tickets.puppetlabs.com/browse/CFACT-154)
+* [CFACT-154](https://tickets.puppetlabs.com/browse/CFACT-154)
 
 ### Better Docs for Core Facts
 

--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -31,32 +31,32 @@ Released November 17, 2015.
 
 Shipped in [`puppet-agent` 1.3.0][puppet-agent 1.3.x].
 
-Facter 3.1.2 is a bug fix release in the Facter 3.1 series.
+Facter 3.1.2 is a bug-fix release in the Facter 3.1 series.
 
-* [Fixes for Facter 3.1.2](https://tickets.puppetlabs.com/issues/?filter=16010)
+* [Fixed in Facter 3.1.2](https://tickets.puppetlabs.com/issues/?filter=16110)
 * [Introduced in Facter 3.1.2](https://tickets.puppetlabs.com/issues/?filter=16111)
 
-### FIX: Correctly Report OSX Versions
+### FIX: Correctly Report OS X Versions
 
-Facter was incorrectly omitting a "point release" part of the full version of major releases of the OSX operating system when the point release is "0". For major new releases like "10.11.0", Facter was reporting this version as "10.11". For "10.11.1", Facter correctly reports "10.11.1". This has been addressed so that Facter consistently reports the full version (e.g. "10.11.0") even if the "point release" part of the version number is "0".
+Facter incorrectly omitted a "point release" part of the full version of major releases of OS X when the point release is "0". For instance, Facter incorrectly reported major releases like "10.11.0" as "10.11". This has been addressed so that Facter consistently reports the full version number even if the "point release" part of the version number is "0".
 
-* [FACT-1267](https://tickets.puppetlabs.com/browse/FACT1267)
+* [FACT-1267](https://tickets.puppetlabs.com/browse/FACT-1267)
 
-### FIX: Missing Required File
+### FIX: Restore Missing Required File
 
-The tarball for Facter 3.1.1 failed to include .gemspec.in, which is required for building from source. This has been fixed.
+The tarball for Facter 3.1.1 failed to include `.gemspec.in`, which is required for building from source. This release includes the file.
 
 * [FACT-1266](https://tickets.puppetlabs.com/browse/FACT-1266)
 
-### FIX: Custom Structured Facts
+### FIX: Access Members of Custom Structured Facts
 
-Facter supports a command line syntax for querying into structured facts (e.g. "foo.bar" gets the "bar" member of the hash fact "foo"). This only worked with built-in and external facts, and not custom facts written in Ruby. This has been fixed so that the feature works with all facts.
+Facter supports a command-line syntax for querying structured facts. For example, "os.name" gets the "name" member of the hash fact "os". However, in previous versions of Facter 3 this didn't work with custom facts written in Ruby. This release fixes this behavior to work with all facts.
 
 * [FACT-1254](https://tickets.puppetlabs.com/browse/FACT-1254)
 
-### FIX: System dmidecode on Older Linux
+### FIX: System `dmidecode` on Older Linux
 
-On older Linux kernels, Facter falls back to executing dmidecode to retrieve certain built-in facts. Facter was incorrectly using the system's dmidecode, if present, instead of the one that ships with Puppet Agent. This has been corrected so that the system installed with Puppet Agent is preferred.
+On older Linux kernels, Facter falls back to executing `dmidecode` to retrieve certain built-in facts. Previous versions of Facter incorrectly used the system's `dmidecode`, if present, instead of the one that ships with Puppet Agent. This release corrects this behavior to use the version installed with Puppet Agent.
 
 * [FACT-1241](https://tickets.puppetlabs.com/browse/FACT-1254)
 
@@ -68,12 +68,12 @@ Shipped in [`puppet-agent` 1.2.7][puppet-agent 1.2.x].
 
 Facter 3.1.1 fixes several bugs and adds functionality for AIX 5.3, 6.1, and 7.1, and Solaris 11.
 
-* [Fixes for Facter 3.1.1](https://tickets.puppetlabs.com/issues/?filter=15777)
+* [Fixed in Facter 3.1.1](https://tickets.puppetlabs.com/issues/?filter=15777)
 * [Introduced in Facter 3.1.1](https://tickets.puppetlabs.com/issues/?filter=15771)
 
 ### New Platforms: AIX and Solaris 11
 
-Facter 3.1.1 now reports facts on AIX 5.3, 6.1, and 7.1 on PowerPC, and Solaris 11 on x86 and SPARC. Note that there are no open source Puppet all-in-one packages for these platforms; for more information, see the [puppet-agent][] 1.2.7 release notes.
+Facter 3.1.1 now reports facts on AIX 5.3, 6.1, and 7.1 on PowerPC, and Solaris 11 on x86 and SPARC. Note that there are no open source Puppet all-in-one packages for these platforms; for more information, see the [`puppet-agent` 1.2.7](/puppet/4.2/reference/release_notes_agent.html#puppet-agent-127) release notes.
 
 * [FACT-890](https://tickets.puppetlabs.com/browse/FACT-890): Facter 3 AIX Support
 * [FACT-549](https://tickets.puppetlabs.com/browse/FACT-549): `serialnumber` Fact for AIX
@@ -120,7 +120,7 @@ Facter 3.1.0 fixes several bugs and introduces support for OpenBSD and Solaris 1
 
 For JIRA issues related to Facter 3.1.0, see:
 
-* [Fixes for Facter 3.1.0](https://tickets.puppetlabs.com/issues/?filter=15500)
+* [Fixed in Facter 3.1.0](https://tickets.puppetlabs.com/issues/?filter=15500)
 * [Introduced in Facter 3.1.0](https://tickets.puppetlabs.com/issues/?filter=15429)
 
 ### New Platforms: OpenBSD and Solaris 10

--- a/source/puppet/4.3/reference/release_notes.markdown
+++ b/source/puppet/4.3/reference/release_notes.markdown
@@ -8,12 +8,12 @@ This page lists the changes in Puppet 4.3 and its patch releases.
 Puppet's version numbers use the format X.Y.Z, where:
 
 * X must increase for major backwards-incompatible changes
-* Y may increase for backwards-compatible new functionality
-* Z may increase for bug fixes
+* Y can increase for backwards-compatible new functionality
+* Z can increase for bug fixes
 
 ## If You're Upgrading from Puppet 3.x
 
-Make sure you also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
 Also of interest: the [Puppet 4.2 release notes](/puppet/4.2/reference/release_notes.html) and [Puppet 4.1 release notes](/puppet/4.1/reference/release_notes.html).
 
@@ -28,20 +28,20 @@ Puppet 4.3.1 is a bug fix release.
 
 ### Bug Fixes: Miscellaneous
 
-* [PUP-5525: Hiera special pseudo-variables breaking with Puppet 4.3](https://tickets.puppetlabs.com/browse/PUP-5525): Puppet 4.3.0 does not initialize Hiera for use with data bindings in the correct order, and does not correctly set special pseudovariables like `calling_module`. This led to lookups not finding values when the special variables were interpolated in hierarchy data paths.
+* [PUP-5525: Hiera special pseudo-variables breaking with Puppet 4.3](https://tickets.puppetlabs.com/browse/PUP-5525): Puppet 4.3.0 does not initialize Hiera for use with automatic class parameter lookups in the correct order, and does not correctly set special pseudovariables like `calling_module`. This led to lookups not finding values when the special variables were interpolated in hierarchy data paths.
 
 ## Puppet 4.3.0
 
 Released November 17, 2015.
 
-Puppet 4.3.0 is a feature and bug fix release in the Puppet 4 series. It adds OS X 10.11 (El Capitan) packages, introduces the experimental `lookup` system, support for new language features used by Application Orchestration, augeas improvements, and many bug fixes.
+Puppet 4.3.0 is a feature and bug fix release in the Puppet 4 series. It adds OS X 10.11 (El Capitan) and Fedora 22 packages, introduces the experimental `lookup` system, support for new language features used by Application Orchestration, augeas improvements, and many bug fixes.
 
 * [Fixed in Puppet 4.3.0](https://tickets.puppetlabs.com/issues/?filter=16109)
 * [Introduced in Puppet 4.3.0](https://tickets.puppetlabs.com/issues/?filter=16108)
 
 ### New Feature: Puppet Lookup
 
-Puppet lookup is a new and improved Hiera-like data lookup system, with lots of room for interesting future growth. It integrates with the existing Hiera system, but fixes a lot of its most frustrating limitations.
+Puppet lookup is a new and improved Hiera-like data lookup system, with lots of room for interesting future growth. It integrates with the existing Hiera system but fixes a lot of its most frustrating limitations.
 
 {% partial ./_lookup_experimental.md %}
 
@@ -53,7 +53,7 @@ Today, the summary of Puppet lookup is:
     * MUCH more powerful. Check out `puppet lookup`'s `--node` and `--explain` options.
 * Automatic class parameter lookup can finally fetch merged data! You can specify merge behavior in your data sources with the new `lookup_options` metadata key.
 
-Custom Hiera backends don't currently work with Puppet lookup.
+Custom Hiera backends don't work with Puppet lookup.
 
 For more details, see:
 
@@ -72,47 +72,44 @@ Related tickets:
 
 ### New Feature: Control the Execution of Augeas Resources
 
-* [PUP-4629: Augeas onlyif does not work when using arrays to match against](https://tickets.puppetlabs.com/browse/PUP-4629): Makes it possible to control execution of an augeas resource based on whether a property in the file being managed has a particular value. For example, you can ensure augeas only applies changes to /etc/nagios/nagios.cfg, if the cfg_file property in the nagios.cfg file does not equal a list of values.
+* [PUP-4629: Augeas onlyif does not work when using arrays to match against](https://tickets.puppetlabs.com/browse/PUP-4629): Makes it possible to control execution of an Augeas resource based on whether a property in the file being managed has a particular value. For example, you can ensure Augeas only applies changes to `/etc/nagios/nagios.cfg` if the `cfg_file` property in the `nagios.cfg` file does not equal a list of values.
 
 ~~~
-	augeas { 'configure-nagios-cfg_file':
-	incl => '/etc/nagios/nagios.cfg',
-	lens => 'NagiosCfg.lns',
-	changes => [ "rm cfg_file",
-	"ins cfg_file",
-	"set cfg_file[1] /etc/nagios/commands.cfg",
-	"ins cfg_file after /files/etc/nagios/nagios.cfg/cfg_file[last()]",
-	"set cfg_file[2] /etc/nagios/anotherconfig.cfg" ],
-	onlyif => "values cfg_file != ['/etc/nagios/commands.cfg', '/etc/nagios/anotherconfig.cfg']"
-	}
+augeas { 'configure-nagios-cfg_file':
+incl => '/etc/nagios/nagios.cfg',
+lens => 'NagiosCfg.lns',
+changes => [ "rm cfg_file",
+"ins cfg_file",
+"set cfg_file[1] /etc/nagios/commands.cfg",
+"ins cfg_file after /files/etc/nagios/nagios.cfg/cfg_file[last()]",
+"set cfg_file[2] /etc/nagios/anotherconfig.cfg" ],
+onlyif => "values cfg_file != ['/etc/nagios/commands.cfg', '/etc/nagios/anotherconfig.cfg']"
+}
 ~~~
-
 
 ### New Features: Miscellaneous
 
-* [PUP-4622: Add a diff command in Puppet filebucket](https://tickets.puppetlabs.com/browse/PUP-4622): Adds a new diff command to the Puppet filebucket application allowing you to diff two files. The files to compare can either be specified using a local path or the checksum of the file in the filebucket, e.g. `puppet filebucket diff d43a6ecaa892a1962398ac9170ea9bf2 7ae322f5791217e031dc60188f4521ef` will diff two files from the filebucket. The diff command works with both local and remote filebuckets.
+* [PUP-4622: Add a diff command in Puppet filebucket](https://tickets.puppetlabs.com/browse/PUP-4622): Adds a new `puppet filebucket diff` command that lets you compare two files. You can specify files using either a local path or the checksum of the file in the filebucket. The diff command works with both local and remote filebuckets.
 
-* [PUP-5097: Hostname and Domain as trusted facts](https://tickets.puppetlabs.com/browse/PUP-5097): This change adds two new trusted facts, `hostname` and `domainname`, which can be handy in a hiera hierarchy. See the ticket description for an example of how it might be used in hiera.
+    For example, `puppet filebucket diff d43a6ecaa892a1962398ac9170ea9bf2 7ae322f5791217e031dc60188f4521ef` will diff two files from the filebucket.
 
-* [PUP-4602: 'bsd' service provider doesn't work with rcng](https://tickets.puppetlabs.com/browse/PUP-4602): Previously, Puppet could not manage services on NetBSD. This change adds an `rcng` service provider, which is the default provider for platforms where the operatingsystem fact returns `netbsd` or `cargos`.
+* [PUP-5097: Hostname and Domain as trusted facts](https://tickets.puppetlabs.com/browse/PUP-5097): This change adds two new trusted facts, `hostname` and `domainname`, which can be handy in a Hiera hierarchy. See the ticket description for an example of how it might be used in Hiera.
 
-* [PUP-2315: function call error message about mis-matched arguments is hard to understand](https://tickets.puppetlabs.com/browse/PUP-2315): When giving arguments to functions, defined types, or classes, and they were not acceptable Puppet would produce too much information and thereby making it hard to understand exactly were the unacceptable argument value was and why it was unacceptable.
+* [PUP-4602: 'bsd' service provider doesn't work with rcng](https://tickets.puppetlabs.com/browse/PUP-4602): Previously, Puppet could not manage services on NetBSD. This change adds an `rcng` service provider, which is the default provider for platforms where the `operatingsystem` fact returns `netbsd` or `cargos`.
 
-    This is now much improved and the presented error message points to what to fix.
+* [PUP-2315: function call error message about mis-matched arguments is hard to understand](https://tickets.puppetlabs.com/browse/PUP-2315): When giving unacceptable arguments to functions, defined types, or classes, Puppet would produce too much information, thereby making it hard to understand exactly were the unacceptable argument value was and why it was unacceptable.
 
-* [PUP-4780: enhance versioncmp() error checking as it only accepts strings](https://tickets.puppetlabs.com/browse/PUP-4780): The `versioncmp()` function now type checks its arguments (they must be Strings). Before this, if something other than Strings were given the result could be a confusing error message. Now it is made clear it is a type mismatch problem.
+    This release improves the error message and provides more information toward diagnosing the issue.
 
-* [PUP-5355: Add additional OIDs for cloud specific data](https://tickets.puppetlabs.com/browse/PUP-5355): Adds more Puppet OIDs under ppRegCertExt (1.3.6.1.4.1.34380.1.1) for certificate extension information, see the table of [Puppet Specific Registered IDs](https://docs.puppetlabs.com/puppet/latest/reference/ssl_attributes_extensions.html#puppet-specific-registered-ids).
+* [PUP-4780: enhance versioncmp() error checking as it only accepts strings](https://tickets.puppetlabs.com/browse/PUP-4780): The `versioncmp()` function now type-checks its arguments, which must be strings, and reports a type mismatch error if this is not the case. Before this, if data other than strings were given, Puppet could produce a confusing error message.
+
+* [PUP-5355: Add additional OIDs for cloud specific data](https://tickets.puppetlabs.com/browse/PUP-5355): Adds more Puppet OIDs under ppRegCertExt (1.3.6.1.4.1.34380.1.1) for certificate extension information. See the table of [Puppet Specific Registered IDs](/puppet/latest/4.3/ssl_attributes_extensions.html#puppet-specific-registered-ids).
 
 * [PUP-4055: Support DNF package manager (yum successor)](https://tickets.puppetlabs.com/browse/PUP-4055): Fedora 22 has moved to DNF as a replacement for yum. With this ticket, we now have a new DNF package provider that supports DNF.
 
-* [PUP-1388: Add 'list' subcommand to filebucket](https://tickets.puppetlabs.com/browse/PUP-1388): Makes it possible to list *local* filebuckets, returning the checksum, date and path of each file in the file bucket. Listing remote filebuckets is not supported. The list command takes optional --fromdate and/or --todate options to limit which files are returned.
-* [PUP-4890: Add code_id to catalog](https://tickets.puppetlabs.com/browse/PUP-4890): Adds `code_id` to the catalog, which is serialized with the catalog, e.g. when the agent requests a catalog. Updates the catalog schema and api docs. For now the code_id will always be nil, so there is not much in the way of user-facing changes.
+* [PUP-1388: Add 'list' subcommand to filebucket](https://tickets.puppetlabs.com/browse/PUP-1388): Makes it possible to list _local_ filebuckets, returning the checksum, date and path of each file in the file bucket. Listing remote filebuckets is not supported. The list command can take `--fromdate` and `--todate` options to limit which files are returned.
 
-* [PUP-5221: (Ankeny) Direct Puppet: code_id support](https://tickets.puppetlabs.com/browse/PUP-5221): This epic covers add a `code_id` field to the catalog during compilation. The catalog sent to the agent and puppetdb will contain & persist the code_id. See the API docs for more information about how this changes the catalog schema.
-
-    For FOSS users, the `code_id` will have a nil value, and doesn't result in user-visible behavior changes. In PE Ankeny, the `code_id` will be the git sha from the file sync service.
-
+* [PUP-4890: Add code_id to catalog](https://tickets.puppetlabs.com/browse/PUP-4890) and [PUP-5221: (Ankeny) Direct Puppet: code_id support](https://tickets.puppetlabs.com/browse/PUP-5221): Adds `code_id` to the catalog that is serialized with the catalog, such as when the agent requests a catalog. This release updates the catalog schema and API documentation. For now, the `code_id` will always be nil, so there is not much in the way of user-facing changes.
 
 ### Bug Fixes: Language
 
@@ -138,7 +135,7 @@ Related tickets:
 
 * [PUP-5271: Windows user resource should not manage password unless specified](https://tickets.puppetlabs.com/browse/PUP-5271): When you are attempting to create users without specifying the password and you have the Windows Password Policy for `Password must meet complexity requirements` set to Enabled, it caused Puppet to fail to create the user. Now it works appropriately.
 
-    >>NOTE: When the Windows Password Policy `Minimum password length` is greater than 0, the password must always be specified. This is due to Windows validation for new user creation requiring a password for all new accounts, so it is not possible to leave password unspecified once that password policy is set.
+    > **Note:** When the Windows Password Policy `Minimum password length` is greater than 0, the password must always be specified. This is due to Windows validation for new user creation requiring a password for all new accounts, so it is not possible to leave password unspecified once that password policy is set.
 
     It is also important to note that when a user is specified with `managehome => true`, the password must always be specified if it is not an already existing user on the system.
 
@@ -163,13 +160,13 @@ Related tickets:
 
 * [PUP-5014: Base class for JSON/msgpack indirection termini calls log_exception() wrong](https://tickets.puppetlabs.com/browse/PUP-5014): If an exception occurred while serializing objects to JSON or msgpack, Puppet generated a new exception while logging the original exception, causing the reason for the original exception to be lost.
 
-* [PUP-4781: filemode retrieved by static_compiler should be stringified](https://tickets.puppetlabs.com/browse/PUP-4781): The static compiler was completely broken in Puppet 4, because it would generate file resources with numeric file modes, which is not allowed. This fix causes the static compiler to generate a quoted octal mode, e.g. "644".
+* [PUP-4781: filemode retrieved by static_compiler should be stringified](https://tickets.puppetlabs.com/browse/PUP-4781): The static compiler was completely broken in Puppet 4, because it would generate file resources with numeric file modes, which is not allowed. This fix causes the static compiler to generate a quoted octal mode, such as "644".
 
 * [PUP-5282: Allow local of install of a gem on windows](https://tickets.puppetlabs.com/browse/PUP-5282): Makes it possible to use the gem provider on windows where the source is a local gem.
 
-* [PUP-5192: undefined method `[]' for Puppet::Transaction::Event with certain reports](https://tickets.puppetlabs.com/browse/PUP-5192): PUP-3272 introduced a regression where you could not load a report containing status events, e.g. YAML.load_file("last_run_report.yaml"). This ticket fixes fixes that and adds tests to ensure we don't regress.
+* [PUP-5192: undefined method `[]' for Puppet::Transaction::Event with certain reports](https://tickets.puppetlabs.com/browse/PUP-5192): PUP-3272 introduced a regression where you could not load a report containing status events, such as `YAML.load_file("last_run_report.yaml")`. This ticket fixes fixes that and adds tests to ensure we don't regress.
 
-* [PUP-5055: parent attributes are set from metadata too early in static_compiler](https://tickets.puppetlabs.com/browse/PUP-5055): When using the static compiler (catalog_terminus=static_compiler), and managing a directory with `recurse => true`, then the static compiler would copy the metadata, e.g. owner, from the parent to the child, even when the manifest already specified the child's metadata.
+* [PUP-5055: parent attributes are set from metadata too early in static_compiler](https://tickets.puppetlabs.com/browse/PUP-5055): When using the static compiler (catalog_terminus=static_compiler), and managing a directory with `recurse => true`, then the static compiler would copy the metadata, such as the owner, from the parent to the child even when the manifest already specified the child's metadata.
 
 * [PUP-4697: Puppet service provider for SuSE should default to systemd except for version 11](https://tickets.puppetlabs.com/browse/PUP-4697): Changes the default service provider for suse to be `systemd`, and falls back to `redhat` for versions 10 and 11. This change aligns with future suse releases as they will be `systemd` based. It's a breaking change for suse 9 and earlier, but those are not supported.
 
@@ -191,37 +188,37 @@ Related tickets:
 
 * [PUP-3694: puppet cert fingerprint invalidhost returns zero instead of non-zero](https://tickets.puppetlabs.com/browse/PUP-3694): Previously, `puppet cert fingerprint invalid_host_name` would report an error but still exit 0. This fixes the command to return a non-zero exit code if the certificate can not be found.
 
-* [PUP-4814: Path of scheduled tasks folder is not necessarily C:\Windows\Tasks](https://tickets.puppetlabs.com/browse/PUP-4814): Previously Puppet's scheduled_task provider on windows assumed the windows system directory was C:\windows\system32. However, it possible for the directory to be on an alternative drive and/or have a different root directory, e.g. D:\winnt\system32. As a result the provider could not manage scheduled tasks. This change uses the SystemRoot environment variable to resolve the correct directory.
+* [PUP-4814: Path of scheduled tasks folder is not necessarily C:\Windows\Tasks](https://tickets.puppetlabs.com/browse/PUP-4814): Previously Puppet's scheduled_task provider on windows assumed the Windows system directory was `C:\windows\system32`. However, it possible for the directory to be on an alternative drive or have a different root directory, such as `D:\winnt\system32`. As a result the provider could not manage scheduled tasks. This change uses the SystemRoot environment variable to resolve the correct directory.
 
 * [PUP-5340: puppet apply doesn't honor --catalog_cache_terminus](https://tickets.puppetlabs.com/browse/PUP-5340): Changes `puppet apply` to observe the `catalog_cache_terminus` Puppet setting to be consistent with `puppet agent`. This way you can run `puppet apply <manifest.pp> --catalog_cache_terminus=json`, then Puppet will store a cached copy of the catalog in `$client_datadir/catalog/<hostname>.json`. The default behavior of `puppet apply` is unchanged.
 
 * [PUP-5381: Evaluating instance match with Optional[T] and NotUndef[T] fails when T is a string value](https://tickets.puppetlabs.com/browse/PUP-5381): The type references Optional[T] and NotUndef[T] should have accepted a string S as a shorthand notation for Enum[S]. Instead this failed with an error which is not corrected.
 
-* [PUP-5292: regsubst doesn't work on empty arrays in Puppet 4.x](https://tickets.puppetlabs.com/browse/PUP-5292): Type system did not recognize an empty array as an acceptable value where a array with a specified subtype was declared. This caused certain calls to be reported as being given the wrong type(s) of arguments - e.g. a regsubst function call operating on an empty array.
+* [PUP-5292: regsubst doesn't work on empty arrays in Puppet 4.x](https://tickets.puppetlabs.com/browse/PUP-5292): The type system did not recognize an empty array as an acceptable value when an array with a specified subtype was declared. This caused certain calls to be reported as being given the wrong types of arguments, such as a `regsubst` function call operating on an empty array.
 
-* [PUP-5427: incorrect path being defined in puppet-agent's init script is causing gems to be installed into Puppet's gem env.](https://tickets.puppetlabs.com/browse/PUP-5427): When running Puppet as a daemon, our private bin directory, /opt/puppetlabs/puppet/bin was prepended to the PATH for the Puppet process, causing Puppet to install gems (such as when using the `gem` package provider) into Puppet's vendored ruby instead of system ruby. Now Puppet correctly installs gems into system ruby when running daemonized, which is consistent with running Puppet in the foreground, e.g. `puppet agent -t`.
+* [PUP-5427: incorrect path being defined in puppet-agent's init script is causing gems to be installed into Puppet's gem env.](https://tickets.puppetlabs.com/browse/PUP-5427): When running Puppet as a daemon, our private bin directory `/opt/puppetlabs/puppet/bin` was prepended to the PATH for the Puppet process, causing Puppet to install gems (such as when using the `gem` package provider) into Puppet's vendored Ruby instead of the system's Ruby. Puppet 4.3.0 correctly installs gems into the system's Ruby when running daemonized, which is consistent with running Puppet in the foreground (`puppet agent -t`).
 
-* [PUP-5262: Solaris (10) service provider returns before service refresh is complete](https://tickets.puppetlabs.com/browse/PUP-5262): In versions of Solaris older than 11.2, service state transitions are not atomic. On slower systems, this could cause race conditions when starting, stopping or restarting services, as Puppet did not wait for services to conclude their operations before continuing to apply different resources. The SMF service provider has been updated to wait up for up to 60 seconds when changing the state of a service.
+* [PUP-5262: Solaris (10) service provider returns before service refresh is complete](https://tickets.puppetlabs.com/browse/PUP-5262): In versions of Solaris older than 11.2, service state transitions are not atomic. On slower systems, this could cause race conditions when starting, stopping, or restarting services, as Puppet did not wait for services to conclude their operations before continuing to apply different resources. The SMF service provider has been updated to wait up for up to 60 seconds when changing the state of a service.
 
-* [PUP-5309: Yum package provider: ensure => latest fails when kernel is updated but not current](https://tickets.puppetlabs.com/browse/PUP-5309): The yum provider will no longer throw "undefined method `[]' for nil:NilClass" if the yum-security plugin is enabled when trying to manage a yum package.
+* [PUP-5309: Yum package provider: ensure => latest fails when kernel is updated but not current](https://tickets.puppetlabs.com/browse/PUP-5309): The yum provider no longer throws "undefined method `[]' for nil:NilClass" if the yum-security plugin is enabled when trying to manage a yum package.
 
 * [PUP-5441: $trusted is not available in master compile and fails when coming from PDB](https://tickets.puppetlabs.com/browse/PUP-5441): Sanitizes the trusted info in the node object when it is restored from cache. This prevents "Attempt to assign to a reserved variable name: 'trusted' " errors when running standalone compiles on a master node, among other scenarios.
 
-* [PUP-5025: Package resource showing notice when ensure attribute contains Epoch tag](https://tickets.puppetlabs.com/browse/PUP-5025): Previously, if the ensure property for a yum/dnf package contained an epoch tag, then Puppet would consider the resource to always be out-of-sync and would try to reinstall the package. Puppet now takes into account the epoch tag when comparing the current and desired versions.
+* [PUP-5025: Package resource showing notice when ensure attribute contains Epoch tag](https://tickets.puppetlabs.com/browse/PUP-5025): Previously, if the `ensure` property for a yum or dnf package contained an epoch tag,  Puppet would consider the resource to always be out of sync try to reinstall the package. Puppet now takes into account the epoch tag when comparing the current and desired versions.
 
-* [PUP-4458: Refactor validation of 4.x parameter signatures](https://tickets.puppetlabs.com/browse/PUP-4458): This makes the typechecking and reporting of parameter types consistent. Earlier there were several different implementatations and they differed in how they checked and reported type mismatches.
+* [PUP-4458: Refactor validation of 4.x parameter signatures](https://tickets.puppetlabs.com/browse/PUP-4458): Earlier there were several different implementatations and they differed in how they checked and reported type mismatches. This release makes the typechecking and reporting of parameter types consistent.
 
-* [PUP-5035: undefined method `keys' for nil:NilClass in static_compiler](https://tickets.puppetlabs.com/browse/PUP-5035): The static compiler would raise a NoMethodError exception if it tried to inline metadata for a file resource where recurse was true, but the source parameter, e.g. `source => 'puppet:///modules/puppet/puppet.conf'`, referred to a file on the master.
+* [PUP-5035: undefined method `keys' for nil:NilClass in static_compiler](https://tickets.puppetlabs.com/browse/PUP-5035): The static compiler would raise a NoMethodError exception if it tried to inline metadata for a file resource where recurse was true, but the source parameter (such as `source => 'puppet:///modules/puppet/puppet.conf'`) referred to a file on the master.
 
 * [PUP-4702: Replace rgen model for the Puppet Type system with immutable classes](https://tickets.puppetlabs.com/browse/PUP-4702): A refactoring was done of the Puppet type system to make it use less memory and faster performing.
 
 * [PUP-5342: Empty arrays does not match type of typed arrays](https://tickets.puppetlabs.com/browse/PUP-5342): The type system did not accept an empty array as valid when the array type matched against did not accept Undef entries.
 
-* [PUP-4932: Deprecate cfacter setting](https://tickets.puppetlabs.com/browse/PUP-4932): The cfacter setting existed so that users could opt-into native facter. But in AIO, it is the one and only facter implementation, and trying to set it will fail, since native facter does not provide cfacter.rb. This ticket deprecates the setting and it will be removed in the next major version.
+* [PUP-4932: Deprecate cfacter setting](https://tickets.puppetlabs.com/browse/PUP-4932): The `cfacter` setting allowed users in past versions of Puppet to use a native Facter implementation instead of the older Ruby Facter. In the `puppet-agent` package, native Facter is the only available implementation, and trying to set the `cfacter` setting will fail since native Facter does not provide `cfacter.rb`. This release deprecates the `cfacter` setting, and it will be removed in the next major version.
 
 * [PUP-5032: Update node terminus configured_environment to mirror agent_specified_environment](https://tickets.puppetlabs.com/browse/PUP-5032): When the `configured_environment` property was added to node and catalog communication, it was always set even when accepting the default. This was less useful than intended, as a node classifier may expect to know whether the agent explicitly requested that environment or is using the default. Change to only set the `configured_environment` property if an environment was explicitly requested on the agent, i.e. via puppet.conf or the command-line.
 
-* [PUP-4516: Agent does not stop with Ctrl-C](https://tickets.puppetlabs.com/browse/PUP-4516): Puppet agents and webrick masters now immediately exit in response to SIGINT and SIGTERM signals, such as when pressing Ctrl-C. Previously, if the agent process was idle, it would take upwards of 5 seconds for the process to stop. If the agent was performing a run, it could not be interrupted until after the run completed.
+* [PUP-4516: Agent does not stop with Ctrl-C](https://tickets.puppetlabs.com/browse/PUP-4516): Puppet agents and WEBrick masters now immediately exit in response to SIGINT and SIGTERM signals, such as when pressing Ctrl-C. Previously, if the agent process was idle, it would take up to 5 seconds for the process to stop. If the agent was performing a run, it could not be interrupted until after the run completed.
 
 * [PUP-5387: AIX service provider returns before service operations are complete](https://tickets.puppetlabs.com/browse/PUP-5387): In AIX, service state transitions are not atomic. On slower systems, this could cause race conditions when starting, stopping or restarting services, as Puppet did not wait for services to conclude their operations before continuing to apply different resources. The SRC service provider has been updated to wait up for up to 60 seconds when changing the state of a service.
 

--- a/source/puppet/4.3/reference/release_notes_agent.md
+++ b/source/puppet/4.3/reference/release_notes_agent.md
@@ -47,16 +47,31 @@ This release also closes a race condition in `pxp-agent` between the completion 
 
 Released November 17, 2015.
 
-Includes [Puppet 4.3.0][], [Facter 3.1.2][], [Hiera 3.0.5][], [MCollective 2.8.6][], Ruby 2.1.7, and OpenSSL 1.0.2d. This version also introduces the [`pxp-agent`](https://github.com/puppetlabs/pxp-agent) component at version 1.0.0 in support of the [PCP Execution Protocol](https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/README.md) and forthcoming Application Orchestration features in Puppet Enterprise 2015.3.
+Includes [Puppet 4.3.0][], [Facter 3.1.2][], [Hiera 3.0.5][], [MCollective 2.8.6][], Ruby 2.1.7, and OpenSSL 1.0.2d. This version also introduces the [`pxp-agent`][pxp-agent] component at version 1.0.0 in support of the [PCP Execution Protocol](https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/README.md) and forthcoming Application Orchestration features in Puppet Enterprise 2015.3.
 
 ### New Platforms
 
-This release adds `puppet-agent` packages for OS X 10.11 (El Capitan).
-
+This release adds `puppet-agent` packages for OS X 10.11 (El Capitan) and Fedora 22.
 
 ### Windows Server 2003 Removed
 
 We no longer provide `puppet-agent` packages that will install on Windows Server 2003 or Server 2003 R2. We [deprecated](./deprecated_win2003.html) those platforms in Puppet 4.2.
+
+### Fedora 20 Removed
+
+We no longer provide `puppet-agent` packages for Fedora 20, which reached its end-of-life on June 23, 2015.
+
+### Known Issues
+
+#### Windows Uninstaller Falsely Suggests a Reboot is Required
+
+When uninstalling `puppet-agent` 1.3.0 and newer for Windows, Windows Installer presents a dialog stating:
+
+> The setup must update files or services that cannot be updated while the system is running. If you choose to continue, a reboot will be required to complete the setup.
+
+Windows Installer incorrectly assumes the newly included `pxp-agent.exe` will be locked by the time it will be removed. This is not true, and you can ignore the dialog. Unattended installs and future upgrades might log an error from the MSI Restart Manager that you can also ignore.
+
+* [PA-65: Windows claims to requires reboot after uninstalling MSI when pxp-agent is running when it does not](https://tickets.puppetlabs.com/browse/PA-65)
 
 ### Bug Fixes
 


### PR DESCRIPTION
* Update `puppet-agent` links in Facter 3.0 notes.
* Make Markdown and text style more consistent across release notes.
  * Use consistent list styles.
  * Use hashes for H2s.
* Edit content for consistency and style.
* Add puppet-agent 1.3.0 known issue for MSI/Windows Installer.