### PR TITLE
Update paths and quick start guides for Puppet 4.

### DIFF
--- a/source/puppet/4.1/reference/config_print.markdown
+++ b/source/puppet/4.1/reference/config_print.markdown
@@ -83,7 +83,7 @@ To see the settings the Puppet master service and the Puppet cert command would 
 To see the effective [modulepath][] used in the `dev` environment:
 
     $ sudo puppet config print modulepath --section master --environment dev
-    /etc/puppetlabs/puppet/environments/dev/modules:/etc/puppetlabs/puppet/modules:/opt/puppet/share/puppet/modules
+    /etc/puppetlabs/code/environments/dev/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules
 
 To see whether the [`$facts` and `$trusted` variables][facts_and_trusted] are enabled:
 

--- a/source/puppet/4.1/reference/lang_defaults.markdown
+++ b/source/puppet/4.1/reference/lang_defaults.markdown
@@ -18,7 +18,7 @@ Syntax
 ~~~ ruby
     Exec {
       path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-      environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+      environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
       logoutput   => true,
       timeout     => 180,
     }

--- a/source/puppet/4.1/reference/lang_visual_index.markdown
+++ b/source/puppet/4.1/reference/lang_visual_index.markdown
@@ -253,7 +253,7 @@ This page can help you find syntax elements when you can't remember their names.
 ~~~ ruby
     Exec {
       path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-      environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+      environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
       logoutput   => true,
       timeout     => 180,
     }

--- a/source/puppet/4.1/reference/services_agent_unix.markdown
+++ b/source/puppet/4.1/reference/services_agent_unix.markdown
@@ -139,7 +139,7 @@ This behavior is good for building a cron job that does configuration runs. You 
 You can use the Puppet resource command to set up this cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
 ~~~ bash
-sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
 ~~~
 
 ### Running Puppet Agent On Demand

--- a/source/puppet/4.1/reference/services_apply.markdown
+++ b/source/puppet/4.1/reference/services_apply.markdown
@@ -111,7 +111,7 @@ Since Puppet apply doesn't run as a service, you must manually create a schedule
 
 On \*nix, you can use the Puppet resource command to set up a cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
-    $ sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppet/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
+    sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
 
 ## Configuring Puppet Apply
 

--- a/source/puppet/4.2/reference/config_print.markdown
+++ b/source/puppet/4.2/reference/config_print.markdown
@@ -83,7 +83,7 @@ To see the settings the Puppet master service and the Puppet cert command would 
 To see the effective [modulepath][] used in the `dev` environment:
 
     $ sudo puppet config print modulepath --section master --environment dev
-    /etc/puppetlabs/puppet/environments/dev/modules:/etc/puppetlabs/puppet/modules:/opt/puppet/share/puppet/modules
+    /etc/puppetlabs/code/environments/dev/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules
 
 To see whether the [`$facts` and `$trusted` variables][facts_and_trusted] are enabled:
 

--- a/source/puppet/4.2/reference/lang_defaults.markdown
+++ b/source/puppet/4.2/reference/lang_defaults.markdown
@@ -18,7 +18,7 @@ Syntax
 ~~~ ruby
 Exec {
   path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-  environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+  environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
   logoutput   => true,
   timeout     => 180,
 }

--- a/source/puppet/4.2/reference/lang_visual_index.markdown
+++ b/source/puppet/4.2/reference/lang_visual_index.markdown
@@ -253,7 +253,7 @@ Concat::Fragment <<| tag == "bacula-storage-dir-${bacula_director}" |>>
 ~~~ ruby
 Exec {
   path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-  environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+  environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
   logoutput   => true,
   timeout     => 180,
 }

--- a/source/puppet/4.2/reference/quick_start_dns.markdown
+++ b/source/puppet/4.2/reference/quick_start_dns.markdown
@@ -29,9 +29,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > #### A Quick Note about Modules
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 

--- a/source/puppet/4.2/reference/quick_start_firewall.markdown
+++ b/source/puppet/4.2/reference/quick_start_firewall.markdown
@@ -54,9 +54,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Module Directories
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/puppet/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those that you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 

