### PR TITLE
Docs home page revisions

### DIFF
--- a/source/files/stylesheets/homepage.css
+++ b/source/files/stylesheets/homepage.css
@@ -148,7 +148,7 @@ body {
 
 /* homepage-sub-footer */
 .homepage-sub-footer {
-  margin-top: 40px;
+  margin-top: 20px;
   text-align: center;
 }
 .homepage-sub-footer .hsf-link {
@@ -163,4 +163,13 @@ body {
 }
 .homepage-sub-footer span.bullet.hsf-link {
   padding: 0;
+}
+
+/* hc-footer */
+.hc-footer-box {
+    border: 1px solid #d8d8d8;
+    text-align: center;
+    border-radius: 12px;
+    background: #fafafa;
+    padding: 40px;
 }

--- a/source/files/stylesheets/homepage.css
+++ b/source/files/stylesheets/homepage.css
@@ -1,26 +1,30 @@
 body {
   background-color: #2f2d6e;
 }
+.site-width {
+  max-width: 1100px;
+  min-width: 980px;
+}
 
 /* homepage-header */
 .homepage-header {
-  display: table;
-  width: 100%;
   margin-top: 40px;
-}
-.homepage-header .hh-col {
-  display: table-cell;
-  vertical-align: middle;
+  padding: 0 20px;
 }
 .homepage-header .hh-col.title {
+  display: inline;
 }
 .homepage-header .hh-col.title h1 {
+  display: inline;
   margin: 0;
   font-weight: lighter;
   font-size: 2.0em;
 }
 .homepage-header .hh-col.language {
+  display: inline;
   text-align: right;
+  float: right;
+  margin-top: 0.5em;
 }
 .homepage-header .hh-col.language select {
   padding: 0.5em 0 0.5em 0.4em;
@@ -127,10 +131,14 @@ body {
   width: 100%;
   height: 100px;
   text-align: left;
+  border-spacing: 0;
 }
 .homepage-callout .hc-col-list .hc-col-list-col {
   display: table-cell;
   width: 50%;
+}
+.hc-col-list-col:first-child {
+  padding-right: 1em;
 }
 .homepage-callout .hc-col-list .hc-col-list-col ul {
 }
@@ -143,13 +151,7 @@ body {
 .homepage-sub-footer {
   margin-top: 20px;
   text-align: center;
-}
-.homepage-sub-footer .hsf-link {
-  display: inline-block;
-  padding: 0 2.0rem;
-}
-.homepage-sub-footer a {
-  text-decoration: underline;
+  padding: 0 20px;
 }
 .homepage-sub-footer span.bullet {
   color: #0095dd;
@@ -158,11 +160,21 @@ body {
   padding: 0;
 }
 
-/* hc-footer */
 .hc-footer-box {
-    border: 1px solid #d8d8d8;
-    text-align: center;
-    border-radius: 12px;
-    background: #fafafa;
-    padding: 40px;
+  border: 1px solid #d8d8d8;
+  text-align: center;
+  border-radius: 12px;
+  background: #fafafa;
+  padding: 40px;
+}
+.hc-footer-list {
+  display: table;
+  width: 100%;
+}
+.hc-footer-list-col {
+  display: table-cell;
+  width: 33%;
+}
+.hc-footer-list-col li {
+  margin-bottom: 0;
 }

--- a/source/files/stylesheets/homepage.css
+++ b/source/files/stylesheets/homepage.css
@@ -39,19 +39,12 @@ body {
   display: table;
   width: 100%;
   height: 200px;
+  border-spacing: 20px 0;
 }
 .homepage-callout .hc-wrapper .hc-col {
   display: table-cell;
   width: 50%;
   vertical-align: top;
-}
-.homepage-callout .hc-wrapper .hc-col.left {
-  padding-right: 10px;
-}
-.homepage-callout .hc-wrapper .hc-col.right {
-  padding-left: 10px;
-}
-.homepage-callout .hc-wrapper .hc-col-box {
   border: 1px solid #d8d8d8;
   min-height: 100px;
   text-align: center;

--- a/source/index.html
+++ b/source/index.html
@@ -356,12 +356,12 @@
 
           <!-- hc-footer -->
           <div class="homepage-sub-footer">
-            <a href="http://docs.puppetlabs.com/pe/latest/pe_versioning.html" class="hsf-link">Software Version Numbering</a>
-            <a href="https://docs.puppetlabs.com/contribute.html" class="hsf-link">Send Feedback</a>
-            <a href="http://learn.puppetlabs.com/?_ga=1.28832956.1018811879.1418687874" class="hsf-link">Take a Class</a>
-            <a href="http://docs.puppetlabs.com/download/" class="hsf-link">Download the Docs</a>
-
-            <br>
+            <div class="hc-footer-box">
+              <a href="https://docs.puppetlabs.com/pe/latest/pe_versioning.html" class="hsf-link">Software Version Numbering</a>
+              <a href="https://docs.puppetlabs.com/contribute.html" class="hsf-link">Send Feedback</a>
+              <a href="https://learn.puppetlabs.com/?_ga=1.28832956.1018811879.1418687874" class="hsf-link">Take a Class</a>
+              <a href="https://docs.puppetlabs.com/download/" class="hsf-link">Download the Docs</a>
+            </div>
           </div>
       </div>
   </section>

--- a/source/index.html
+++ b/source/index.html
@@ -357,12 +357,24 @@
           <!-- hc-footer -->
           <div class="homepage-sub-footer">
             <div class="hc-footer-box">
-              <a href="https://docs.puppetlabs.com/pe/latest/pe_versioning.html" class="hsf-link">Software Version Numbering</a>
-              <a href="https://docs.puppetlabs.com/contribute.html" class="hsf-link">Send Feedback</a>
-              <a href="https://learn.puppetlabs.com/?_ga=1.28832956.1018811879.1418687874" class="hsf-link">Take a Class</a>
-              <a href="https://docs.puppetlabs.com/download/" class="hsf-link">Download the Docs</a>
+              <div class="hc-footer-list">
+                <ul class="hc-footer-list-col">
+                  <li><a href="https://docs.puppetlabs.com/pe/latest/api_index.html" class="hsf-link">Puppet APIs</a></li>
+                  <li><a href="https://docs.puppetlabs.com/pe/latest/pe_versioning.html" class="hsf-link">Software Version Numbering</a></li>
+                </ul>
+                <ul class="hc-footer-list-col">
+                  <li><a href="https://learn.puppetlabs.com/?_ga=1.126222344.422025574.1442952075" class="hsf-link">Take a Class</a></li>
+                  <li><a href="https://docs.puppetlabs.com/community/community_guidelines.html">Puppet Community Guidelines</a></li>
+                  <li><a href="https://docs.puppetlabs.com/contribute.html" class="hsf-link">Report Errors and Suggest Changes</a></li>
+                </ul>
+                <ul class="hc-footer-list-col">
+                  <li><a href="https://docs.puppetlabs.com/download/" class="hsf-link">Download the Docs</a></li>
+                  <li><a href="https://docs.puppetlabs.com/pe/latest/localization.html" class="hsf-link">Contribute to Localization</a></li>                  
+                </ul>
+              </div>
             </div>
           </div>
+                    
       </div>
   </section>
 


### PR DESCRIPTION
The heights of the two sections at the center of the docs home page
don't always match. The CSS already implements these divs as CSS tables,
but because the borders are built on divs nested inside the cells
instead of the cells themselves, the borders don't take advantage of
this configuration to automatically align when the box heights differ.

This PR revises the home page HTML and CSS to apply the borders to
the table-cell divs instead of the inner boxes, and adds border-spacing
to recreate the gap between boxes. As a result, the site-width, header,
and sub-footer divs also must be adjusted to accomodate the different
alignment produced by the use of border-spacing instead of padding.

Also, wrap the sub-footer in a similar box as the columns, create
three evenly spaced columns instead of a horizontal list of links, and
expand the sub-footer per MKOPS-1500.