### PR TITLE
Improve version picker redirects for agent install docs.

### DIFF
--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -312,3 +312,9 @@ rewrite /pe/(latest|201[6-9][\d\.]+)/accounts_class.html           https://forge
 rewrite /pe/2015.3/accounts_class.html                             https://forge.puppetlabs.com/puppetlabs/accounts  permanent;
 
 rewrite /pe/(latest|2015\.[3-9]|201[6-9]\.\d+)/install_answer_file_reference.html  /pe/$1/install_complete_answer_file_reference.html permanent;
+
+# DOC-2583: Customers are hitting 404s when looking for Puppet Agent install docs from Puppet 3.8 Linux platform docs using the version picker.
+# Redirect them from Puppet 4 picker links to the corresponding pre-install docs, as we already suggest they do at the top of the content.
+rewrite /puppet/(latest|4.[0-4])/reference/install_(debian_ubuntu|el|fedora|osx|windows).html    /puppet/$1/reference/install_pre.html permanent;
+rewrite /puppet/(latest|4.[0-4])/reference/pre_install.html                                      /puppet/$1/reference/install_pre.html permanent;
+

--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -315,6 +315,6 @@ rewrite /pe/(latest|2015\.[3-9]|201[6-9]\.\d+)/install_answer_file_reference.htm
 
 # DOC-2583: Customers are hitting 404s when looking for Puppet Agent install docs from Puppet 3.8 Linux platform docs using the version picker.
 # Redirect them from Puppet 4 picker links to the corresponding pre-install docs, as we already suggest they do at the top of the content.
-rewrite /puppet/(latest|4.[0-4])/reference/install_(debian_ubuntu|el|fedora|osx|windows).html    /puppet/$1/reference/install_pre.html permanent;
-rewrite /puppet/(latest|4.[0-4])/reference/pre_install.html                                      /puppet/$1/reference/install_pre.html permanent;
+rewrite /puppet/(latest|4.\d)/reference/install_(debian_ubuntu|el|fedora|osx|windows).html    /puppet/$1/reference/install_pre.html permanent;
+rewrite /puppet/(latest|4.\d)/reference/pre_install.html                                      /puppet/$1/reference/install_pre.html permanent;
 


### PR DESCRIPTION
DOC-2583: Customers are hitting 404s when looking for Puppet Agent install docs from Puppet 3.8 Linux platform docs using the version picker. Redirect them from Puppet 4 picker links to the corresponding pre-install docs, as we already suggest they do at the top of the content.