### PR TITLE
Note removed Util modules.

### DIFF
--- a/source/facter/3.0/custom_facts.md
+++ b/source/facter/3.0/custom_facts.md
@@ -22,6 +22,8 @@ the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
+> **Note:** Facter 3.0 removed the Ruby implementations of some features and replaced them with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For more information, see the [Facter 3.0 release notes](./release_notes.html).
+
 ## The Concept
 
 You can add new facts by writing snippets of Ruby code on the
@@ -89,8 +91,8 @@ This allows you to do something like this:
 > ### Note: Changes in Built-in Pluginsync Support in Facter 3
 >
 > Facter 2.4 **deprecated** Facter's support for loading facts via Puppet's pluginsync
-> (the `-p` option), and Facter 3.0.0 **removed** the `-p` option. However, we reversed 
-> this decision in Facter 3.0.2 and re-enabled the `-p` option. For details about current 
+> (the `-p` option), and Facter 3.0.0 **removed** the `-p` option. However, we reversed
+> this decision in Facter 3.0.2 and re-enabled the `-p` option. For details about current
 > and future support for this option, see the [Facter 3.0.2 release notes][].
 
 ## Two Parts of Every Fact

--- a/source/facter/3.0/release_notes.md
+++ b/source/facter/3.0/release_notes.md
@@ -76,7 +76,7 @@ When running the MCollective agent plugin on Windows, Facter could report a miss
 
 * [FACT-1125](https://tickets.puppetlabs.com/browse/FACT-1125)
 
-### REGRESSION FIX: Resolved an OLE COM Initialization Issue When Reporting Windows Facts 
+### REGRESSION FIX: Resolved an OLE COM Initialization Issue When Reporting Windows Facts
 
 Facter 3.0.0 can fail when reporting Windows facts that require `win32ole`, resulting in a "fail: OLE initialize" error. Facter 3.0.2 resolves this issue.
 
@@ -90,7 +90,7 @@ If a command returns a non-zero exit code or can't be found, Facter 3.0.0 return
 
 ### REGRESSION FIX: Fixed `stderr` Redirection
 
-When Facter 3.0.0 invokes commands to report facts that result in `stderr` output, Facter reports the `stderr` output as the fact. Also, if the required command doesn't exist, Facter 3.0.0 reports a null value. 
+When Facter 3.0.0 invokes commands to report facts that result in `stderr` output, Facter reports the `stderr` output as the fact. Also, if the required command doesn't exist, Facter 3.0.0 reports a null value.
 
 Facter 3.0.2 correctly reports facts in these situations. To view additional diagnostic information, including the invoked commands' `stderr` output, run Facter with the `--debug` flag.
 
@@ -234,6 +234,18 @@ We reversed this decision in Facter 3.0.2.
 We changed the value of the hardware fact (`os.hardware`) from "x64" to "x86_64" for 64-bit Windows editions to make Windows consistent with other operating systems. The `architecture` fact is still "x64" as it represents the platform-specific name for the system architecture.
 
 * [FACT-610](https://tickets.puppetlabs.com/browse/FACT-610)
+
+### BREAK: Removed `file_read.rb` and `registry.rb`
+
+Facter 3 removed the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) and [`registry.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/registry.rb), which provide the `Facter::Util::FileRead` and `Facter::Util::Registry` modules to Facter. This can break custom facts that rely on these modules, and produce error messages like this:
+
+```
+Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
+```
+
+As a workaround, you can rewrite your custom facts to avoid these Util implementations, which handle only error cases. You can also copy the missing Facter 2 files (such as from the Raw versions of the above links) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example.
+
+* [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)
 
 ### REGRESSION / BREAK (fixed in 3.0.2): Hostname missing from the `fqdn` fact
 

--- a/source/facter/3.0/release_notes.md
+++ b/source/facter/3.0/release_notes.md
@@ -235,15 +235,15 @@ We changed the value of the hardware fact (`os.hardware`) from "x64" to "x86_64"
 
 * [FACT-610](https://tickets.puppetlabs.com/browse/FACT-610)
 
-### BREAK: Removed `file_read.rb` and `registry.rb`
+### BREAK: Removed Ruby Facter implementations
 
-Facter 3 removed the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) and [`registry.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/registry.rb), which provide the `Facter::Util::FileRead` and `Facter::Util::Registry` modules to Facter. This can break custom facts that rely on these modules, and produce error messages like this:
+Facter 3 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
 
 ```
 Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
 ```
 
-As a workaround, you can rewrite your custom facts to avoid these Util implementations, which handle only error cases. You can also copy the missing Facter 2 files (such as from the Raw versions of the above links) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example.
+As a workaround, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](https://docs.puppet.com/facter/3.0/custom_facts.html).
 
 * [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)
 

--- a/source/facter/3.0/release_notes.md
+++ b/source/facter/3.0/release_notes.md
@@ -237,15 +237,15 @@ We changed the value of the hardware fact (`os.hardware`) from "x64" to "x86_64"
 
 ### BREAK: Removed Ruby Facter implementations
 
-Facter 3 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
+Facter 3.0 removes the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
 
 ```
 Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
 ```
 
-As a workaround, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](https://docs.puppet.com/facter/3.0/custom_facts.html).
+As a workaround, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](./custom_facts.html).
 
