### PR TITLE
Manage redirects and improve deployments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -168,7 +168,6 @@ task :generate do
 
   system("mkdir -p #{OUTPUT_DIR}")
   system("rm -rf #{OUTPUT_DIR}/*")
-  system("mkdir #{OUTPUT_DIR}/references")
   jekyll()
 
   Rake::Task['symlink_latest_versions'].invoke

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,15 +33,14 @@ desc "Release the documentation site"
 remote_task :release do
   Rake::Task['check_build_version'].invoke
   puts "DEPLOYING TO: #{domain}"
-  tarball_name = "puppetdocs-latest.tar.gz"
-  staging_dir = "~/puppetdocs_deploy"
 
-  sh "rsync -av --delete output/ #{domain}:#{deploy_to}/"
+  stage_dir = deploy_to + '/stage'
 
-  run "rm -rf #{staging_dir}"
-  run "cp -R #{deploy_to} #{staging_dir}"
-  run "cd #{staging_dir} && ruby ./linkmunger.rb && tar -czf #{tarball_name} *"
-  run "mv #{staging_dir}/#{tarball_name} #{deploy_to}/#{tarball_name}"
+  sh "rsync -crlpv --delete --force output/ #{domain}:#{stage_dir}/"
+
+  # Create tarball, move everything into place, and reload NGINX. Rake has
+  # trouble mixing stdout and stderr, so we combine them on the remote host.
+  run "sh #{stage_dir}/install.sh #{deploy_to} 2>&1"
 end
 
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,18 +13,18 @@ task :mirror1 do
 end
 
 task :preview1 do
-    set :domain,    "#{user}@docspreview1.puppetlabs.lan"
-    set :deploy_to, "/opt/docspreview1"
+    set :domain,    "#{user}@staticweb1-dev.puppetlabs.com"
+    set :deploy_to, "/var/www/docspreview1.ops.puppetlabs.net"
 end
 
 task :preview2 do
-    set :domain,    "#{user}@docspreview2.puppetlabs.lan"
-    set :deploy_to, "/opt/docspreview2"
+    set :domain,    "#{user}@staticweb1-dev.puppetlabs.com"
+    set :deploy_to, "/var/www/docspreview2.ops.puppetlabs.net"
 end
 
 task :preview3 do
-    set :domain,    "#{user}@docspreview3.puppetlabs.lan"
-    set :deploy_to, "/opt/docspreview3"
+    set :domain,    "#{user}@staticweb1-dev.puppetlabs.com"
+    set :deploy_to, "/var/www/docspreview3.ops.puppetlabs.net"
 end
 
 namespace :vlad do

--- a/source/install.sh
+++ b/source/install.sh
@@ -1,0 +1,35 @@
+#!/bin/zsh
+
+set -e
+
+root="$1"
+if [ -z "$root" ] ; then
+  echo "Usage: $0 site-root" >&2
+  exit 1
+fi
+
+stage="$root/stage"
+final="$root/final"
+
+# Create tarball
+tarball_source="$root/tarball-source"
+rsync -a --delete --force "$stage/" "$tarball_source/"
+ruby "$stage/linkmunger.rb" "$tarball_source"
+( cd "$tarball_source" ; tar -czf - * ) >"$stage/puppetdocs-latest.tar.gz"
+
+# Swap web root into place
+rm -rf "$final.moving"
+mv "$final" "$final.moving"
+
+if ! mv "$stage" "$final" ; then
+  echo "Failed to mv $stage $final" >&2
+  echo "Attempting to restore: mv $final.moving $final" >&2
+  mv "$final.moving" "$final"
+  exit 1
+fi
+
+mv "$final.moving" "$stage"
+
+# Swap NGINX configuration into place and reload NGINX
+/opt/operations/scripts/swap_nginx_conf \
+  "$final/nginx_rewrite.conf" "$root/nginx_rewrite.conf"

--- a/source/install.sh
+++ b/source/install.sh
@@ -31,5 +31,26 @@ fi
 mv "$final.moving" "$stage"
 
 # Swap NGINX configuration into place and reload NGINX
-/opt/operations/scripts/swap_nginx_conf \
-  "$final/nginx_rewrite.conf" "$root/nginx_rewrite.conf"
+source_conf="$final/nginx_rewrite.conf"
+target_conf="$root/nginx_rewrite.conf"
+
+if diff -q "$source_conf" "$target_conf" >/dev/null 2>&1 ; then
+  # Files are the same; no need to swap or reload
+  exit 0
+fi
+
+cp "$target_conf" "$target_conf".good
+cp "$source_conf" "$target_conf"
+sudo service nginx configtest || {
+  # cp instead of mv in case we can't write to the directory
+  cp "$target_conf".good "$target_conf"
+  echo "$0: '$source_conf' not valid" >&2
+  exit 1
+}
+
+sudo service nginx reload || {
+  # cp instead of mv in case we can't write to the directory
+  cp "$target_conf".good "$target_conf"
+  echo "$0: '$source_conf' tested valid, but NGINX cannot reload" >&2
+  exit 1
+}

--- a/source/linkmunger.rb
+++ b/source/linkmunger.rb
@@ -2,31 +2,92 @@
 # Script takes a path to the folder acting as site root as argument, or else
 # assumes it should treat the cwd as the site root.
 
