### PR TITLE
(PDB-2502) Prepare for release 4.0 of PuppetDB

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -56,6 +56,7 @@ symlink_latest:
   - facter
   - pe
 lock_latest:
+  puppetdb: 3.2
 #  puppet: 4.3
 #  hiera: 3.0
 
@@ -387,13 +388,21 @@ documents:
       commit: ce030bb
       subdirectory: documentation
 
+  /puppetdb/4.0
+    doc: puppetdb
+    version: 4.0
+    nav: ./_puppetdb_nav.html
+    external_source:
+      repo: git://github.com/puppetlabs/puppetdb.git
+      commit: origin/stable
+      subdirectory: documentation
   /puppetdb/3.2:
     doc: puppetdb
     version: 3.2
     nav: ./_puppetdb_nav.html
     external_source:
       repo: git://github.com/puppetlabs/puppetdb.git
-      commit: origin/stable
+      commit: origin/3.2.x
       subdirectory: documentation
   /puppetdb/3.1:
     doc: puppetdb

--- a/source/puppetdb/index.markdown
+++ b/source/puppetdb/index.markdown
@@ -8,6 +8,7 @@ PuppetDB is the fast, scalable, and reliable data warehouse for Puppet. It cache
 
 ## Current Versions
 
+* [PuppetDB 4.0](./4.0) is compatible with Puppet 4.x.
 * [PuppetDB 3.2](./3.2) is compatible with Puppet 4.x.
 * [PuppetDB 3.1](./3.1) is compatible with Puppet 4.x.
 * [PuppetDB 3.0](./3.0) is compatible with Puppet 4.x.


### PR DESCRIPTION
This patch switches the branching over for 3.2 to 3.2.x, and 4.0 to
stable, but locks the latest version to be 3.2 for now, until we release.

Signed-off-by: Ken Barber <ken@bob.sh>