-* [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)
+* [FACT-1400](https://tickets.puppetlabs.com/browse/FACT-1400)
 
 ### REGRESSION / BREAK (fixed in 3.0.2): Hostname missing from the `fqdn` fact
 

--- a/source/facter/3.1/custom_facts.md
+++ b/source/facter/3.1/custom_facts.md
@@ -22,6 +22,8 @@ the best solution is to add a new fact to Facter. These additional facts
 can then be distributed to Puppet clients and are available for use
 in manifests and templates, just like any other fact would be.
 
+> **Note:** Facter 3.0 removed the Ruby implementations of some features and replaced them with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For more information, see the [Facter 3.0 release notes](../3.0/release_notes.html).
+
 ## The Concept
 
 You can add new facts by writing snippets of Ruby code on the
@@ -61,7 +63,6 @@ Facter would try to load 'facter/system\_load.rb', 'facter/users.rb', and
 Facter can take multiple `--custom-dir` options on the command line that specifies a single directory
 to search for custom facts. Facter attempts to load all Ruby files in the specified directories.
 This allows you to do something like this:
-
 
     $ ls my_facts
     system_load.rb
@@ -329,7 +330,7 @@ In a module (recommended):
 
     <MODULEPATH>/<MODULE>/facts.d/
 
-On Unix/Linux/Mac OS X, there are three directories:
+On Unix/Linux/OS X, there are three directories:
 
     /opt/puppetlabs/facter/facts.d/
     /etc/puppetlabs/facter/facts.d/

--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -8,7 +8,7 @@ title: "Facter 3.1: Release Notes"
 [puppet-agent 1.4.x]: /puppet/4.4/reference/about_agent.html
 
 
-This page documents the history of the Facter 3.1 series. (Previous version: [Facter 3.0 release notes](../3.0/release_notes.html).)
+This page documents the history of the Facter 3.1 series. If you're upgrading from Facter 2, also review the [Facter 3.0 release notes](../3.0/release_notes.html) for important information about other breaking changes, new features, and changed functionality.
 
 ## Facter 3.1.5
 
@@ -281,15 +281,3 @@ Facter now reports the 'noatime' option in the `mountpoints` fact when it is set
 The `puppet-agent` package that installs Facter 3.0.0 did not create the `rubysitedir` pointed to by the `rubysitedir` fact. The `puppet-agent` 1.2.4 update resolves this issue.
 
 * [FACT-1154](https://tickets.puppetlabs.com/browse/FACT-1154)
-
-### BREAK: Removed Ruby Facter implementations
-
-Facter 3.0 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
-
-```
-Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
-```
-
-As a workaround when porting Facter 2-compatible custom facts to Facter 3, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](./custom_facts.html).
-
-* [FACT-1400](https://tickets.puppetlabs.com/browse/FACT-1400)

--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -284,12 +284,12 @@ The `puppet-agent` package that installs Facter 3.0.0 did not create the `rubysi
 
 ### BREAK: Removed Ruby Facter implementations
 
-Facter 3 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
+Facter 3.0 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
 
 ```
 Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
 ```
 
-As a workaround when porting Facter 2-compatible custom facts to Facter 3, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](https://docs.puppet.com/facter/3.1/custom_facts.html).
+As a workaround when porting Facter 2-compatible custom facts to Facter 3, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](./custom_facts.html).
 
-* [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)
+* [FACT-1400](https://tickets.puppetlabs.com/browse/FACT-1400)

--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -31,7 +31,7 @@ Facter will now consider the 'source' attribute of routing table entries associa
 
 In Puppet with Facter 3, using Windows-1252 extended characters such as ö and æ in a user name on Windows would cause an exception to be thrown by Facter. This has been fixed.
 
-* [FACT-1341](https://tickets.puppetlabs.com/browse/FACT-1341) 
+* [FACT-1341](https://tickets.puppetlabs.com/browse/FACT-1341)
 
 ### FIX: YAML
 
@@ -282,3 +282,14 @@ The `puppet-agent` package that installs Facter 3.0.0 did not create the `rubysi
 
 * [FACT-1154](https://tickets.puppetlabs.com/browse/FACT-1154)
 
+### BREAK: Removed `file_read.rb` and `registry.rb`
+
+Facter 3 removed the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) and [`registry.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/registry.rb), which provide the `Facter::Util::FileRead` and `Facter::Util::Registry` modules to Facter. This can break custom facts that rely on these modules, and produce error messages like this:
+
+```
+Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
+```
+
+As a workaround, you can rewrite your custom facts to avoid these Util implementations, which handle only error cases. You can also copy the missing Facter 2 files (such as from the Raw versions of the above links) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example.
+
+* [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)

--- a/source/facter/3.1/release_notes.md
+++ b/source/facter/3.1/release_notes.md
@@ -282,14 +282,14 @@ The `puppet-agent` package that installs Facter 3.0.0 did not create the `rubysi
 
 * [FACT-1154](https://tickets.puppetlabs.com/browse/FACT-1154)
 
-### BREAK: Removed `file_read.rb` and `registry.rb`
+### BREAK: Removed Ruby Facter implementations
 
-Facter 3 removed the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) and [`registry.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/registry.rb), which provide the `Facter::Util::FileRead` and `Facter::Util::Registry` modules to Facter. This can break custom facts that rely on these modules, and produce error messages like this:
+Facter 3 removed the Ruby implementations of some features and replaced it with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` will fail with an error. For example, requiring the [`file_read.rb`](https://github.com/puppetlabs/facter/blob/2.x/lib/facter/util/file_read.rb) (`Facter::Util::FileRead`) Ruby module will produce an error message like this:
 
 ```
 Error: Facter: error while resolving custom facts in /opt/configmgmt/environments/production/modules/custom_facts/lib/facter/customfact.rb: cannot load such file -- facter/util/file_read
 ```
 
-As a workaround, you can rewrite your custom facts to avoid these Util implementations, which handle only error cases. You can also copy the missing Facter 2 files (such as from the Raw versions of the above links) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example.
+As a workaround when porting Facter 2-compatible custom facts to Facter 3, you can rewrite your custom facts to avoid requiring these Ruby implementations, and instead use the [new API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). You can also [copy the necessary Facter 2 Ruby libraries](https://github.com/puppetlabs/facter/tree/2.x/lib/facter/util) to the `lib/facter/util/` subdirectory of the affected `custom_facts` path, such as `/opt/configmgmt/environments/production/modules/custom_facts/lib/facter/util/` in the above example. For more information about writing custom facts for Facter 3, see [the Facter documentation](https://docs.puppet.com/facter/3.1/custom_facts.html).
 
 * [PE-13225](https://tickets.puppetlabs.com/browse/PE-13225)


### PR DESCRIPTION
Supports DOC-2401.

Looks like BBEdit also stripped some trailing spaces (3.0 L79, 93; 3.1 L34).

CC @jtappa @kylog @MikaelSmith 