### PR TITLE
Delete ~180 lines of footer CSS from adjustments.css

### DIFF
--- a/source/files/stylesheets/adjustments.css
+++ b/source/files/stylesheets/adjustments.css
@@ -311,6 +311,21 @@ ul.doc-navigation {
   transition: color 0.2s linear;
 }
 
+/* On desktop, keep some negative space between footer content and legal links */
+.layout-footer .footer-row-1 {
+  min-height: 260px;
+}
+
+/* IE 11 hack to prevent footer-splosion */
+.layout-footer .footer-row-1:before,
+.layout-footer .footer-row-1:after,
+.layout-footer .footer-row-1 > .fg-col:first-child:before,
+.layout-footer .footer-row-1 > .fg-col:first-child:after,
+.layout-footer .footer-row-1 > .fg-col:last-child:before,
+.layout-footer .footer-row-1 > .fg-col:last-child:after {
+  content: "";
+}
+
 .layout-footer .footer-row-1 > .fg-col {
   font-size: 0.9em;
 }
@@ -335,6 +350,11 @@ ul.doc-navigation {
   background: #222222;
   border: 1px solid rgba(219, 218, 218, 0.1);
   border-radius: 0;
+}
+
+/* Space between mailing list copy and form field */
+.layout-footer .footer-row-1 > .fg-col p {
+  margin: 0 0 20px 0;
 }
 
 .layout-footer .footer-row-1 .puppet-logo {

--- a/source/files/stylesheets/adjustments.css
+++ b/source/files/stylesheets/adjustments.css
@@ -283,12 +283,6 @@ ul.doc-navigation {
 /* Site Footer */
 /* -------------------------------------- */
 .layout-footer {
-/*
-  margin: 0 auto;
-  max-width: 100%;
-  min-width: 768px;
-  position: relative;
- */
   padding: 60px 0 0 0;
   background: #222222;
   color: rgba(219, 218, 218, 0.5);
@@ -319,9 +313,6 @@ ul.doc-navigation {
 
 .layout-footer .footer-row-1 {
   margin: 0 auto;
-/*
-  max-width: 67em;
- */
   padding: 0 10px;
   min-height: 260px;
 }
@@ -329,53 +320,16 @@ ul.doc-navigation {
 .layout-footer .footer-row-1:before,
 .layout-footer .footer-row-1:after {
   content: "";
-/*
-  display: table;
- */
 }
-
-/*
-.layout-footer .footer-row-1:after {
-  clear: both;
-}
- */
 
 .layout-footer .footer-row-1 > .fg-col {
   font-size: 0.9em;
 }
 
-/*
-.layout-footer .footer-row-1 > .fg-col:first-child {
-  position: relative;
-  float: left;
-}
- */
-
-/*
-.layout-footer .footer-row-1 > .fg-col:first-child {
-  box-sizing: border-box;
-}
- */
-
 .layout-footer .footer-row-1 > .fg-col:first-child:before,
 .layout-footer .footer-row-1 > .fg-col:first-child:after {
   content: " ";
-/*
-  display: table;
- */
 }
-
-/*
-.layout-footer .footer-row-1 > .fg-col:first-child:after {
-  clear: both;
-}
- */
-
-/*
-html.csscalc .layout-footer .footer-row-1 > .fg-col:first-child {
-  margin-left: 20px;
-}
- */
 
 html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:first-child {
   margin-left: 1.6%;
@@ -395,32 +349,10 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:first-child {
   width: 65.8666%;
 }
 
-/*
-.layout-footer .footer-row-1 > .fg-col:last-child {
-  position: relative;
-  float: left;
-}
- */
-
-/*
-.layout-footer .footer-row-1 > .fg-col:last-child {
-  box-sizing: border-box;
-}
- */
-
 .layout-footer .footer-row-1 > .fg-col:last-child:before,
 .layout-footer .footer-row-1 > .fg-col:last-child:after {
   content: " ";
-/*
-  display: table;
- */
 }
-
-/*
-.layout-footer .footer-row-1 > .fg-col:last-child:after {
-  clear: both;
-}
- */
 
 html.csscalc .layout-footer .footer-row-1 > .fg-col:last-child {
   margin-left: 20px;
@@ -435,21 +367,7 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child:first-child
   margin-left: 0;
 }
 
-/*
-html.csscalc .layout-footer .footer-row-1 > .fg-col:last-child {
-  width: -webkit-calc(33.3333% - (20px / 2));
-  width: calc(33.3333% - (20px / 2));
-}
-
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child {
-  width: 32.5333%;
-}
- */
-
 .layout-footer .footer-row-1 > .fg-col h3 {
-/*
-  margin: 18px 0 20px 0;
- */
   color: rgba(219, 218, 218, 0.5);
   font-size: 1.3em;
   font-weight: 400;
@@ -470,11 +388,6 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child {
 }
 
 .layout-footer .footer-row-1 > .fg-col input[type="email"] {
-/*
-  width: 98%;
-  max-width: 98%;
-  padding: 2%;
- */
   background: #222222;
   border: 1px solid rgba(219, 218, 218, 0.1);
   border-radius: 0;
@@ -512,41 +425,15 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child {
   overflow: auto;
   padding: 10px;
   margin: 0 auto;
-/*
-  max-width: 960px;
- */
 }
 
 .layout-footer .footer-row-2 .footer-row-2-wrapper a {
-/*
-  float: left;
- */
   color: rgba(219, 218, 218, 0.5);
 }
 
 .layout-footer .footer-row-2 .footer-row-2-wrapper a + a {
   margin-left: 20px;
 }
-
-/*
-.layout-footer .footer-row-2 .footer-row-2-wrapper .footer-row-2-col-1 {
-  float: left;
-}
- */
-
-/*
-.layout-footer .footer-row-2 .footer-row-2-wrapper .footer-row-2-col-2 {
-  float: right;
-}
- */
-
-/*
-.layout-footer .fg-col {
-  display: block;
-  float: left;
-  width: 25%;
-}
- */
 
 .social-icon img {
   opacity: 0.7;

--- a/source/files/stylesheets/adjustments.css
+++ b/source/files/stylesheets/adjustments.css
@@ -311,60 +311,8 @@ ul.doc-navigation {
   transition: color 0.2s linear;
 }
 
-.layout-footer .footer-row-1 {
-  margin: 0 auto;
-  padding: 0 10px;
-  min-height: 260px;
-}
-
-.layout-footer .footer-row-1:before,
-.layout-footer .footer-row-1:after {
-  content: "";
-}
-
 .layout-footer .footer-row-1 > .fg-col {
   font-size: 0.9em;
-}
-
-.layout-footer .footer-row-1 > .fg-col:first-child:before,
-.layout-footer .footer-row-1 > .fg-col:first-child:after {
-  content: " ";
-}
-
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:first-child {
-  margin-left: 1.6%;
-}
-
-html.csscalc .layout-footer .footer-row-1 > .fg-col:first-child:first-child,
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:first-child:first-child {
-  margin-left: 0;
-}
-
-html.csscalc .layout-footer .footer-row-1 > .fg-col:first-child {
-  width: -webkit-calc(66.6666% - (20px / 2));
-  width: calc(66.6666% - (20px / 2));
-}
-
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:first-child {
-  width: 65.8666%;
-}
-
-.layout-footer .footer-row-1 > .fg-col:last-child:before,
-.layout-footer .footer-row-1 > .fg-col:last-child:after {
-  content: " ";
-}
-
-html.csscalc .layout-footer .footer-row-1 > .fg-col:last-child {
-  margin-left: 20px;
-}
-
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child {
-  margin-left: 1.6%;
-}
-
-html.csscalc .layout-footer .footer-row-1 > .fg-col:last-child:first-child,
-html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child:first-child {
-  margin-left: 0;
 }
 
 .layout-footer .footer-row-1 > .fg-col h3 {
@@ -383,15 +331,10 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child:first-child
   margin-top: 10px;
 }
 
-.layout-footer .footer-row-1 > .fg-col p {
-  margin: 0 0 20px 0;
-}
-
 .layout-footer .footer-row-1 > .fg-col input[type="email"] {
   background: #222222;
   border: 1px solid rgba(219, 218, 218, 0.1);
   border-radius: 0;
-  font-family: 'Calibre Web', Helvetica, Arial, sans-serif !important;
 }
 
 .layout-footer .footer-row-1 .puppet-logo {
@@ -400,18 +343,12 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child:first-child
   height: auto;
 }
 
-.layout-footer .footer-row-1 .social-icon {
-  float: left;
-  margin-top: 10px;
-}
-
-.layout-footer .footer-row-1 .social-icon + .social-icon {
-  margin-left: 10px;
-}
-
 .layout-footer .footer-row-1 .social-icon img {
+  float: left;
+  margin-top: 20px;
   width: 20px;
   height: auto;
+  margin-right: 10px;
 }
 
 .layout-footer .footer-row-2 {
@@ -429,10 +366,7 @@ html:not(.csscalc) .layout-footer .footer-row-1 > .fg-col:last-child:first-child
 
 .layout-footer .footer-row-2 .footer-row-2-wrapper a {
   color: rgba(219, 218, 218, 0.5);
-}
-
-.layout-footer .footer-row-2 .footer-row-2-wrapper a + a {
-  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .social-icon img {


### PR DESCRIPTION
The footer CSS is some of our worst remaining jank, and this commit removes about 40% of it, to basically no observable effect. (The spacing differs by about 5-10 px in various places, but you only notice it if you flip back and forth between tabs in the same browser window.) 

At least, I think there's no observable effect; I could use another pair of eyes to make sure I'm not missing anything significant. @gguillotte, could you review this? 