### PR TITLE
Add "Jump to table of contents" link on sm and xs viewports

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -55,7 +55,9 @@
 
     <div id="doc-switchers" class="container">
       <div class="col-md-8">{% include template/doc_switcher.html %} {% include template/version_switcher.html %}</div>
-      <div class="col-md-4"><div class="visible-sm-inline visible-xs-inline"><a href="#document-nav">Jump to table of contents</a></div></div>
+      <div class="col-md-4"><div class="visible-sm-inline visible-xs-inline"><a href="#document-nav">
+        Jump to {% if page.doc %}{{ site.document_names[page.doc.doc] }} navigation{% else %}related pages{% endif %}
+      </a></div></div>
     </div>
 
     <div class="container">

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -55,7 +55,7 @@
 
     <div id="doc-switchers" class="container">
       <div class="col-md-8">{% include template/doc_switcher.html %} {% include template/version_switcher.html %}</div>
-      <div class="col-md-4"></div>
+      <div class="col-md-4"><div class="visible-sm-inline visible-xs-inline"><a href="#document-nav">Jump to table of contents</a></div></div>
     </div>
 
     <div class="container">


### PR DESCRIPTION
On smaller viewports, the sidebar nav gets pushed down below the page content,
and it can take a maddening amount of scrolling to reach it. This should solve
95% of that problem in a nice, non-overkill way.

I think grouping this link with the document/version switchers should help
show which TOC we're talking about (the document-wide one, not the in-page one).