### PR TITLE
Agent 1.3.2 release notes

### DIFF
--- a/source/puppet/4.3/reference/release_notes_agent.md
+++ b/source/puppet/4.3/reference/release_notes_agent.md
@@ -30,6 +30,21 @@ The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release 
 
 Also of interest: [About Agent](/puppet/4.3/reference/about_agent.html) and the [Puppet 4.3 release notes](/puppet/4.3/reference/release_notes.html).
 
+## Puppet Agent 1.3.2
+
+Released December 2, 2015.
+
+This release restores a missing root certificate. No other components are updated.
+
+* [Fixed in `puppet-agent` 1.3.2]()
+* [Introduced in `puppet-agent` 1.3.2]()
+
+#### DigiCert Global Root Certificate is Restored
+
+The `puppet-agent` 1.3.0 package mistakenly omits the DigiCert Global Root certificate from `/opt/puppetlabs/puppet/ssl/cert.pem`, which was included in `puppet-agent` up to version 1.2.7. This certificate is restored in `puppet-agent` 1.3.2.
+
+* [PA-95: DigiCert Global Root cert missing in puppet-agent 1.3.0](https://tickets.puppetlabs.com/browse/PA-95)
+
 ## Puppet Agent 1.3.1
 
 Released November 30, 2015.
@@ -47,12 +62,11 @@ This release also closes a race condition in `pxp-agent` between the completion 
 
 Released November 17, 2015.
 
-Includes [Puppet 4.3.0][], [Facter 3.1.2][], [Hiera 3.0.5][], [MCollective 2.8.6][], Ruby 2.1.7, and OpenSSL 1.0.2d. This version also introduces the [`pxp-agent`](https://github.com/puppetlabs/pxp-agent) component at version 1.0.0 in support of the [PCP Execution Protocol](https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/README.md) and forthcoming Application Orchestration features in Puppet Enterprise 2015.3.
+Includes [Puppet 4.3.0][], [Facter 3.1.2][], [Hiera 3.0.5][], [MCollective 2.8.6][], Ruby 2.1.7, and OpenSSL 1.0.2d. This version also introduces the [`pxp-agent`][pxp-agent] component at version 1.0.0 in support of the [PCP Execution Protocol](https://github.com/puppetlabs/pcp-specifications/blob/master/pxp/README.md) and forthcoming Application Orchestration features in Puppet Enterprise 2015.3.
 
 ### New Platforms
 
-This release adds `puppet-agent` packages for OS X 10.11 (El Capitan).
-
+This release adds `puppet-agent` packages for OS X 10.11 (El Capitan) and Fedora 22.
 
 ### Windows Server 2003 Removed
 
@@ -61,6 +75,14 @@ We no longer provide `puppet-agent` packages that will install on Windows Server
 ### Bug Fixes
 
 * Resolves [a daemonization issue on AIX](https://tickets.puppetlabs.com/browse/PA-67) that made the service appear to be inoperative when running.
+
+### Regressions
+
+#### DigiCert Global Root Certificate is Restored
+
+The `puppet-agent` 1.3.0 package mistakenly omits the DigiCert Global Root certificate from `/opt/puppetlabs/puppet/ssl/cert.pem`, which was included in `puppet-agent` up to version 1.2.7. This certificate is restored in `puppet-agent` 1.3.2.
+
+* [PA-95: DigiCert Global Root cert missing in puppet-agent 1.3.0](https://tickets.puppetlabs.com/browse/PA-95)
 
 ### Updated Components
 

--- a/source/puppet/4.3/reference/release_notes_agent.md
+++ b/source/puppet/4.3/reference/release_notes_agent.md
@@ -34,7 +34,7 @@ Also of interest: [About Agent](/puppet/4.3/reference/about_agent.html) and the 
 
 Released December 2, 2015.
 
-This release restores a missing root certificate. No other components are updated.
+This release includes a more comprehensive root certificate authority (CA) certificate bundle. No other components are updated.
 
 * [Fixed in `puppet-agent` 1.3.2](https://tickets.puppetlabs.com/issues/?filter=16400)
 * [Introduced in `puppet-agent` 1.3.2](https://tickets.puppetlabs.com/issues/?filter=16401)
@@ -43,7 +43,7 @@ This release restores a missing root certificate. No other components are update
 
 #### More CA Certificates Bundled
 
-In `puppet-agent` 1.3.0 and 1.3.1, the included bundle of certificate authority (CA) certificates was smaller than the system bundles used in `puppet-agent` 1.2.7 and earlier, which could cause Puppet features that rely on the omitted CA certificates to fail. This release resolves the issue by expanding the certificate bundle to be more comparable to the set provided by other vendors.
+In `puppet-agent` 1.3.0 and 1.3.1, the included bundle of CA certificates was smaller than the system bundles used in `puppet-agent` 1.2.7 and earlier, which could cause Puppet features that rely on the omitted CA certificates to fail. This release resolves the issue by expanding the certificate bundle to be more comparable to the set provided by other vendors.
 
 * [PA-95: DigiCert Global Root cert missing in puppet-agent 1.3.0](https://tickets.puppetlabs.com/browse/PA-95)
 * [PA-101: AIO's OpenSSL cannot make SSL connection to apt.dockerproject.org](https://tickets.puppetlabs.com/browse/PA-101)
@@ -83,7 +83,7 @@ We no longer provide `puppet-agent` packages that will install on Windows Server
 
 #### Smaller CA Certificate Bundle Can Cause Failures
 
-Through version 1.2.7, the `puppet-agent` package used the system-provided OpenSSL certificate authority (CA) certificate bundle on platforms where it was available, such as on Linux-based operating systems. Starting with `puppet-agent` 1.3.0, the package includes a CA certificate bundle to support encrypted access consistently across platforms, including those that don't provide their own certificate bundle.
+Through version 1.2.7, the `puppet-agent` package used the system-provided OpenSSL certificate authority (CA) certificate bundle on platforms where it was available, such as on Linux-based operating systems. Starting with `puppet-agent` 1.3.0, the package includes a CA certificate bundle to support authenticated SSL connections consistently across platforms, including platforms that don't provide their own certificate bundle.
 
 However, the bundle we provide in `puppet-agent` 1.3.0 and 1.3.1 includes only a subset of the CA certificates generally provided by Linux vendors, which can cause some Puppet features that require any of the omitted certificates to fail. Starting in version 1.3.2, the bundle includes a more complete set of CA certificates that's comparable to the full set provided by other vendors.
 

--- a/source/puppet/4.3/reference/release_notes_agent.md
+++ b/source/puppet/4.3/reference/release_notes_agent.md
@@ -36,14 +36,17 @@ Released December 2, 2015.
 
 This release restores a missing root certificate. No other components are updated.
 
-* [Fixed in `puppet-agent` 1.3.2]()
-* [Introduced in `puppet-agent` 1.3.2]()
+* [Fixed in `puppet-agent` 1.3.2](https://tickets.puppetlabs.com/issues/?filter=16400)
+* [Introduced in `puppet-agent` 1.3.2](https://tickets.puppetlabs.com/issues/?filter=16401)
 
-#### DigiCert Global Root Certificate is Restored
+### Regression Fixes
 
-The `puppet-agent` 1.3.0 package mistakenly omits the DigiCert Global Root certificate from `/opt/puppetlabs/puppet/ssl/cert.pem`, which was included in `puppet-agent` up to version 1.2.7. This certificate is restored in `puppet-agent` 1.3.2.
+#### More CA Certificates Bundled
+
+In `puppet-agent` 1.3.0 and 1.3.1, the included bundle of certificate authority (CA) certificates was smaller than the system bundles used in `puppet-agent` 1.2.7 and earlier, which could cause Puppet features that rely on the omitted CA certificates to fail. This release resolves the issue by expanding the certificate bundle to be more comparable to the set provided by other vendors.
 
 * [PA-95: DigiCert Global Root cert missing in puppet-agent 1.3.0](https://tickets.puppetlabs.com/browse/PA-95)
+* [PA-101: AIO's OpenSSL cannot make SSL connection to apt.dockerproject.org](https://tickets.puppetlabs.com/browse/PA-101)
 
 ## Puppet Agent 1.3.1
 
@@ -78,11 +81,14 @@ We no longer provide `puppet-agent` packages that will install on Windows Server
 
 ### Regressions
 
-#### DigiCert Global Root Certificate is Restored
+#### Smaller CA Certificate Bundle Can Cause Failures
 
-The `puppet-agent` 1.3.0 package mistakenly omits the DigiCert Global Root certificate from `/opt/puppetlabs/puppet/ssl/cert.pem`, which was included in `puppet-agent` up to version 1.2.7. This certificate is restored in `puppet-agent` 1.3.2.
+Through version 1.2.7, the `puppet-agent` package used the system-provided OpenSSL certificate authority (CA) certificate bundle on platforms where it was available, such as on Linux-based operating systems. Starting with `puppet-agent` 1.3.0, the package includes a CA certificate bundle to support encrypted access consistently across platforms, including those that don't provide their own certificate bundle.
+
+However, the bundle we provide in `puppet-agent` 1.3.0 and 1.3.1 includes only a subset of the CA certificates generally provided by Linux vendors, which can cause some Puppet features that require any of the omitted certificates to fail. Starting in version 1.3.2, the bundle includes a more complete set of CA certificates that's comparable to the full set provided by other vendors.
 
 * [PA-95: DigiCert Global Root cert missing in puppet-agent 1.3.0](https://tickets.puppetlabs.com/browse/PA-95)
+* [PA-101: AIO's OpenSSL cannot make SSL connection to apt.dockerproject.org](https://tickets.puppetlabs.com/browse/PA-101)
 
 ### Updated Components
 


### PR DESCRIPTION
Adds the Agent 1.3.2 release notes and a related regression
to the Agent 1.3.0 release notes.

Also adds F22 support to the 1.3.1 notes and consolidates a
link reference to the `pxp-agent` repository.