-require 'pathname'
+def relativepath(path, relative_to)
+  if path == relative_to
+    if path[-1] == "/" and relative_to[-1] == "/"
+      return "."
+    else
+      return File.basename(path)
+    end
+  end
 
-def munge_links(html, page_url) # page_url must be a Pathname object, and be absolute, where / is the site root (not the system root)
-  html.gsub( Regexp.new( %q{((href|src)=['"])(/|/[^/][^'"]*)(['"])} ) ) {|match|
-    attribute_and_quote = $1
-    # just_href_or_src = $2
-    absolute_path = $3
-    closing_quote = $4
-    pagedir = page_url.dirname
+  if path == "#{relative_to}/"
+    # from /a to /a/
+    return File.basename(path) + "/"
+  end
 
-    relative_path = Pathname.new(absolute_path).relative_path_from(pagedir)
+  if "#{path}/" == relative_to
+    # from /a/ to /a
+    return "../" + File.basename(path)
+  end
 
-    attribute_and_quote + relative_path.to_s + closing_quote
-  }
+  path = path.chomp("/")
+  if path == ""
+    path = [""]
+  else
+    # The negative limit ensures that empty values aren't dropped.
+    path = path.split(File::SEPARATOR, -1)
+  end
+
+  relative_to = relative_to.chomp("/")
+  if relative_to == ""
+    relative_to = [""]
+  else
+    # The negative limit ensures that empty values aren't dropped.
+    relative_to = relative_to.split(File::SEPARATOR, -1)
+  end
+
+  while (path.length > 0) && (path.first == relative_to.first)
+    path.shift
+    relative_to.shift
+  end
+
+  if relative_to.length == 0 and path.length == 0
+    throw "BUG: Processed paths were equivalent when raw paths were the same"
+  elsif relative_to.length == 0
+    path.join(File::SEPARATOR)
+  elsif path.length == 0 and relative_to.length == 1
+    "."
+  else
+    (['..'] * (relative_to.length - 1) + path).join(File::SEPARATOR)
+  end
 end
 
-site_root = Pathname.new('/')
-document_root = Pathname.new( File.expand_path( ARGV.shift || Dir.pwd ) )
-all_html_files = Pathname.glob( document_root + "**/*.html" ) # array of absolute Pathname objects
-
-all_html_files.each do |page_file|
-  page_url = site_root + page_file.relative_path_from(document_root)
-  puts "Processing: #{page_url.to_s}"
-  content = page_file.read
-  page_file.open('w') {|f|
-    f.print( munge_links(content, page_url) )
-  }
+noop = ARGV.first == "-n"
+if noop
+  ARGV.shift
+  puts "Running in noop mode"
 end
