### PR TITLE
Add static catalog docs.

### DIFF
--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -49,7 +49,7 @@ Consequently, the agent's Puppet runs might produce different results each time 
 
 Additionally, each time a Puppet agent applies a normal cached catalog that contains file resources sourced from `puppet:///` locations, the agent requests file metadata from the master each time the catalog's applied, even though nothing's changed in the cached catalog. This causes the master to perform unnecessary resource-intensive checksum calculations for each such file resource.
 
-Static catalogs avoid these problems by including metadata that refers to a specific version of the resource's file. This prevents the a newer version from being incorrectly applied, and avoids having the agent regenerate the metadata on each Puppet run.
+Static catalogs avoid these problems by including metadata that refers to a specific version of the resource's file. This prevents the a newer version from being incorrectly applied, and avoids having the agent request the metadata on each Puppet run.
 
 These are the traits that make this type of catalog "static": it contains all of the information that an agent needs to determine whether the node's configuration matches the instructions and **static** state of file resources **at the point in time when the catalog was compiled.**
 
@@ -72,7 +72,7 @@ With static catalogs enabled, the Puppet master generates metadata for each file
 
 Inlined metadata is part of a `FileMetadata` object in the catalog that's divided into two new catalog sections: `metadata` for metadata associated with individual files, and `recursive_metadata` for metadata associated with many files. To use the appropriate version of the file content for the catalog, [Puppet Server][] also adds a `code_id` parameter to the catalog. The value of `code_id` is a unique string, such as the hash of a git or r10k commit, that corresponds to the version of all files in an environment at the time when the catalog was compiled.
 
-When applying a file resource from a static catalog, an agent first checks the catalog for that file's metadata. If it finds some, Puppet uses the metadata to call the [`static_file_content`][] API endpoint on the Puppet master and retrieve the `code_content`. If the catalog doesn't contain metadata for the resource, Puppet does what it's always done: generate the metadata itself, then request the resource's file from the master in the file's current state.
+When applying a file resource from a static catalog, an agent first checks the catalog for that file's metadata. If it finds some, Puppet uses the metadata to call the [`static_file_content`][] API endpoint on the Puppet master and retrieve the `code_content`. If the catalog doesn't contain metadata for the resource, Puppet does what it's always done: request the file resource's metadata, then request the resource's file from the master in its current state.
 
 ### Configuring `code_id` and the `static_file_content` endpoint
 
@@ -114,7 +114,7 @@ The script's standard output is then provided as the file's `code_content`. Agai
 
 ### Enabling or disabling static catalogs
 
-If you're using static catalogs, the agents don't need to generate file metadata or recurse into directories, catalog application time significantly decreases. And since static catalogs allow agents to use static catalogs more reliably, they're less likely to need the master to generate catalogs as frequently.
+If you're using static catalogs, the agents don't need to request file metadata or recurse into directories. And since static catalogs allow agents to use static catalogs more reliably, they're less likely to need to request catalogs as frequently.
 
 In other words, even if you aren't using static catalogs, disabling it doesn't substantially improve server or agent performance.
 

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -118,7 +118,7 @@ If you're using static catalogs, the agents don't need to generate file metadata
 
 In other words, even if you aren't using static catalogs, disabling it doesn't substantially improve server or agent performance.
 
-However, if you still want to toggle static catalog generation, you can do so with the Boolean `static_catalog` setting in two places:
+However, if you still want to toggle static catalog generation, you can do so with the Boolean `static_catalogs` setting in two places:
 
-* **[`puppet.conf`][]:** You can globally determine whether Puppet generates static catalogs by setting `static_catalog` in `puppet.conf`.
-* **[`environment.conf`][]:** You can override the global setting in each environment by setting `static_catalog` in an environment's `environment.conf` file.
+* **[`puppet.conf`][]:** You can globally determine whether Puppet generates static catalogs by setting `static_catalogs` in `puppet.conf`.
+* **[`environment.conf`][]:** You can override the global setting in each environment by setting `static_catalogs` in an environment's `environment.conf` file.

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -83,9 +83,9 @@ If static catalogs are enabled but none of the relevant Puppet Server settings a
 
 Puppet Server locates these commands via the `code-id-command` and `code-content-command` settings in Puppet Server's [`puppetserver.conf`][] file. Puppet Server runs the `code-id-command` each time it compiles a static catalog, and it runs the `code-content-command` each time an agent requests file contents from the `static_file_content` endpoint.
 