--- a/source/puppet/4.2/reference/quick_start_helloworld.markdown
+++ b/source/puppet/4.2/reference/quick_start_helloworld.markdown
@@ -19,9 +19,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Modules
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/code/environments/production/modules` on the master This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 
 Modules are directory trees. For this task, you'll create the following structure and files:
 
@@ -30,7 +30,7 @@ Modules are directory trees. For this task, you'll create the following structur
       - `init.pp` (manifest file that contains the `helloworld` class)
       - `motd.pp` (manifest file that contains a file resource that ensures the creation of the motd)
 
-Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `helloworld`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>`, or in this case, `helloworld::motd`.
+Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](./lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `helloworld`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>`, or in this case, `helloworld::motd`.
 
 * For more on how modules work, see [Module Fundamentals](/puppet/3.8/reference/modules_fundamentals.html) in the Puppet documentation.
 * For more on best practices, methods, and approaches to writing modules, see the [Beginners Guide to Modules](/guides/module_guides/bgtm.html).

--- a/source/puppet/4.2/reference/quick_start_module_install_nix.markdown
+++ b/source/puppet/4.2/reference/quick_start_module_install_nix.markdown
@@ -12,7 +12,7 @@ In the [Module Writing Basics for Linux Quick Start Guide](./quick_writing_nix.h
 
 The process for installing a module is the same on both Windows and *nix operating systems.
 
-> **Prerequisites**: This guide assumes you've already [installed Puppet](https://docs.puppetlabs.com/puppetserver/2.1/install_from_packages.html), and have installed at least one [*nix agent](https://docs.puppetlabs.com/puppet/4.2/reference/install_linux.html).
+> **Prerequisites**: This guide assumes you've already [installed Puppet](/2.1/install_from_packages.html), and have installed at least one [*nix agent](./install_linux.html).
 
 > Before starting this walk-through, complete the [Hello World](./quick_start_helloworld) exercise in the [introductory quick start guide](./quick_start.html). You should still be logged in as root or administrator on your nodes.
 
@@ -28,7 +28,7 @@ The process for installing a module is the same on both Windows and *nix operati
         puppetlabs-apache     Puppet module for apache              @puppetlabs   apache
 
 
-    To view detailed information about the module, see the [Apache module on Forge](http://forge.puppetlabs.com/puppetlabs/apache).
+    To view detailed information about the module, see the [Apache module on Forge](https://forge.puppetlabs.com/puppetlabs/apache).
 
 2. To install the Apache module, run:  `puppet module install puppetlabs-apache`. The result looks like this:
 
@@ -42,11 +42,11 @@ The process for installing a module is the same on both Windows and *nix operati
 
 > ### A Quick Note about Module Directories
 >
-> By default, installed modules are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 
->`puppetlabs-apache` is a [PE-supported module](https://forge.puppetlabs.com/supported?_ga=1.208920786.1181567766.1438190846). It is tested and maintained by Puppet Labs, and Puppet Enterprise users are able to file support escalations on these modules.
+>`puppetlabs-apache` is a [PE-supported module](https://forge.puppetlabs.com/supported). It is tested and maintained by Puppet Labs, and Puppet Enterprise users are able to file support escalations on these modules.
 
 --------
 

--- a/source/puppet/4.2/reference/quick_start_sudo.markdown
+++ b/source/puppet/4.2/reference/quick_start_sudo.markdown
@@ -20,13 +20,13 @@ In most cases, managing sudo on your agents involves controlling which users hav
 
 > Before starting this walk-through, complete the previous exercises in the [essential configuration tasks](./quick_start_essential_config.html). Log in as root or administrator on your nodes.
 
-> **Prerequisites**: This guide assumes you've already [installed Puppet](https://docs.puppetlabs.com/puppetserver/2.1/install_from_packages.html), and have installed at least one [*nix agent](https://docs.puppetlabs.com/puppet/4.2/reference/install_linux.html).
+> **Prerequisites**: This guide assumes you've already [installed Puppet](/puppetserver/2.1/install_from_packages.html), and have installed at least one [*nix agent](./install_linux.html).
 
 >**Note**: You can add the sudo and privileges classes to as many agents as needed, although we describe only one for ease of explanation. 
 
 ## Install the `saz-sudo` Module
 
-The `saz-sudo` module, available on the Puppet Forge, is one of many modules written by a member of the Puppet user community.  You can learn more about the module by visiting [http://forge.puppetlabs.com/saz/sudo](http://forge.puppetlabs.com/saz/sudo).
+The `saz-sudo` module, available on the Puppet Forge, is one of many modules written by a member of the Puppet user community.  You can learn more about the module by visiting [https://forge.puppetlabs.com/saz/sudo](https://forge.puppetlabs.com/saz/sudo).
 
 **To install the `saz-sudo` module**:
 
@@ -49,9 +49,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Modules Directories
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/puppet/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 
@@ -137,7 +137,7 @@ For more information about working with Puppet and Sudo Users, check out our [Mo
 
 Puppet Labs offers many opportunities for learning and training, from formal certification courses to guided online lessons. We've noted one below; head over to the [learning Puppet page](https://puppetlabs.com/learn) to discover more.
 
-* [Learning Puppet](http://docs.puppetlabs.com/learning/) is a series of exercises on various core topics about deploying and using Puppet.
+* [Learning Puppet](/learning/) is a series of exercises on various core topics about deploying and using Puppet.
 * The Puppet Labs workshop contains a series of self-paced, online lessons that cover a variety of topics on Puppet basics. You can sign up at the [learning page](https://puppetlabs.com/learn).
 * Learn about [Managing sudo Privileges](https://puppetlabs.com/learn/managing-sudo-privileges) through this online training workshop.
 

--- a/source/puppet/4.2/reference/quick_writing_nix.markdown
+++ b/source/puppet/4.2/reference/quick_writing_nix.markdown
@@ -21,10 +21,9 @@ Although many Forge modules are exact solutions that fit your site, many are *al
 ### Module Basics
 > ### About Module Directories
 >
-> By default, installed modules are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those that you write yourself.
-> To change this path, modify  the [`modulepath`](/references/3.8.latest/configuration.html#modulepath) setting in [`puppet.conf`](https://docs.puppetlabs.com/puppet/latest/reference/config_file_main.html).)
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself. In a fresh installation, you need to create this `modules` subdirectory yourself by navigating to `/etc/puppetlabs/code/environments/production` and running `mkdir modules`.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 
@@ -39,10 +38,10 @@ Modules are directory trees. For these exercises you'll use the following files:
         - `vhost/`
             - `_file_header.erb` (contains the vhost template, managed by Puppet)
 
-Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `apache`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>` or `<MODULE NAME>::<FOLDER>::<FILE NAME>`.
+Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](./lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `apache`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>` or `<MODULE NAME>::<FOLDER>::<FILE NAME>`.
 Many modules, including Apache, contain directories other than `manifests` and `templates`. For simplicity's sake, we do not cover them in this introductory guide.
 
-* For more on how modules work, see [Module Fundamentals](/puppet/3.8/reference/modules_fundamentals.html) in the Puppet documentation.
+* For more on how modules work, see [Module Fundamentals](./modules_fundamentals.html) in the Puppet documentation.
 * For more on best practices, methods, and approaches to writing modules, see the [Beginners Guide to Modules](/guides/module_guides/bgtm.html).
 * For a more detailed guided tour, also see [the module chapters of Learning Puppet](/learning/modules1.html).
 

--- a/source/puppet/4.2/reference/services_agent_unix.markdown
+++ b/source/puppet/4.2/reference/services_agent_unix.markdown
@@ -139,7 +139,7 @@ This behavior is good for building a cron job that does configuration runs. You 
 You can use the Puppet resource command to set up this cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
 ~~~ bash
-sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
 ~~~
 
 ### Running Puppet Agent On Demand

--- a/source/puppet/4.2/reference/services_apply.markdown
+++ b/source/puppet/4.2/reference/services_apply.markdown
@@ -111,7 +111,7 @@ Since Puppet apply doesn't run as a service, you must manually create a schedule
 
 On \*nix, you can use the Puppet resource command to set up a cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
-    $ sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppet/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
+    sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
 
 ## Configuring Puppet Apply
 

--- a/source/puppet/4.3/reference/config_print.markdown
+++ b/source/puppet/4.3/reference/config_print.markdown
@@ -83,7 +83,7 @@ To see the settings the Puppet master service and the Puppet cert command would 
 To see the effective [modulepath][] used in the `dev` environment:
 
     $ sudo puppet config print modulepath --section master --environment dev
-    /etc/puppetlabs/puppet/environments/dev/modules:/etc/puppetlabs/puppet/modules:/opt/puppet/share/puppet/modules
+    /etc/puppetlabs/code/environments/dev/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules
 
 To see whether the [`$facts` and `$trusted` variables][facts_and_trusted] are enabled:
 

--- a/source/puppet/4.3/reference/lang_defaults.markdown
+++ b/source/puppet/4.3/reference/lang_defaults.markdown
@@ -18,7 +18,7 @@ Syntax
 ~~~ ruby
 Exec {
   path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-  environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+  environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
   logoutput   => true,
   timeout     => 180,
 }

--- a/source/puppet/4.3/reference/lang_visual_index.markdown
+++ b/source/puppet/4.3/reference/lang_visual_index.markdown
@@ -253,7 +253,7 @@ Concat::Fragment <<| tag == "bacula-storage-dir-${bacula_director}" |>>
 ~~~ ruby
 Exec {
   path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-  environment => 'RUBYLIB=/opt/puppet/lib/ruby/site_ruby/1.8/',
+  environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
   logoutput   => true,
   timeout     => 180,
 }

--- a/source/puppet/4.3/reference/quick_start_dns.markdown
+++ b/source/puppet/4.3/reference/quick_start_dns.markdown
@@ -29,9 +29,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > #### A Quick Note about Modules
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 

--- a/source/puppet/4.3/reference/quick_start_firewall.markdown
+++ b/source/puppet/4.3/reference/quick_start_firewall.markdown
@@ -54,9 +54,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Module Directories
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/puppet/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those that you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 

--- a/source/puppet/4.3/reference/quick_start_helloworld.markdown
+++ b/source/puppet/4.3/reference/quick_start_helloworld.markdown
@@ -19,9 +19,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Modules
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/code/environments/production/modules` on the master This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 
 Modules are directory trees. For this task, you'll create the following structure and files:
 

--- a/source/puppet/4.3/reference/quick_start_module_install_nix.markdown
+++ b/source/puppet/4.3/reference/quick_start_module_install_nix.markdown
@@ -28,7 +28,7 @@ The process for installing a module is the same on both Windows and *nix operati
         puppetlabs-apache     Puppet module for apache              @puppetlabs   apache
 
 
-    To view detailed information about the module, see the [Apache module on Forge](http://forge.puppetlabs.com/puppetlabs/apache).
+    To view detailed information about the module, see the [Apache module on Forge](https://forge.puppetlabs.com/puppetlabs/apache).
 
 2. To install the Apache module, run:  `puppet module install puppetlabs-apache`. The result looks like this:
 
@@ -42,11 +42,11 @@ The process for installing a module is the same on both Windows and *nix operati
 
 > ### A Quick Note about Module Directories
 >
-> By default, installed modules are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 
->`puppetlabs-apache` is a [PE-supported module](https://forge.puppetlabs.com/supported?_ga=1.208920786.1181567766.1438190846). It is tested and maintained by Puppet Labs, and Puppet Enterprise users are able to file support escalations on these modules.
+>`puppetlabs-apache` is a [PE-supported module](https://forge.puppetlabs.com/supported). It is tested and maintained by Puppet Labs, and Puppet Enterprise users are able to file support escalations on these modules.
 
 --------
 

--- a/source/puppet/4.3/reference/quick_start_sudo.markdown
+++ b/source/puppet/4.3/reference/quick_start_sudo.markdown
@@ -49,9 +49,9 @@ Some modules can be large, complex, and require a significant amount of trial an
 
 > ### A Quick Note about Modules Directories
 >
->By default, the modules you use to manage nodes are located in `/etc/puppetlabs/puppet/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those you write yourself.
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 
@@ -137,7 +137,7 @@ For more information about working with Puppet and Sudo Users, check out our [Mo
 
 Puppet Labs offers many opportunities for learning and training, from formal certification courses to guided online lessons. We've noted one below; head over to the [learning Puppet page](https://puppetlabs.com/learn) to discover more.
 
-* [Learning Puppet](http://docs.puppetlabs.com/learning/) is a series of exercises on various core topics about deploying and using Puppet.
+* [Learning Puppet](/learning/) is a series of exercises on various core topics about deploying and using Puppet.
 * The Puppet Labs workshop contains a series of self-paced, online lessons that cover a variety of topics on Puppet basics. You can sign up at the [learning page](https://puppetlabs.com/learn).
 * Learn about [Managing sudo Privileges](https://puppetlabs.com/learn/managing-sudo-privileges) through this online training workshop.
 

--- a/source/puppet/4.3/reference/quick_writing_nix.markdown
+++ b/source/puppet/4.3/reference/quick_writing_nix.markdown
@@ -21,10 +21,9 @@ Although many Forge modules are exact solutions that fit your site, many are *al
 ### Module Basics
 > ### About Module Directories
 >
-> By default, installed modules are located in `/etc/puppetlabs/code/environments/production/modules`. This includes modules installed by Puppet, those that you download from the Forge, and those that you write yourself.
-> To change this path, modify  the [`modulepath`](/references/3.8.latest/configuration.html#modulepath) setting in [`puppet.conf`](https://docs.puppetlabs.com/puppet/latest/reference/config_file_main.html).)
+>By default, Puppet keeps modules in an environment's [`modulepath`](./dirs_modulepath.html), which for the production environment defaults to `/etc/puppetlabs/code/environments/production/modules`. This includes modules that Puppet installs, those that you download from the Forge, and those you write yourself. In a fresh installation, you need to create this `modules` subdirectory yourself by navigating to `/etc/puppetlabs/code/environments/production` and running `mkdir modules`.
 >
-> **Note**: Puppet also checks the path `/opt/puppet/share/puppet/modules` for modules, but don’t modify anything in this directory or add modules of your own to it.
+>**Note:** Puppet also creates another module directory: `/opt/puppetlabs/puppet/modules`. Don't modify or add anything in this directory, including modules of your own.
 >
 >There are plenty of resources about modules and the creation of modules that you can reference. Check out [Modules and Manifests](./puppet_modules_manifests.html), the [Beginner's Guide to Modules](/guides/module_guides/bgtm.html), and the [Puppet Forge](https://forge.puppetlabs.com/).
 
@@ -39,10 +38,10 @@ Modules are directory trees. For these exercises you'll use the following files:
         - `vhost/`
             - `_file_header.erb` (contains the vhost template, managed by Puppet)
 
-Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `apache`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>` or `<MODULE NAME>::<FOLDER>::<FILE NAME>`.
+Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](/reference/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `apache`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>` or `<MODULE NAME>::<FOLDER>::<FILE NAME>`.
 Many modules, including Apache, contain directories other than `manifests` and `templates`. For simplicity's sake, we do not cover them in this introductory guide.
 
-* For more on how modules work, see [Module Fundamentals](/puppet/3.8/reference/modules_fundamentals.html) in the Puppet documentation.
+* For more on how modules work, see [Module Fundamentals](./modules_fundamentals.html) in the Puppet documentation.
 * For more on best practices, methods, and approaches to writing modules, see the [Beginners Guide to Modules](/guides/module_guides/bgtm.html).
 * For a more detailed guided tour, also see [the module chapters of Learning Puppet](/learning/modules1.html).
 

--- a/source/puppet/4.3/reference/services_agent_unix.markdown
+++ b/source/puppet/4.3/reference/services_agent_unix.markdown
@@ -139,7 +139,7 @@ This behavior is good for building a cron job that does configuration runs. You 
 You can use the Puppet resource command to set up this cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
 ~~~ bash
-sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppet/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
+sudo puppet resource cron puppet-agent ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --splay --splaylimit 60'
 ~~~
 
 ### Running Puppet Agent On Demand

--- a/source/puppet/4.3/reference/services_apply.markdown
+++ b/source/puppet/4.3/reference/services_apply.markdown
@@ -111,7 +111,7 @@ Since Puppet apply doesn't run as a service, you must manually create a schedule
 
 On \*nix, you can use the Puppet resource command to set up a cron job. Below is an example that runs Puppet once an hour; adjust the path to the Puppet command if you are not using Puppet Enterprise.
 
-    $ sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppet/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
+    sudo puppet resource cron puppet-apply ensure=present user=root minute=30 command='/opt/puppetlabs/bin/puppet apply /etc/puppetlabs/puppet/manifests --logdest syslog'
 
 ## Configuring Puppet Apply
 


### PR DESCRIPTION
Several pieces of Puppet 4 documentation used Puppet 3 paths, and some also incorrectly linked to Puppet 3 documentation. The Quick Start Guides also provide incorrect information regarding the `modulepath` setting. Update these guides, paths, and links.