+
+if ARGV.first
+  Dir.chdir(ARGV.shift)
+end
+
+regex = %r{
+  (href|src)=
+  # The first quote, which must be matched by the final quote
+  (['"])
+    # The value is either a single /, or it starts with / but not //, since
+    # that's a URL with a host but no protocol. Sometimes it will incorrectly
+    # have a quote that's different from the one that starts the attribute.
+    (
+      /(?:[^/'"].*?)?
+    )
+  # Look for a matching quote.
+  \2
+}xi
+
+changed = 0
+Dir['**/*.html'].each do |page_path|
+  puts "Processing: /#{page_path}"
+  results = File.read(page_path).gsub(regex) do |match|
+    changed += 1
+    "#{$1}=#{$2}" + relativepath($3, "/" + page_path) + $2
+  end
+
+  if ! noop
+    File.write(page_path, results)
+  end
+end
+
+puts "Updated #{changed} links"

--- a/source/linkmunger.rb
+++ b/source/linkmunger.rb
@@ -82,8 +82,12 @@ regex = %r{
 }xi
 
 changed = 0
+prev_dir = ''
 Dir['**/*.html'].each do |page_path|
-  puts "Processing: /#{page_path}"
+  if File.dirname(page_path) != prev_dir
+    prev_dir = File.dirname(page_path)
+    puts "Processing: #{prev_dir}/"
+  end
   results = File.read(page_path).gsub(regex) do |match|
     changed += 1
     "#{$1}=#{$2}" + relativepath($3, "/" + page_path) + $2

--- a/source/linkmunger.rb
+++ b/source/linkmunger.rb
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
-# Script takes a path to the folder acting as site root as argument, or else
+# USAGE:
+#  ./linkmunger.rb [-n] <PATH>
+# Takes a path to the folder acting as site root as argument, or else
 # assumes it should treat the cwd as the site root.
+# OPTIONS:
+#  -n: run in no-op mode
 
 def relativepath(path, relative_to)
   if path == relative_to
@@ -56,7 +60,7 @@ end
 noop = ARGV.first == "-n"
 if noop
   ARGV.shift
-  puts "Running in noop mode"
+  puts "Running in no-op mode"
 end
 
 if ARGV.first

--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -349,3 +349,5 @@ rewrite /references/\d+\.(latest|stable)/(.*)  /puppet/latest/reference/$2     p
 rewrite /puppet/4.1/reference/experiments_future.html    /puppet/4.1/reference/lang_updating_manifests.html   permanent;
 rewrite /puppet/4.2/reference/experiments_future.html    /puppet/4.2/reference/lang_updating_manifests.html   permanent;
 rewrite /puppet/4.3/reference/experiments_future.html    /puppet/4.3/reference/lang_updating_manifests.html   permanent;
+
+error_page 404 /files/errors/404.html;

--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -1,0 +1,351 @@
+#^/(.*) https://docs.puppetlabs.com/$1 permanent;
+rewrite /guides/language_tutorial.html /guides/language_guide.html permanent;
+
+# See #11359 "Create a pile of redirects to clean up my deletion of the page-per-type types reference"
+rewrite /guides/types/ /references/latest/type.html permanent;
+rewrite /guides/types/nagios/ /references/latest/type.html permanent;
+rewrite /guides/types/selinux/ /references/latest/type.html permanent;
+rewrite /guides/types/ssh/ /references/latest/type.html permanent;
+rewrite /guides/types/alphabetical_index.html /references/latest/type.html permanent;
+rewrite /guides/types/augeas.html /references/latest/type.html#augeas permanent;
+rewrite /guides/types/computer.html /references/latest/type.html#computer permanent;
+rewrite /guides/types/cron.html /references/latest/type.html#cron permanent;
+rewrite /guides/types/exec.html /references/latest/type.html#exec permanent;
+rewrite /guides/types/file.html /references/latest/type.html#file permanent;
+rewrite /guides/types/filebucket.html /references/latest/type.html#filebucket permanent;
+rewrite /guides/types/group.html /references/latest/type.html#group permanent;
+rewrite /guides/types/host.html /references/latest/type.html#host permanent;
+rewrite /guides/types/index.html /references/latest/type.html#index permanent;
+rewrite /guides/types/k5login.html /references/latest/type.html#k5login permanent;
+rewrite /guides/types/macauthorization.html /references/latest/type.html#macauthorization permanent;
+rewrite /guides/types/mailalias.html /references/latest/type.html#mailalias permanent;
+rewrite /guides/types/maillist.html /references/latest/type.html#maillist permanent;
+rewrite /guides/types/mcx.html /references/latest/type.html#mcx permanent;
+rewrite /guides/types/mount.html /references/latest/type.html#mount permanent;
+rewrite /guides/types/nagios/nagios_command.html /references/latest/type.html#nagioscommand permanent;
+rewrite /guides/types/nagios/nagios_contact.html /references/latest/type.html#nagioscontact permanent;
+rewrite /guides/types/nagios/nagios_contactgroup.html /references/latest/type.html#nagioscontactgroup permanent;
+rewrite /guides/types/nagios/nagios_host.html /references/latest/type.html#nagioshost permanent;
+rewrite /guides/types/nagios/nagios_hostdependency.html /references/latest/type.html#nagioshostdependency permanent;
+rewrite /guides/types/nagios/nagios_hostescalation.html /references/latest/type.html#nagioshostescalation permanent;
+rewrite /guides/types/nagios/nagios_hostextinfo.html /references/latest/type.html#nagioshostextinfo permanent;
+rewrite /guides/types/nagios/nagios_hostgroup.html /references/latest/type.html#nagioshostgroup permanent;
+rewrite /guides/types/nagios/nagios_service.html /references/latest/type.html#nagiosservice permanent;
+rewrite /guides/types/nagios/nagios_servicedependency.html /references/latest/type.html#nagiosservicedependency permanent;
+rewrite /guides/types/nagios/nagios_serviceescalation.html /references/latest/type.html#nagiosserviceescalation permanent;
+rewrite /guides/types/nagios/nagios_serviceextinfo.html /references/latest/type.html#nagiosserviceextinfo permanent;
+rewrite /guides/types/nagios/nagios_servicegroup.html /references/latest/type.html#nagiosservicegroup permanent;
+rewrite /guides/types/nagios/nagios_timeperiod.html /references/latest/type.html#nagiostimeperiod permanent;
+rewrite /guides/types/notify.html /references/latest/type.html#notify permanent;
+rewrite /guides/types/package.html /references/latest/type.html#package permanent;
+rewrite /guides/types/resources.html /references/latest/type.html#resources permanent;
+rewrite /guides/types/schedule.html /references/latest/type.html#schedule permanent;
+rewrite /guides/types/selinux/selboolean.html /references/latest/type.html#selboolean permanent;
+rewrite /guides/types/selinux/selmodule.html /references/latest/type.html#selmodule permanent;
+rewrite /guides/types/service.html /references/latest/type.html#service permanent;
+rewrite /guides/types/ssh/ssh_authorized_key.html /references/latest/type.html#sshauthorizedkey permanent;
+rewrite /guides/types/ssh/sshkey.html /references/latest/type.html#sshkey permanent;
+rewrite /guides/types/tidy.html /references/latest/type.html#tidy permanent;
+rewrite /guides/types/user.html /references/latest/type.html#user permanent;
+rewrite /guides/types/yumrepo.html /references/latest/type.html#yumrepo permanent;
+rewrite /guides/types/zfs.html /references/latest/type.html#zfs permanent;
+rewrite /guides/types/zone.html /references/latest/type.html#zone permanent;
+rewrite /guides/types/zpool.html /references/latest/type.html#zpool permanent;
+
+# #12093 and #12113 add yet more redirects for docs.
+rewrite /guides/installing_dashboard.html /dashboard/manual/1.2/bootstrapping.html permanent;
+rewrite /pe/2.0/installing.html /pe/2.0/install_preparing.html permanent;
+
+# Per nigel
+rewrite /pe/2.5/install_preparing.html /pe/2.5/install_system_requirements.html permanent;
+
+# A moved page in the mcollective site
+rewrite /mcollective/simplerpc/ddl.html /mcollective/reference/plugins/ddl.html permanent;
+
+# Some random 404s Alanna found:
+rewrite /guides/style.html /guides/style_guide.html permanent;
+rewrite /guides/security.html /guides/rest_auth_conf.html permanent;
+# 2.7 series grace period for network reference removal
+rewrite /references/2\.7\.\d+/network.html /references/0.25.5/network.html permanent;
+rewrite /references/latest/network.html /references/0.25.5/network.html permanent;
+rewrite /references/stable/network.html /references/0.25.5/network.html permanent;
+rewrite /guides/using_dashboard.html /dashboard/manual/1.2/using.html permanent;
+rewrite /trac/puppet/wiki/PuppetTemplating /guides/templating.html permanent;
+rewrite /puppet_core_types_cheatsheet_expanded.pdf /puppet_core_types_cheatsheet.pdf permanent;
+rewrite /pe/2.0/mcollective_overview.html /pe/2.0/orchestration_overview.html permanent;
+rewrite /guides/more_language.html /guides/language_guide.html permanent;
+rewrite /mcollective/introduction/screencasts.html /mcollective/screencasts.html permanent;
+rewrite /pe/2.0/troubleshooting.html /pe/2.0/maint_common_config_errors.html permanent;
+rewrite /pe/2.0/using_accounts.html /pe/2.0/accounts_user_type.html permanent;
+
+# Metaparameters reference doesn't exist as a standalone file in 0.24.x, metaparameters are found in the Type reference - mph
+rewrite /references/0\.24\.(.+?)\/metaparameter.html /references/0.24.$1/type.html permanent;
+
+# The first of several in a planned really big reorganization. -NF
+rewrite /guides/modules.html /puppet/2.7/reference/modules_fundamentals.html permanent;
+
+# Usually we're not redirecting cross-version broken links, but this case was special.
+rewrite /puppetdb/1/connect_puppet.html /puppetdb/1/connect_puppet_master.html permanent;
+
+# Redirect first page of PE deployment guide from longish URL to index, to make for a more concise URL
+rewrite /guides/deployment_guide/dg_intro_install.html /guides/deployment_guide/index.html permanent;
+
+# It's time for the language guide to go bye-bye. Redirect it to the modern language reference, latest version:
+rewrite /guides/language_guide.html /puppet/latest/reference/lang_summary.html permanent;
+
+# Merging some split release notes for the Puppet 3 series
+rewrite /puppet/3/reference/whats_new.html /puppet/3/reference/release_notes.html permanent;
+
+# Rearranging the experimental features section of the Puppet 3 manual
+rewrite /puppet/3/reference/lang_experimental_3_2.html /puppet/3/reference/experiments_overview.html permanent;
+
+# Redirect outdated man pages to up-to-date versioned man pages
+rewrite ^/man/([a-z]+).html /references/stable/man/$1.html permanent;
+
+# Redirect old location for puppetdb faq
+rewrite /puppetdb/puppetdb-faq.html /puppetdb/latest/puppetdb-faq.html permanent;
+
+# Redirect old parameterized classes guide to classes reference
+rewrite /guides/parameterized_classes.html /puppet/latest/reference/lang_classes.html permanent;
+
+# Redirect Redmine workflow to Jira workflow
+rewrite /community/puppet_projects_redmine_workflow.html /community/puppet_projects_workflow.html permanent;
+
+# The name of the second chapter of the quick start guide changed, as of PE 3.2
+rewrite /pe/latest/quick_writing.html /pe/latest/quick_writing_nix.html permanent;
+rewrite /pe/3.2/quick_writing.html /pe/3.2/quick_writing_nix.html permanent;
+
+# Account for the extra "reference" directory in the /puppet/ path. In
+# retrospect, NF probably should have put everything directly in /puppet/,
+# but until we can get away with changing that...
+rewrite ^/puppet/([\w\-\.]+)/index.html /puppet/$1/reference permanent;
+
+# These Puppet guides have been broken up into more useful units and moved into
+# their own folder.
+rewrite /guides/installation.html /guides/install_puppet/pre_install.html permanent;
+rewrite /guides/upgrading.html /guides/install_puppet/upgrading.html permanent;
+rewrite /windows/installing.html /guides/install_puppet/install_windows.html permanent;
+
+# The PE release notes changed their location.
+rewrite /pe/latest/appendix.html /pe/latest/release_notes.html permanent;
+rewrite /pe/latest/overview_whats_new.html /pe/latest/release_notes.html permanent;
+
+# The Custom Facts Guide now lives with the corresponding Facter version docs
+rewrite /guides/custom_facts.html /facter/latest/custom_facts.html permanent;
+
+# This is old and we replaced it without even realizing it.
+rewrite /guides/setting_up.html /guides/install_puppet/post_install.html permanent;
+
+# Redirect several pages deleted while merging the Windows docs with the Puppet reference manual.
+rewrite /guides/tools.html /puppet/latest/reference/services_commands.html permanent;
+rewrite /guides/from_source.html /guides/install_puppet/from_source.html permanent;
+rewrite /windows/from_source.html /guides/install_puppet/from_source.html permanent;
+rewrite /windows/running.html /puppet/latest/reference/services_commands_windows.html permanent;
+rewrite /windows/writing.html /windows/index.html permanent;
+
+# Redirect some guides pages that have been replaced by better versioned pages.
+rewrite /guides/configuring.html /puppet/latest/reference/config_about_settings.html permanent;
+rewrite /guides/environment.html /puppet/latest/reference/environments.html permanent;
+
+# Redirect CloudPack getting started page to CloudProvisioner overview
+rewrite /guides/cloud_pack_getting_started.html /pe/latest/cloudprovisioner_overview.html permanent;
+
+# Redirect the console auth pages to the RBAC intro page
+rewrite /pe/latest/console_auth.html /pe/latest/rbac_intro.html permanent;
+rewrite /pe/3.7/console_auth.html /pe/latest/rbac_intro.html permanent;
+
+# Redirect all PE 3.4, 3.5, and 3.6 requests to the equivalent PE 3.7 page.
+rewrite ^/pe/3\.[4-6]/(.*)$ /pe/3.7/$1 permanent;
+
+# Redirect any .markdown or .md request to the equivalent .html URL
+rewrite ^(.*)\.(markdown|md)$ $1.html permanent;
+
+# Larissa's redirects for PE2015.2
+rewrite /pe/latest/console_rake_api.html /pe/2015.2/release_notes.html#console-rake-api-removed permanent;
+rewrite /pe/latest/nc_mapping.html /pe/2015.2/release_notes.html#console-rake-api-removed permanent;
+
+# Language redirects for Japanese
+rewrite /ja/puppet/3.7/reference/release_notes_ja.html /puppet/3.7/reference/release_notes.html permanent;
+rewrite /ja/puppet/3.7/reference/type_ja.html /references/3.7.latest/type.html permanent;
+rewrite /ja/puppet/3.7/reference/lang_visual_index_ja.html /puppet/3.7/reference/lang_visual_index.html permanent;
+rewrite /ja/puppet/latest/reference/system_requirements_ja.html /puppet/latest/reference/system_requirements.html permanent;
+rewrite /ja/puppet/3.7/reference/subsystem_catalog_compilation_ja.html /puppet/3.7/reference/subsystem_catalog_compilation.html permanent;
+rewrite /ja/puppet/3.7/reference/services_master_rack_ja.html /puppet/3.7/reference/services_master_rack.html permanent;
+rewrite /ja/puppet/3.7/reference/lang_resources_ja.html /puppet/3.7/reference/lang_resources.html permanent;
+rewrite /ja/puppet/3.7/reference/services_agent_unix_ja.html /puppet/3.7/reference/services_agent_unix.html permanent;
+rewrite /ja/puppet/3.7/reference/services_agent_windows_ja.html /puppet/3.7/reference/services_agent_windows.html permanent;
+rewrite /ja/puppet/3.7/reference/services_master_rack_ja.html /puppet/3.7/reference/services_master_rack.html permanent;
+rewrite /ja/puppet/3.7/reference/services_master_webrick_ja.html /puppet/3.7/reference/services_master_webrick.html permanent;
+rewrite /ja/puppet/3.7/reference/services_apply_ja.html /puppet/3.7/reference/services_apply.html permanent;
+
+# Redirect the Dashboard docs to the sodabrew/puppet-dashboard repo.
+rewrite /dashboard/.* https://github.com/sodabrew/puppet-dashboard permanent;
+
+# Redirect the old lambdas/iteration page to new equivalent (Puppet 3.x world)
+rewrite /puppet/3.7/reference/experiments_lambdas.html /puppet/3.7/reference/future_lang_iteration.html permanent;
+# Redirect the old lambdas/iteration page to new equivalent (Puppet 4.x world)
+rewrite /puppet/latest/reference/experiments_lambdas.html /puppet/latest/reference/lang_iteration.html permanent;
+
+# Redirect Learning VM docs about the Learning VM to the new Learning VM page
+rewrite /learning/introduction.html https://puppetlabs.com/download-learning-vm permanent;
+rewrite /learning/agentprep.html https://puppetlabs.com/download-learning-vm permanent;
+rewrite /learning/index.html https://puppetlabs.com/download-learning-vm permanent;
+
+# Redirect Learning VM docs about using Puppet to appropriate reference pages
+rewrite /learning/agent_master_basic.html /puppet/latest/reference/architecture.html permanent;
+rewrite /learning/manifests.html  /puppet/latest/reference/lang_summary.html permanent;
+rewrite /learning/variables.html /puppet/latest/reference/lang_variables.html permanent;
+rewrite /learning/modules1.html /guides/module_guides/bgtm.html permanent;
+rewrite /learning/ordering.html /puppet/latest/reference/lang_relationships.html permanent;
+rewrite /learning/ral.html /puppet/latest/reference/lang_resources.html permanent;
+rewrite /learning/templates.html /puppet/latest/reference/lang_template.html permanent;
+rewrite /learning/definedtypes.html /puppet/latest/reference/lang_defined_types.html permanent;
+rewrite /learning/modules2.html /puppet/latest/reference/lang_classes.html permanent;
+
+# Create redirects for PE 2015.1 release
+rewrite /pe/latest/install_add_dashboard_workers.html /pe/3.8/install_add_dashboard_workers.html permanent;
+
+# Redirect pages we deleted for the 4.1 docs
+rewrite /puppet/latest/reference/lang_import.html /puppet/latest/reference/dirs_manifest.html permanent;
+rewrite /puppet/latest/reference/environments_classic.html /puppet/latest/reference/environments.html permanent;
+rewrite /puppet/latest/reference/config_file_tagmail.html https://forge.puppetlabs.com/puppetlabs/tagmail permanent;
+
+# Redirect all future_lang pages to their plain lang_ equivalent
+rewrite /puppet/latest/reference/future_lang_classes.html                  /puppet/latest/reference/lang_classes.html          permanent;
+rewrite /puppet/latest/reference/future_lang_collectors.html               /puppet/latest/reference/lang_collectors.html       permanent;
+rewrite /puppet/latest/reference/future_lang_comments.html                 /puppet/latest/reference/lang_comments.html         permanent;
+rewrite /puppet/latest/reference/future_lang_conditional.html              /puppet/latest/reference/lang_conditional.html      permanent;
+rewrite /puppet/latest/reference/future_lang_containment.html              /puppet/latest/reference/lang_containment.html      permanent;
+rewrite /puppet/latest/reference/future_lang_data.html                     /puppet/latest/reference/lang_data.html             permanent;
+rewrite /puppet/latest/reference/future_lang_data_abstract.html            /puppet/latest/reference/lang_data_abstract.html    permanent;
+rewrite /puppet/latest/reference/future_lang_data_array.html               /puppet/latest/reference/lang_data_array.html       permanent;
+rewrite /puppet/latest/reference/future_lang_data_boolean.html             /puppet/latest/reference/lang_data_boolean.html     permanent;
+rewrite /puppet/latest/reference/future_lang_data_default.html             /puppet/latest/reference/lang_data_default.html     permanent;
+rewrite /puppet/latest/reference/future_lang_data_hash.html                /puppet/latest/reference/lang_data_hash.html        permanent;
+rewrite /puppet/latest/reference/future_lang_data_number.html              /puppet/latest/reference/lang_data_number.html      permanent;
+rewrite /puppet/latest/reference/future_lang_data_regexp.html              /puppet/latest/reference/lang_data_regexp.html      permanent;
+rewrite /puppet/latest/reference/future_lang_data_resource_reference.html  /puppet/latest/reference/lang_data_resource_reference.html  permanent;
+rewrite /puppet/latest/reference/future_lang_data_resource_type.html       /puppet/latest/reference/lang_data_resource_type.html       permanent;
+rewrite /puppet/latest/reference/future_lang_data_string.html              /puppet/latest/reference/lang_data_string.html      permanent;
+rewrite /puppet/latest/reference/future_lang_data_type.html                /puppet/latest/reference/lang_data_type.html        permanent;
+rewrite /puppet/latest/reference/future_lang_data_undef.html               /puppet/latest/reference/lang_data_undef.html       permanent;
+rewrite /puppet/latest/reference/future_lang_defaults.html                 /puppet/latest/reference/lang_defaults.html         permanent;
+rewrite /puppet/latest/reference/future_lang_defined_types.html            /puppet/latest/reference/lang_defined_types.html    permanent;
+rewrite /puppet/latest/reference/future_lang_exported.html                 /puppet/latest/reference/lang_exported.html         permanent;
+rewrite /puppet/latest/reference/future_lang_expressions.html              /puppet/latest/reference/lang_expressions.html      permanent;
+rewrite /puppet/latest/reference/future_lang_facts_and_builtin_vars.html   /puppet/latest/reference/lang_facts_and_builtin_vars.html   permanent;
+rewrite /puppet/latest/reference/future_lang_functions.html                /puppet/latest/reference/lang_functions.html        permanent;
+rewrite /puppet/latest/reference/future_lang_iteration.html                /puppet/latest/reference/lang_iteration.html        permanent;
+rewrite /puppet/latest/reference/future_lang_lambdas.html                  /puppet/latest/reference/lang_lambdas.html          permanent;
+rewrite /puppet/latest/reference/future_lang_namespaces.html               /puppet/latest/reference/lang_namespaces.html       permanent;
+rewrite /puppet/latest/reference/future_lang_node_definitions.html         /puppet/latest/reference/lang_node_definitions.html permanent;
+rewrite /puppet/latest/reference/future_lang_relationships.html            /puppet/latest/reference/lang_relationships.html    permanent;
+rewrite /puppet/latest/reference/future_lang_reserved.html                 /puppet/latest/reference/lang_reserved.html         permanent;
+rewrite /puppet/latest/reference/future_lang_resources.html                /puppet/latest/reference/lang_resources.html        permanent;
+rewrite /puppet/latest/reference/future_lang_resources_advanced.html       /puppet/latest/reference/lang_resources_advanced.html permanent;
+rewrite /puppet/latest/reference/future_lang_run_stages.html               /puppet/latest/reference/lang_run_stages.html       permanent;
+rewrite /puppet/latest/reference/future_lang_scope.html                    /puppet/latest/reference/lang_scope.html            permanent;
+rewrite /puppet/latest/reference/future_lang_summary.html                  /puppet/latest/reference/lang_summary.html          permanent;
+rewrite /puppet/latest/reference/future_lang_tags.html                     /puppet/latest/reference/lang_tags.html             permanent;
+rewrite /puppet/latest/reference/future_lang_variables.html                /puppet/latest/reference/lang_variables.html        permanent;
+rewrite /puppet/latest/reference/future_lang_virtual.html                  /puppet/latest/reference/lang_virtual.html          permanent;
+rewrite /puppet/latest/reference/future_lang_visual_index.html             /puppet/latest/reference/lang_visual_index.html     permanent;
+rewrite /puppet/latest/reference/future_lang_windows_file_paths.html       /puppet/latest/reference/lang_windows_file_paths.html permanent;
+
+# The PuppetDB v2 and v3 API docs have arrived at their final home; won't be in future /latest/ versions.
+rewrite /puppetdb/latest/api/query/v2/(.*)   /puppetdb/2.3/api/query/v2/$1   permanent;
+rewrite /puppetdb/latest/api/query/v3/(.*)   /puppetdb/2.3/api/query/v3/$1   permanent;
+
+# Redirect old data types page
+rewrite /puppet/latest/reference/lang_datatypes.html /puppet/latest/reference/lang_data.html permanent;
+
+# This page will be deleted in 4.3, so lock it to 4.2.
+rewrite /puppet/latest/reference/experiments_cfacter.html /puppet/4.2/reference/experiments_cfacter.html permanent;
+
+# Renamed two files in the Puppet 4.2 reference
+rewrite /puppet/latest/reference/upgrade_agent.html    /puppet/latest/reference/upgrade_major_agent.html   permanent;
+rewrite /puppet/latest/reference/upgrade_server.html   /puppet/latest/reference/upgrade_major_server.html  permanent;
+rewrite /puppet/4.2/reference/upgrade_agent.html       /puppet/4.2/reference/upgrade_major_agent.html      permanent;
+rewrite /puppet/4.2/reference/upgrade_server.html      /puppet/4.2/reference/upgrade_major_server.html     permanent;
+
+# Create redirects for the PE 4.0 (Shallow Gravy) release below:
+rewrite /pe/latest/orchestration_resources.html                            /pe/latest/release_notes.html#cloud-provisioner-and-live-management-are-no-longer-part-of-puppet-enterprise permanent;
+rewrite /pe/latest/console_navigating_live_mgmt.html                       /pe/latest/release_notes.html#cloud-provisioner-and-live-management-are-no-longer-part-of-puppet-enterprise permanent;
+rewrite /pe/latest/console_event-inspector.html                            /pe/latest/CM_events.html permanent;
+rewrite /pe/latest/console_reports.html                                    /pe/latest/CM_reports.html permanent;
+rewrite /pe/latest/r10k_setup.html                                         /pe/latest/r10k.html permanent;
+rewrite /pe/latest/r10k_yaml.html                                          /pe/latest/r10k.html permanent;
+
+# Mongrel is long gone from our little world.
+rewrite /guides/mongrel.html   /puppetserver/latest  permanent;
+
+# Redirect Geppetto docs to the project repo
+rewrite /geppetto/.*						https://github.com/puppetlabs/geppetto/tree/dev/docs permanent;
+
+# This guides page is outdated.
+rewrite /guides/templating.html    /puppet/latest/reference/lang_template.html  permanent;
+
+# Redirect the MCollective Chef page to the plugin for Ohai facts
+rewrite /mcollective/reference/integration/chef.html   https://github.com/puppetlabs/mcollective-ohai-facts  permanent;
+
+# Redirect r10k puppetfile docs removed in Ankeny.
+rewrite /pe/latest/r10k_puppetfile.html      /pe/latest/cmgmt_puppetfile.html    permanent;
+rewrite /pe/latest/quick_start_r10k.html     /pe/latest/r10k.html    permanent;
+rewrite /pe/latest/r10k_install_prep.html    /pe/latest/cmgmt_control_repo.html    permanent;
+rewrite /pe/latest/r10k_config_console.html  /pe/latest/r10k_custom.html    permanent;
+rewrite /pe/latest/r10k_config_answers.html  /pe/latest/r10k_config.html    permanent;
+
+# The install docs in /guides are now versioned, redirect to their corresponding new location in 3.8 docs.
+rewrite /guides/install_puppet/pre_install.html              /puppet/3.8/reference/pre_install.html            permanent;
+rewrite /guides/install_puppet/install_el.html               /puppet/3.8/reference/install_el.html             permanent;
+rewrite /guides/install_puppet/install_fedora.html           /puppet/3.8/reference/install_fedora.html         permanent;
+rewrite /guides/install_puppet/install_debian_ubuntu.html    /puppet/3.8/reference/install_debian_ubuntu.html  permanent;
+rewrite /guides/install_puppet/install_osx.html              /puppet/3.8/reference/install_osx.html            permanent;
+rewrite /guides/install_puppet/install_windows.html          /puppet/3.8/reference/install_windows.html        permanent;
+rewrite /guides/install_puppet/post_install.html             /puppet/3.8/reference/post_install.html           permanent;
+rewrite /guides/install_puppet/upgrading.html                /puppet/3.8/reference/upgrading.html              permanent;
+rewrite /guides/install_puppet/from_source.html              /puppet/3.8/reference/from_source.html            permanent;
+rewrite /guides/install_puppet/install_tarball.html          /puppet/3.8/reference/install_tarball.html        permanent;
+rewrite /guides/install_puppet/install_gem.html              /puppet/3.8/reference/install_gem.html            permanent;
+
+# Pages removed and combined into Object types overview.
+rewrite /pe/latest/razor_tasks.html          /pe/latest/razor_objects.html#tasks     permanent;
+rewrite /pe/latest/razor_tags.html           /pe/latest/razor_objects.html#tags      permanent;
+
+# Most of the "Puppet Core" section is removed from Ankeny forward. Give Ankeny special treatment (since those links were in
+# the wild for a bit), but PE versions from the future can just go to "latest" if we're redirecting into the platform docs.
+rewrite /pe/(latest|201[6-9][\d\.]+)/puppet_tools.html            /puppet/latest/reference/services_commands.html       permanent;
+rewrite /pe/2015.3/puppet_tools.html                              /puppet/4.3/reference/services_commands.html          permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/puppet_data_library.html     /puppetdb/latest/api/query/tutorial.html              permanent;
+rewrite /pe/2015.3/puppet_data_library.html                       /puppetdb/3.2/api/query/tutorial.html                 permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/modules_installing.html      /puppet/latest/reference/modules_installing.html      permanent;
+rewrite /pe/2015.3/modules_installing.html                        /puppet/4.3/reference/modules_installing.html         permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/modules_publishing.html      /puppet/latest/reference/modules_publishing.html      permanent;
+rewrite /pe/2015.3/modules_publishing.html                        /puppet/4.3/reference/modules_publishing.html         permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/puppet_modules_manifests.html    /puppet/latest/reference/lang_summary.html        permanent;
+rewrite /pe/2015.3/puppet_modules_manifests.html                      /puppet/4.3/reference/lang_summary.html           permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/puppet_references.html       /pe/$1/puppet_overview.html                           permanent;
+rewrite /pe/2015.3/puppet_references.html                         /pe/2015.3/puppet_overview.html                       permanent;
+
+rewrite /pe/(latest|201[6-9][\d\.]+)/puppet_config.html           /pe/$1/puppet_overview.html                           permanent;
+rewrite /pe/2015.3/puppet_config.html                             /pe/2015.3/puppet_overview.html                       permanent;
+
+# Generated references are moved into the Puppet reference manual now.
+# Most sub-paths are the same, but "developer" changed to "yard." Change that first, then redirect again:
+rewrite (/references/[^/]+)/developer/(.*)     $1/yard/$2  permanent;
+# Versions like 4.2.1, 4.2.latest, and 4.2.stable:
+rewrite /references/(\d+\.\d+)\.[^/]+/(.*)     /puppet/$1/reference/$2         permanent;
+# Versions like latest and stable (stable is no longer necessary):
+rewrite /references/(latest|stable)/(.*)       /puppet/latest/reference/$2     permanent;
+# Versions like 3.latest are tricky, and they're also not really useful. So just fudge them:
+rewrite /references/\d+\.(latest|stable)/(.*)  /puppet/latest/reference/$2     permanent;
+
+# experiments_future being renamed to lang_updating_manifests, to be less confusing to customers
+rewrite /puppet/4.1/reference/experiments_future.html    /puppet/4.1/reference/lang_updating_manifests.html   permanent;
+rewrite /puppet/4.2/reference/experiments_future.html    /puppet/4.2/reference/lang_updating_manifests.html   permanent;
+rewrite /puppet/4.3/reference/experiments_future.html    /puppet/4.3/reference/lang_updating_manifests.html   permanent;


### PR DESCRIPTION
This adds a redirect configuration file, so that redirects don't have to be managed through pull requests on puppetlabs-modules.

This requires changes to puppetlabs-modules: https://github.com/puppetlabs/puppetlabs-modules/pull/5346

Deployment process
------------------

This changes the deployment process to make it faster, more reliable, and less likely to be noticed by users. An outline of the new steps:

 1. rsync assets to stage
 2. rsync stage to tarball source directory
 3. create the tarball
 4. move the tarball into stage
 5. swap stage and final (site is now live)
 6. check the NGINX rewrite configuration file
 7. reload NGINX if the configuration file is valid

This process reduces the amount of time during which the live site is changing. Swapping the two directories is nearly instantaneous, but rsyncing takes quite a while.

This also means that the tarball will be readily as soon as the new site is made live.

Directory structure
-------------------

This changes the directory structure of the deployment target. There is now a containing directory, e.g. /var/www/docs.puppetlabs.com, with final and stage subdirectories, and an nginx_rewrite.conf file.

The staging directory for the tarball is now also in the containing directory, instead of ~docsdeploy.

No longer syncing modification times
------------------------------------

For background, Jekyll updates the modification time of pretty much every file when it builds. Rsync uses those modifications times to determine what files have changed, so it thinks every file has changed.

This switches to using fast checksums in rsync, which ignores the modification times, and doesn't update them on the server when they change on the machine the deployment is running from.

The primary benefit is that deployments run more than 5 times faster.

A side benefit of this is that timestamp based caching will work better for users. It's hard for me to tell how useful that would be, but roughly 2% of requests over the last 6 hours on the production web site were "304 Not Modified", which indicates caching was in use.