-> **Note: The Puppet Server process must be able to execute these scripts. Puppet Server also validates their output and checks their exit codes. Environment names can contain only alphanumeric characters and underscores (`_`). The `code_id` can  contain only alphanumeric characters and dashes (`-`), underscores (`_`), semicolons (`;`), and colons (`:`). If either command returns a non-zero exit code, Puppet Server logs an error and returns the error message and a 500 response code to the API request.
+> **Note:** The Puppet Server process must be able to execute these scripts. Puppet Server also validates their output and checks their exit codes. Environment names can contain only alphanumeric characters and underscores (`_`). The `code_id` can  contain only alphanumeric characters and dashes (`-`), underscores (`_`), semicolons (`;`), and colons (`:`). If either command returns a non-zero exit code, Puppet Server logs an error and returns the error message and a 500 response code to the API request.
 
-Puppet Server validates the standard output of each of these scripts, and if the output's acceptable, it adds the results to the catalog as their respective parameters' values. This lets you use any versioning or synchronization tools you want, as long as you can write scripts that produce a hash for the `code_id` and code content using the catalog's `code_id` and file's environment.
+Puppet Server validates the standard output of each of these scripts, and if the output's acceptable, it adds the results to the catalog as their respective parameters' values. This lets you use any versioning or synchronization tools you want, as long as you can write scripts that produce a valid string for the `code_id` and code content using the catalog's `code_id` and file's environment.
 
 The `code-id-command` and `code-content-command` scripts can be as simple or complex as necessary.
 
@@ -118,8 +118,6 @@ cd /etc/puppetlabs/code/environments/"$1" && git show $2:$3
 ```
 
 The script's standard output is then provided as the file's `code_content` as long as the script returns a non-zero exit code.
-
-
 
 ### Enabling or disabling static catalogs
 

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -86,11 +86,11 @@ If static catalogs are enabled but none of the relevant Puppet Server settings a
 
 Puppet Server locates these commands via the `code-id-command` and `code-content-command` settings in Puppet Server's [`puppetserver.conf`][] file. Puppet Server runs the `code-id-command` each time it compiles a static catalog, and it runs the `code-content-command` each time an agent requests file contents from the `static_file_content` endpoint.
 
-> **Puppet Enterprise note:** You can set `code-id-command` and `code-content-command` in the PE console by changing the `code_id_command` and `code_content_command` parameters. Note that these only take effect if [file sync][] is disabled by setting the `file_sync_enabled` console parameter to false.
+> **Puppet Enterprise note:** In future versions of PE, you can set `code-id-command` and `code-content-command` in the PE console by changing the `code_id_command` and `code_content_command` parameters. Note that these only take effect if [file sync][] is disabled.
 
-Puppet Server validates the standard output of each of these scripts, and if the output's acceptable, it adds the results to the catalog as their respective parameters' values. This lets you use any versioning or synchronization tools you want, as long as you can write scripts that produce a valid hash for the `code_id` and code content using the catalog's `code_id` and file's environment.
+Puppet Server validates the standard output of each of these scripts, and if the output's acceptable, it adds the results to the catalog as their respective parameters' values. This lets you use any versioning or synchronization tools you want, as long as you can write scripts that produce a hash for the `code_id` and code content using the catalog's `code_id` and file's environment.
 
-The `code-id-command` and `code-content-command` scripts can be as simple or complex as necessary. For instance, if files in an environment are simply managed by git, a `code-id-command` script can be nothing more than this, with the environment name passed to the script as the first parameter:
+The `code-id-command` and `code-content-command` scripts can be as simple or complex as necessary. For instance, if files in an environment are simply managed by git, a `code-id-command` script can be nothing more than this, with the environment name passed to the script as the first command-line argument:
 
 ``` bash
 #!/bin/bash
