### PR TITLE
Simplify and improve the future_lang redirects.

### DIFF
--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -165,46 +165,7 @@ rewrite /puppet/latest/reference/environments_classic.html /puppet/latest/refere
 rewrite /puppet/latest/reference/config_file_tagmail.html https://forge.puppetlabs.com/puppetlabs/tagmail permanent;
 
 # Redirect all future_lang pages to their plain lang_ equivalent
-rewrite /puppet/latest/reference/future_lang_classes.html                  /puppet/latest/reference/lang_classes.html          permanent;
-rewrite /puppet/latest/reference/future_lang_collectors.html               /puppet/latest/reference/lang_collectors.html       permanent;
-rewrite /puppet/latest/reference/future_lang_comments.html                 /puppet/latest/reference/lang_comments.html         permanent;
-rewrite /puppet/latest/reference/future_lang_conditional.html              /puppet/latest/reference/lang_conditional.html      permanent;
-rewrite /puppet/latest/reference/future_lang_containment.html              /puppet/latest/reference/lang_containment.html      permanent;
-rewrite /puppet/latest/reference/future_lang_data.html                     /puppet/latest/reference/lang_data.html             permanent;
-rewrite /puppet/latest/reference/future_lang_data_abstract.html            /puppet/latest/reference/lang_data_abstract.html    permanent;
-rewrite /puppet/latest/reference/future_lang_data_array.html               /puppet/latest/reference/lang_data_array.html       permanent;
-rewrite /puppet/latest/reference/future_lang_data_boolean.html             /puppet/latest/reference/lang_data_boolean.html     permanent;
-rewrite /puppet/latest/reference/future_lang_data_default.html             /puppet/latest/reference/lang_data_default.html     permanent;
-rewrite /puppet/latest/reference/future_lang_data_hash.html                /puppet/latest/reference/lang_data_hash.html        permanent;
-rewrite /puppet/latest/reference/future_lang_data_number.html              /puppet/latest/reference/lang_data_number.html      permanent;
-rewrite /puppet/latest/reference/future_lang_data_regexp.html              /puppet/latest/reference/lang_data_regexp.html      permanent;
-rewrite /puppet/latest/reference/future_lang_data_resource_reference.html  /puppet/latest/reference/lang_data_resource_reference.html  permanent;
-rewrite /puppet/latest/reference/future_lang_data_resource_type.html       /puppet/latest/reference/lang_data_resource_type.html       permanent;
-rewrite /puppet/latest/reference/future_lang_data_string.html              /puppet/latest/reference/lang_data_string.html      permanent;
-rewrite /puppet/latest/reference/future_lang_data_type.html                /puppet/latest/reference/lang_data_type.html        permanent;
-rewrite /puppet/latest/reference/future_lang_data_undef.html               /puppet/latest/reference/lang_data_undef.html       permanent;
-rewrite /puppet/latest/reference/future_lang_defaults.html                 /puppet/latest/reference/lang_defaults.html         permanent;
-rewrite /puppet/latest/reference/future_lang_defined_types.html            /puppet/latest/reference/lang_defined_types.html    permanent;
-rewrite /puppet/latest/reference/future_lang_exported.html                 /puppet/latest/reference/lang_exported.html         permanent;
-rewrite /puppet/latest/reference/future_lang_expressions.html              /puppet/latest/reference/lang_expressions.html      permanent;
-rewrite /puppet/latest/reference/future_lang_facts_and_builtin_vars.html   /puppet/latest/reference/lang_facts_and_builtin_vars.html   permanent;
-rewrite /puppet/latest/reference/future_lang_functions.html                /puppet/latest/reference/lang_functions.html        permanent;
-rewrite /puppet/latest/reference/future_lang_iteration.html                /puppet/latest/reference/lang_iteration.html        permanent;
-rewrite /puppet/latest/reference/future_lang_lambdas.html                  /puppet/latest/reference/lang_lambdas.html          permanent;
-rewrite /puppet/latest/reference/future_lang_namespaces.html               /puppet/latest/reference/lang_namespaces.html       permanent;
-rewrite /puppet/latest/reference/future_lang_node_definitions.html         /puppet/latest/reference/lang_node_definitions.html permanent;
-rewrite /puppet/latest/reference/future_lang_relationships.html            /puppet/latest/reference/lang_relationships.html    permanent;
-rewrite /puppet/latest/reference/future_lang_reserved.html                 /puppet/latest/reference/lang_reserved.html         permanent;
-rewrite /puppet/latest/reference/future_lang_resources.html                /puppet/latest/reference/lang_resources.html        permanent;
-rewrite /puppet/latest/reference/future_lang_resources_advanced.html       /puppet/latest/reference/lang_resources_advanced.html permanent;
-rewrite /puppet/latest/reference/future_lang_run_stages.html               /puppet/latest/reference/lang_run_stages.html       permanent;
-rewrite /puppet/latest/reference/future_lang_scope.html                    /puppet/latest/reference/lang_scope.html            permanent;
-rewrite /puppet/latest/reference/future_lang_summary.html                  /puppet/latest/reference/lang_summary.html          permanent;
-rewrite /puppet/latest/reference/future_lang_tags.html                     /puppet/latest/reference/lang_tags.html             permanent;
-rewrite /puppet/latest/reference/future_lang_variables.html                /puppet/latest/reference/lang_variables.html        permanent;
-rewrite /puppet/latest/reference/future_lang_virtual.html                  /puppet/latest/reference/lang_virtual.html          permanent;
-rewrite /puppet/latest/reference/future_lang_visual_index.html             /puppet/latest/reference/lang_visual_index.html     permanent;
-rewrite /puppet/latest/reference/future_lang_windows_file_paths.html       /puppet/latest/reference/lang_windows_file_paths.html permanent;
+rewrite /puppet/(4.\d|latest)/reference/future_lang_(.*)              /puppet/$1/reference/lang_$2          permanent;
 
 # The PuppetDB v2 and v3 API docs have arrived at their final home; won't be in future /latest/ versions.
 rewrite /puppetdb/latest/api/query/v2/(.*)   /puppetdb/2.3/api/query/v2/$1   permanent;


### PR DESCRIPTION
Instead of having a separate redirect for each future_lang page, and instead of only redirecting `latest` links, use regex match groups to redirect all future_lang_ pages to specific equivalents, for any Puppet 4 version selected from the version picker. (If there isn't an equivalent, it'll 404 anyway.)