@@ -102,7 +102,7 @@ fi
 cd /etc/puppetlabs/code/environments/$1 && git rev-parse HEAD
 ```
 
-As long as the script's standard output is a valid hash, Puppet Server will store it as the catalog's `code_id`. If the script returns a non-zero exit code, Puppet Server logs an error.
+As long as the script's exit code is zero, Puppet Server uses the script's standard output as the catalog's `code_id`. If the script returns a non-zero exit code, Puppet Server logs an error and returns the error and a 500 response code to the API request.
 
 A `code-content-command` script can also be simple. Puppet Server passes the environment name as the first command-line argument, the `code_id` as the second argument, and the path to the file resource from its `content_uri` as the third argument:
 

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -130,8 +130,8 @@ Puppet Server also won't produce static catalogs for an agent under the followin
 * If the agent's `static_catalogs` setting is false, either globally in [`puppet.conf`][] or in the [`environment.conf`][] file for the environment under which the agent is requesting a catalog.
 * If the agent's Puppet version is older than 4.4.0.
 
-Additionally, Puppet Server only inlines metadata for [file resources][] under the following circumstances:
+Additionally, Puppet Server only inlines metadata for [file resources][] if **all** of the following conditions are true:
 
 * It contains a `source` parameter with a Puppet URI, such as `source => 'puppet:///path/to/file'`.
 * It contains a `source` parameter that uses the built-in `modules` mount point.
-* The file it sources is within the following glob relative to the environment: `*/*/files/**`. For example, Puppet Server will inline metadata into static catalogs for file resources sourcing module files located by default in `/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.
+* The file it sources is within the following glob relative to the environment's root directory: `*/*/files/**`. For example, Puppet Server will inline metadata into static catalogs for file resources sourcing module files located by default in `/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -41,7 +41,7 @@ Unlike a standard Puppet catalog, a static catalog includes metadata that identi
 
 ### Why use static catalogs?
 
-When a Puppet master produces a normal catalog, the result doesn't specify the a version of file resources. When the agent applies the catalog, it always retrieves the latest version of that file resource.
+When a Puppet master produces a normal catalog, the result doesn't specify the a version of file resources. When the agent applies the catalog, it always retrieves the latest version of that file resource, or uses a previously retrieved version if it matches the latest version's contents.
 
 When a Puppet manifest depends on a file whose contents might change more frequently than the Puppet agent receives new catalogs --- for instance, if the agent is caching catalogs for improved performance, to enable certain features like Puppet Enterprise's [Application Orchestration][], or because it can't reach a Puppet master over the network --- this can lead to a node applying a version of the referenced file that doesn't match the instructions in the catalog.
 
@@ -80,7 +80,7 @@ When applying a file resource from a static catalog, an agent first checks the c
 
 When requesting the file's content from a static catalog's metadata, the Puppet agent passes the file's path, the catalog's `code_id`, and the requested environment to Puppet Server's new [`static_file_content`][] API endpoint, and the endpoint returns the appropriate version of the file's contents as the `code_content`.
 
-> **Puppet Enterprise note:** If [file sync][] is enabled on future versions of Puppet Enterprise that include Puppet Server 2.3, Puppet Server automatically populates the `code_id` and serves the `code_content` out of the box. You don't need to read any further to configure static catalogs --- they're already configured. However, if you've disabled file sync (for instance, to use r10k instead of Code Manager) and want to use static catalogs, you'll need to read on for information about creating the necessary scripts and configuring Puppet Server.
+> **Puppet Enterprise note:** When [file sync][] is enabled on future versions of Puppet Enterprise that include Puppet Server 2.3, Puppet Server automatically populates the `code_id` and serves the `code_content` out of the box. You don't need to read any further to configure static catalogs --- they're already configured. However, if file sync is disabled and you want to use static catalogs, you'll need to read on for information about creating the necessary scripts and configuring Puppet Server.
 
 If static catalogs are enabled but none of the relevant Puppet Server settings are configured, the `code_id` parameter defaults to a null value and the `static_file_content` API endpoint always returns the latest content. To populate the `code_id` with a more useful identifier and have the `static_file_content` endpoint return the appropriate version of the file's content, you must specify scripts or commands that provide Puppet with the right information.
 
@@ -104,7 +104,7 @@ cd /etc/puppetlabs/code/environments/$1 && git rev-parse HEAD
 
 As long as the script's standard output is a valid hash, Puppet Server will store it as the catalog's `code_id`. If the script returns a non-zero exit code, Puppet Server logs an error.
 
-A `code-content-command` script can also be simple. The following example assumes the environment name is passed to the script as the first parameter, the `code_id` is passed as the second parameter, and the path to the file resource from its `content_uri` is passed as the third parameter:
+A `code-content-command` script can also be simple. Puppet Server passes the environment name as the first command-line argument, the `code_id` as the second argument, and the path to the file resource from its `content_uri` as the third argument:
 
 ``` bash
 #!/bin/bash

--- a/source/puppet/4.4/reference/static_catalogs.md
+++ b/source/puppet/4.4/reference/static_catalogs.md
@@ -6,6 +6,7 @@ canonical: "/puppet/latest/reference/static_catalogs.html"
 
 [catalogs]: ./subsystem_catalog_compilation.html
 [catalog endpoint]: ./http_api/http_catalog.html
+[file metadata]: ./http_api/http_file_metadata.html
 [`file_content`]: ./http_api/http_file_content.html
 [`static_file_content`]: /puppetserver/latest/puppet-api/v3/static_file_content.html
 [resource_declaration]: ./lang_resources.html
@@ -48,7 +49,7 @@ When a Puppet manifest depends on a file whose contents might change more freque
 
 Consequently, the agent's Puppet runs might produce different results each time the agent applies the same catalog. This often causes problems, because Puppet generally expects a catalog to produce the same results each time it's applied, regardless of any code or file content updates on the master.
 
-Additionally, each time a Puppet agent applies a normal cached catalog that contains file resources sourced from `puppet:///` locations, the agent requests file metadata from the master each time the catalog's applied, even though nothing's changed in the cached catalog. This causes the master to perform unnecessary resource-intensive checksum calculations for each such file resource.
+Additionally, each time a Puppet agent applies a normal cached catalog that contains file resources sourced from `puppet:///` locations, the agent requests [file metadata][] from the master each time the catalog's applied, even though nothing's changed in the cached catalog. This causes the master to perform unnecessary resource-intensive checksum calculations for each such file resource.
 
 Static catalogs avoid these problems by including metadata that refers to a specific version of the resource's file. This prevents the a newer version from being incorrectly applied, and avoids having the agent request the metadata on each Puppet run.
 
@@ -121,7 +122,7 @@ The script's standard output is then provided as the file's `code_content` as lo
 
 ### Enabling or disabling static catalogs
 
-If you're using static catalogs, the agents don't need to request file metadata or recurse into directories. And since static catalogs allow agents to use static catalogs more reliably, they're less likely to need to request catalogs as frequently.
+If you're using static catalogs, the agents don't need to request [file metadata][] or recurse into directories. And since static catalogs allow agents to use static catalogs more reliably, they're less likely to need to request catalogs as frequently.
 
 In other words, even if you aren't using static catalogs, disabling it doesn't substantially improve server or agent performance.
 


### PR DESCRIPTION
This pull request adds an overview and basic implementation documentation for static catalogs. It depends on [`puppet-server` PR 941](https://github.com/puppetlabs/puppet-server/pull/941) and [`puppet` PR 4749](https://github.com/puppetlabs/puppet/pull/4749).

CC @joshcooper @KevinCorcoran @fpringvaldsen @ipeldridge