### PR TITLE
Continue updating packaging/PC docs

### DIFF
--- a/source/_includes/agent_lifecycle.md
+++ b/source/_includes/agent_lifecycle.md
@@ -1,32 +1,32 @@
-## Puppet Agent and Operating System Support Life Cycles
+## Puppet agent and operating system support life cycles
 
-In PE 2015.2 and Puppet 4.0 and onwards, the same Puppet agent packages are used in our open source and Puppet Enterprise ecosystems. Because of this, we've set the following guidelines for managing Puppet agent life cycles.
+In PE 2015.2 and open source Puppet 4.0 and onward, we use the same Puppet agent packages in our open source and Puppet Enterprise ecosystems. Because of this, we've set the following guidelines for managing Puppet agent life cycles.
 
-#### Community-Supported Operating Systems
+#### Community-supported operating systems
 
-On community-supported operating systems, we support Puppet agent for the OS's own life cycle. Essentially, Puppet stops supporting an agent within 30 days of that platform's end-of-life (EOL) date. For example, Fedora 20 goes EOL June 23, 2015. This means that on or around July 23, Puppet no longer provides fixes, updates, or support for either the Puppet Enterprise or Open Source versions of that agent.
+On community-supported operating systems, we support Puppet agent for the OS's life cycle. Essentially, Puppet stops supporting an agent 30 days after that platform's end-of-life (EOL) date. For example, Fedora 20 reached its EOL on June 23, 2015. This means that on or around July 23, Puppet stopped providing fixes, updates, or support for either the Puppet Enterprise or open source versions of that agent.
 
-This covers the following community-supported operating systems:
+This guideline covers the following community-supported operating systems:
 
-- Debian
-- Fedora
-- Ubuntu (non LTS)
+-   Debian
+-   Fedora
+-   Ubuntu (non-LTS)
 
-#### Enterprise-Class Operating Systems
+#### Enterprise-class operating systems
 
-On enterprise operating systems, we support Puppet agent for _at least_ the OS's own life cycle. In Puppet Enterprise, Puppet continues to support certain enterprise-class agent platforms after they reach EOL. Please note that supporting an OS past EOL is solely at the discretion of Puppet.
+On enterprise-class operating systems, we support Puppet agent for _at least_ the OS's life cycle. In Puppet Enterprise, Puppet continues to support certain enterprise-class agent platforms after their EOL, though we do so solely at our own discretion.
 
 This covers the following enterprise operating systems:
 
-- CentOS
-- Mac OS X
-- Oracle Enterprise Linux
-- Red Hat Enterprise Linux
-- Scientific Linux
-- Suse Linux Enterprise Server\*
-- Solaris\*
-- AIX\*
-- Ubuntu LTS
-- Microsoft Windows Server
+-   AIX\*
+-   CentOS
+-   Microsoft Windows Server
+-   OS X
+-   Oracle Enterprise Linux
+-   Red Hat Enterprise Linux
+-   Scientific Linux
+-   Solaris\*
+-   Suse Linux Enterprise Server\*
+-   Ubuntu LTS
 
-(\* denotes PE-only platforms, which we don't provide open source agent packages for.)
+(\* denotes PE-only platforms, for which we don't provide open-source agent packages.)

--- a/source/_includes/pup44_platforms_fedora.markdown
+++ b/source/_includes/pup44_platforms_fedora.markdown
@@ -1,0 +1,6 @@
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Fedora:
+
+* Fedora 22
+* Fedora 21
+
+<!-- When updating these, also edit guides/puppetlabs_package_repositories.markdown and add/delete the repo packages as needed. -->

--- a/source/_includes/pup44_platforms_osx.markdown
+++ b/source/_includes/pup44_platforms_osx.markdown
@@ -1,4 +1,4 @@
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following OS X versions:
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) installers for the following OS X versions:
 
 -   10.11 El Capitan
 -   10.10 Yosemite

--- a/source/_includes/pup44_platforms_osx.markdown
+++ b/source/_includes/pup44_platforms_osx.markdown
@@ -1,0 +1,5 @@
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following OS X versions:
+
+-   10.11 El Capitan
+-   10.10 Yosemite
+-   10.9 Mavericks

--- a/source/_includes/pup44_platforms_redhat_like.markdown
+++ b/source/_includes/pup44_platforms_redhat_like.markdown
@@ -1,0 +1,10 @@
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Red Hat Enterprise Linux (RHEL):
+
+* Enterprise Linux 7 (also supported by [Puppet Enterprise][peinstall])
+* Enterprise Linux 6 (also supported by [Puppet Enterprise][peinstall])
+* Enterprise Linux 5 (also supported by [Puppet Enterprise][peinstall])
+
+This information applies to RHEL itself, as well as any distributions that maintain binary compatibility with it, including but not limited to CentOS, Scientific Linux, and Oracle Linux.
+
+[peinstall]: /pe/latest/install_basic.html
+<!-- When updating these, also edit guides/puppetlabs_package_repositories.markdown and add/delete the repo packages as needed. -->

--- a/source/_includes/pup44_platforms_windows.markdown
+++ b/source/_includes/pup44_platforms_windows.markdown
@@ -1,16 +1,19 @@
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Windows:
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) installers for the following versions of Windows, including both 32-bit and 64-bit architectures:
 
--   Windows Server 2012 R2 (supported by [Puppet Enterprise][peinstall])
--   Windows Server 2008 R2 (supported by [Puppet Enterprise][peinstall])
+-   Windows Server 2012 R2
+-   Windows Server 2008 R2
 
-We also publish, but do not automatically test, `puppet-agent` packages for the following versions of Windows:
+We also publish, but do not automatically test, open source `puppet-agent` packages for the following versions of Windows for 64-bit architectures:
 
--   Windows Server 2012 (supported by [Puppet Enterprise][peinstall])
--   Windows Server 2008 (supported by [Puppet Enterprise][peinstall])
--   Windows 8.1 (supported by [Puppet Enterprise][peinstall])
--   Windows 8 (supported by [Puppet Enterprise][peinstall])
--   Windows 7 (supported by [Puppet Enterprise][peinstall])
--   Windows Vista (supported by [Puppet Enterprise][peinstall])
+-   Windows Server 2012
+-   Windows Server 2008
+-   Windows 10
+-   Windows 8.1
+-   Windows 8
+-   Windows 7
+-   Windows Vista
+
+All of these versions are supported in [Puppet Enterprise][peinstall].
 
 [peinstall]: /pe/latest/install_windows.html
 <!-- When updating these, check the current version of the PE system requirements and make sure they don't need a bump as well. -->

--- a/source/_includes/pup44_platforms_windows.markdown
+++ b/source/_includes/pup44_platforms_windows.markdown
@@ -1,9 +1,9 @@
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) installers for the following versions of Windows, including both 32-bit and 64-bit architectures:
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) installers for 32-bit and 64-bit editions of the following Windows versions:
 
 -   Windows Server 2012 R2
 -   Windows Server 2008 R2
 
-We also publish, but do not automatically test, open source `puppet-agent` packages for the following versions of Windows for 64-bit architectures:
+We also publish, but do not automatically test, open source `puppet-agent` packages for the 32-bit and 64-bit editions of the following Windows versions:
 
 -   Windows Server 2012
 -   Windows Server 2008
@@ -13,7 +13,6 @@ We also publish, but do not automatically test, open source `puppet-agent` packa
 -   Windows 7
 -   Windows Vista
 
-All of these versions are supported in [Puppet Enterprise][peinstall].
+[Puppet Enterprise][/pe/latest/install_windows.html] supports the 32-bit and 64-bit versions of Windows Server 2012 R2 and 2008 R2, and the 64-bit versions of the other Windows versions listed above.
 
-[peinstall]: /pe/latest/install_windows.html
 <!-- When updating these, check the current version of the PE system requirements and make sure they don't need a bump as well. -->

--- a/source/_includes/pup44_platforms_windows.markdown
+++ b/source/_includes/pup44_platforms_windows.markdown
@@ -1,0 +1,16 @@
+We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Windows:
+
+-   Windows Server 2012 R2 (supported by [Puppet Enterprise][peinstall])
+-   Windows Server 2008 R2 (supported by [Puppet Enterprise][peinstall])
+
+We also publish, but do not automatically test, `puppet-agent` packages for the following versions of Windows:
+
+-   Windows Server 2012 (supported by [Puppet Enterprise][peinstall])
+-   Windows Server 2008 (supported by [Puppet Enterprise][peinstall])
+-   Windows 8.1 (supported by [Puppet Enterprise][peinstall])
+-   Windows 8 (supported by [Puppet Enterprise][peinstall])
+-   Windows 7 (supported by [Puppet Enterprise][peinstall])
+-   Windows Vista (supported by [Puppet Enterprise][peinstall])
+
+[peinstall]: /pe/latest/install_windows.html
+<!-- When updating these, check the current version of the PE system requirements and make sure they don't need a bump as well. -->

--- a/source/guides/platforms.markdown
+++ b/source/guides/platforms.markdown
@@ -1,24 +1,19 @@
 ---
 layout: default
-title: Puppet Open Source » Supported Platforms and System Requirements
+title: Open source Puppet platforms and requirements
 ---
 
 [pe-requirements]: /pe/latest/install_system_requirements.html
 
-Puppet Open Source Supported Platforms
-===================
+Puppet tests the [open source Puppet suite](/puppet/) against several operating systems and configurations, and for many of them also packages it into the [`puppet-agent` package](/puppet/latest/reference/about_agent.html).
 
-This page lists supported platforms for the open source version of Puppet. For Puppet Enterprise's supported platforms visit the [PE system requirements page][pe-requirements].
+> **Note:** For [Puppet Enterprise's](/pe/) supported platforms, see its [system requirements][pe-requirements].
 
-Please [contact Puppet Labs](http://puppetlabs.com/contact/) if you are interested in a platform not on this list.
-
-**[See Installing Puppet](/puppet/latest/reference/install_pre.html)** for more details about the packages available for your platform(s).
-
+For more information about about the most recent Puppet 4 packages and platforms, see the [Puppet Collections documentation](/puppet/latest/reference/puppet_collections.html). To request an official package for a platform not on this list, [contact us](https://puppet.com/contact).
 
 {% include agent_lifecycle.md %}
 
-Linux
------
+## Linux
 
 ### Red Hat Enterprise Linux (and Derivatives)
 
@@ -39,27 +34,23 @@ Linux
 - Mandriva Corporate Server 4
 - ArchLinux
 
-BSD
----
+## BSD
 
-- FreeBSD 4.7 and later
-- OpenBSD 4.1 and later
+-   FreeBSD 4.7 and later
+-   OpenBSD 4.1 and later
 
-Other Unix
-----------
+## Other Unix
 
-- Mac OS X, version 10.7 (Leopard) and higher
+- OS X, version 10.7 (Leopard) and higher
 - Oracle Solaris, version 10 and higher
 - AIX, version 5.3 and higher
 - HP-UX
 
-Windows
--------
+## Windows
 
 {% include platforms_windows.markdown %}
 
-Ruby Versions
------
+## Ruby versions
 
 Puppet requires an [MRI](http://en.wikipedia.org/wiki/Ruby_MRI) [Ruby](http://www.ruby-lang.org/en/) interpreter.
 Certain versions of Ruby are tested more thoroughly with Puppet than others, and some versions are not tested at all. Run `ruby --version` to check the version of Ruby on your system.
@@ -68,34 +59,33 @@ Certain versions of Ruby are tested more thoroughly with Puppet than others, and
 > Likewise [Puppet Enterprise](/pe/) does not rely on the OS's Ruby version, as it bundles its own Ruby environment. You can install PE alongside any version of Ruby or on systems without Ruby installed.
 > ![windows logo](/images/windows-logo-small.jpg) The [Windows installers](http://downloads.puppetlabs.com/windows) provided by Puppet Labs don't rely on the OS's Ruby version, and can be installed alongside any version of Ruby or on systems without Ruby installed.
 
-Ruby version | Puppet 3.x              | Puppet 4.x
--------------|----------------------------------------------------------
-2.3.x\*      | No                      | Lightly Tested (4.5 and higher)
-2.2.x        | No                      | Lightly Tested
-2.1.x        | Tested (3.5 and higher) | Tested
-2.0.x        | Tested (3.2 and higher) | Lightly Tested
-1.9.3\*\*    | Tested                  | Lightly Tested
-1.8.7        | Tested                  | No
+| Ruby version | Puppet 3.x              | Puppet 4.x                      |
+|--------------|-----------------------------------------------------------|
+| 2.3.x\*      | No                      | Lightly Tested (4.5 and higher) |
+| 2.2.x        | No                      | Lightly Tested                  |
+| 2.1.x        | Tested (3.5 and higher) | Tested                          |
+| 2.0.x        | Tested (3.2 and higher) | Lightly Tested                  |
+| 1.9.3\*\*    | Tested                  | Lightly Tested                  |
+| 1.8.7        | Tested                  | No                              |
 
 > \* Ruby 2.3.1+. Ruby 2.3.0 has a bug that causes segmentation faults under certain scenarios with puppet.
 > \*\* Ruby 1.9.3-p392 and up only. Unfortunately, Ubuntu Precise ships with 1.9.3-p0. If you're using Precise with Puppet 3.x, we recommend using Puppet Enterprise or installing a third-party Ruby package.
 
-Versions marked as "Tested" are recommended by Puppet Labs and are under automated test coverage. As of Puppet 4, where puppet-agent packages bundle Ruby, versions marked "Lightly Tested" are under reduced automated test coverage (specifically, spec tests only) -- the Ruby version bundled with puppet-agent is the recommended version. Other versions are not recommended and we make no guarantees about their performance with Puppet.
+Versions marked as "Tested" are recommended by Puppet and are under automated test coverage. As of Puppet 4, where `puppet-agent` packages bundle Ruby, versions marked "Lightly Tested" are under reduced automated test coverage (specifically, spec tests only) -- the Ruby version bundled with `puppet-agent` is the recommended version. We do not recommend other versions or make any guarantees about their performance with Puppet.
 
-Prerequisites
------
+## Prerequisites
 
 Puppet has a very small number of external dependencies:
 
-Dependency | Puppet 3.x | Puppet 4.x
------------|------------|-----------
-[Facter][] | Required   | Required
-[Hiera][]  | Required   | Required
-[rgen][]   | Optional   | Required
+| Dependency | Puppet 3.x | Puppet 4.x |
+|------------|------------|------------|
+| [Facter][] | Required   | Required   |
+| [Hiera][]  | Required   | Required   |
+| [rgen][]   | Optional   | Required   |
 
 Rgen is only needed if you are using Puppet 4 (or Puppet ≥ 3.2 [with `parser = future` enabled](/puppet/latest/reference/lang_future.html)). The official Puppet Labs packages will install it as a dependency.
 
-[Facter]: /facter
+[Facter]: /facter/
 [Hiera]: /hiera/latest/installing.html
 [rgen]: http://ruby-gen.org/downloads
 
@@ -114,4 +104,3 @@ All other prerequisite Ruby libraries should come with any standard Ruby install
 * webrick
 * webrick/https
 * xmlrpc
-

--- a/source/puppet/4.3/reference/puppet_collections.md
+++ b/source/puppet/4.3/reference/puppet_collections.md
@@ -56,9 +56,15 @@ Puppet Collection 1 contains the following components:
 
 {% include puppet-collections/_puppet_collection_1_osx1009.md %}
 
+### Windows systems
+
+Microsoft Installer (MSI) packages for `puppet-agent` are distributed from [downloads.puppetlabs.com](https://downloads.puppetlabs.com/windows/) and aren't directly associated with Puppet Collections. For more information, see the [Windows Agent installation documentation](./install_windows.html).
+
+{% include pup44_platforms_windows.markdown %}
+
 ## Verifying Puppet packages
 
-At Puppet Labs, we sign most of our packages, Ruby gems, and release tarballs with GNU Privacy Guard (GPG). This helps prove that the packages originate from Puppet Labs and have not been compromised.
+At Puppet, we sign most of our packages, Ruby gems, and release tarballs with GNU Privacy Guard (GPG). This helps prove that the packages originate from Puppet and have not been compromised.
 
 Security-conscious users can use GPG to verify signatures on our packages.
 
@@ -66,7 +72,7 @@ Security-conscious users can use GPG to verify signatures on our packages.
 
 Certain operating system and installation methods automatically verify our package signatures.
 
-* If you install Puppet Labs packages via our Yum and Apt repositories, the Puppet Collection release package that enables the repository also installs our release signing key. The Yum and Apt tools automatically verify the integrity of our packages as you install them.
+* If you install Puppet packages via our Yum and Apt repositories, the Puppet Collection release package that enables the repository also installs our release signing key. The Yum and Apt tools automatically verify the integrity of our packages as you install them.
 * Our Microsoft Installer (MSI) packages for Windows are signed with a different key, and the Windows installer automatically verifies the signature before installing the package.
 
 In these cases, you don't need to do anything to verify the package signature.
@@ -77,7 +83,7 @@ If you're using Puppet source tarballs or Ruby gems, or installing RPM packages 
 
 #### Import the release signing key
 
-Before you can verify signatures, you must import the Puppet Labs public key and verify its fingerprint. This key is certified by several Puppet developers and should be available from the public keyservers.
+Before you can verify signatures, you must import the Puppet public key and verify its fingerprint. This key is certified by several Puppet developers and should be available from the public keyservers.
 
 To import the release signing key, run:
 
@@ -98,7 +104,7 @@ The key is also [available via HTTP](http://pool.sks-keyservers.net:11371/pks/lo
 
 #### Verify the fingerprint
 
-The fingerprint of the Puppet Labs release signing key is **`47B3 20EB 4C7C 375A A9DA  E1A0 1054 B7A2 4BD6 EC30`**. Run the following:
+The fingerprint of the Puppet release signing key is **`47B3 20EB 4C7C 375A A9DA  E1A0 1054 B7A2 4BD6 EC30`**. Run the following:
 
     gpg --list-key --fingerprint 1054b7a24bd6ec30
 
@@ -132,11 +138,11 @@ This is normal if you do not have a trust path to the key. If you've verified th
 
 #### Verify an RPM package
 
-Puppet RPM packages include an embedded signature. To verify it, you must import the Puppet Labs public key to `rpm`, then use `rpm` to check the signature.
+Puppet RPM packages include an embedded signature. To verify it, you must import the Puppet public key to `rpm`, then use `rpm` to check the signature.
 
-First, retrieve the [Puppet Labs public key](http://pool.sks-keyservers.net:11371/pks/lookup?op=get&search=0x1054B7A24BD6EC30) and place it in a file on your node.
+First, retrieve the [Puppet public key](http://pool.sks-keyservers.net:11371/pks/lookup?op=get&search=0x1054B7A24BD6EC30) and place it in a file on your node.
 
-Next, run the following, replacing `<PUBLIC KEY FILE>` with the path to the file containing the Puppet Labs public key:
+Next, run the following, replacing `<PUBLIC KEY FILE>` with the path to the file containing the Puppet public key:
 
     sudo rpm --import PUBKEY <PUBLIC KEY FILE>
 
@@ -156,7 +162,7 @@ puppetlabs-release-pc1-fedora-22.noarch.rpm:
     MD5 digest: OK (97a9c407a8a7ee9f8689c79bab97250e)
 ~~~
 
-If you don't import the Puppet Labs public key, you can still verify the package's integrity using `rpm -vK`. However, you won't be able to validate the package's origin:
+If you don't import the Puppet public key, you can still verify the package's integrity using `rpm -vK`. However, you won't be able to validate the package's origin:
 
 ~~~
 puppetlabs-release-pc1-fedora-22.noarch.rpm:
@@ -168,7 +174,7 @@ puppetlabs-release-pc1-fedora-22.noarch.rpm:
 
 #### Verify an OS X `puppet-agent` package
 
-Puppet Labs signs `puppet-agent` packages for OS X with a developer ID and certificate. To verify the signature, download and mount the `puppet-agent` disk image, then use the `pkgutil` tool with the `--check-signature` flag:
+Puppet signs `puppet-agent` packages for OS X with a developer ID and certificate. To verify the signature, download and mount the `puppet-agent` disk image, then use the `pkgutil` tool with the `--check-signature` flag:
 
     pkgutil --check-signature /Volumes/puppet-agent-1.3.2-1.osx10.10/puppet-agent-1.3.2-1-installer.pkg
 

--- a/source/puppet/4.4/reference/install_linux.markdown
+++ b/source/puppet/4.4/reference/install_linux.markdown
@@ -7,29 +7,43 @@ canonical: "/puppet/latest/reference/install_linux.html"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: ./configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html
 [modules]: ./modules_fundamentals.html
 [main manifest]: ./dirs_manifest.html
 [environments]: ./environments.html
-[Puppet Collection]: ./puppet_collections.html
-[`puppet-agent`]: ./about_agent.html
+[puppet_collections]: ./puppet_collections.html
+[puppet_agent]: ./about_agent.html
+[server_setting]: ./configuration.html#server
+[system_requirements]: ./system_requirements.html
+
+> **Note:** These instructions describe how to install the open source Puppet agent software on Linux distributions for which Puppet provides official packages.
+>
+> -   To install the Puppet Enterprise agent on supported operating systems, see [its documentation]({{pe}}/install_agents.html).
+> -   To install the open source agent on Linux distributions that don't have official packages, review [Puppet's prerequisites](./system_requirements.html#platforms-without-packages).
+> -   To install the open source agent on Windows operating systems, see the [Windows installation instructions](./install_windows.html).
+> -   To install the open source agent on OS X, see the [OS X installation instructions](./install_osx.html).
+> -   To install open source Puppet Server on a Puppet master, see [its documentation][server_install].
 
 ## Make sure you're ready
 
-Before installing Puppet on any agent nodes, make sure you've read the [pre-install tasks](./install_pre.html) and [installed Puppet Server][server_install].
+Before installing Puppet agent on any nodes, complete the [pre-install tasks](./install_pre.html) and [install Puppet Server][server_install] on your designated Puppet master.
 
-> **Note:** Puppet 4 changed the locations for many of the most important files and directories. If you're familiar with Puppet 3 and earlier, read [a summary of the changes][where] and refer to the [full specification of Puppet directories](https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md).
+> **Note:** Puppet 4 changes the locations for many of the most important files and directories. If you're familiar with Puppet 3 and earlier, read [a summary of the changes][where] and refer to the [full specification of Puppet directories](https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md).
 
-## Review supported versions and requirements
+## Review system requirements
 
-Most Linux systems (including CentOS, Redhat, Ubuntu, and Debian) have official Puppet agent packages. For a complete list of supported platforms, view the [system requirements page.](./system_requirements.html)
+The agent service requires few resources and runs on many systems. For details, see Puppet's [system requirements][system_requirements].
 
 ## Install a release package to enable Puppet Collection repositories
 
-Release packages configure your system to download and install appropriate versions of the `puppetserver` and [`puppet-agent`][] packages. These packages are grouped into a [Puppet Collection][] repository comprised of compatible versions of Puppet tools.
+For most Linux distributions (including CentOS, Red Hat, Ubuntu, and Debian), you can install official Puppet agent packages directly from Puppet.
+
+Release packages configure your system to download and install appropriate versions of the Puppet packages, including the [`puppet-agent`][puppet_agent] package. These packages are grouped into a [Puppet Collection][puppet_collections] repository comprised of compatible versions of Puppet tools.
+
+> **Note:** Your distribution's repositories might provide their own Puppet packages, which often install older versions of the Puppet agent service. To install the latest version of Puppet and receive updates as soon as we release them, use a Puppet Collection repository.
 
 {% include puppet-collections/_puppet_collections_intro.md %}
 
@@ -39,51 +53,70 @@ Release packages configure your system to download and install appropriate versi
 
 {% include puppet-collections/_puppet_collection_1_yum.md %}
 
-> **Note:** We only provide the `puppet-agent` package for recent versions of Puppet on RHEL 5, and to install it you must first download the package as `rpm` on RHEL 5 doesn't support installing packages from a URL.
+> **Note:** To install the release package on Red Hat Enterprise Linux 5, you must download it first. The `rpm` package manager on RHEL 5 doesn't support installing packages from a URL.
 
 ### Installing release packages on Apt-based systems
 
 {% include puppet-collections/_puppet_collection_1_apt.md %}
 
-## Confirm you can run Puppet executables
+## Confirm that you can run Puppet executables
 
-The new location for Puppet's executables is `/opt/puppetlabs/bin/`, which is not in your `PATH` environment variable by default.
+Since version 4, Puppet's executables are installed to `/opt/puppetlabs/bin/`, which is not in the default `PATH` environment variable.
 
-This doesn't matter for Puppet services --- for instance, `service puppet start` works regardless of the `PATH` --- but if you're running interactive `puppet` commands, you must either add their location to your `PATH` or execute them using their full path.
+This doesn't matter for Puppet services --- for instance, the `service puppet start` command works regardless of the `PATH` --- but if you're running interactive `puppet` commands, you must either add their location to your `PATH` or execute them using their full path.
 
-To quickly add this location to your `PATH` for your current terminal session, use the command `export PATH=/opt/puppetlabs/bin:$PATH`. You can also add this location wherever you configure your `PATH`, such as your `.profile` or `.bashrc` configuration files.
+To quickly add this location to your `PATH` for your current terminal session only, run `export PATH=/opt/puppetlabs/bin:$PATH`. You can also add this location wherever you configure your `PATH`, such as your `.profile` or `.bashrc` configuration files.
 
-For more information, see [our page about files and directories moved in Puppet 4][where].
+For more information, review the [list of files and directories moved in Puppet 4][where].
 
 ## Install the `puppet-agent` package
 
+Use your operating system's package manager to install the `puppet-agent` package. After installing the package, **do not** start the `puppet` service until you [configure critical settings](#configure-critical-agent-settings).
+
 ### For Yum-based systems
 
-On your Puppet agent nodes, run `sudo yum install puppet-agent`.
+On each node, run:
+
+    sudo yum install puppet-agent
 
 ### For Apt-based systems
 
-On your Puppet agent nodes, run `sudo apt-get install puppet-agent`.
+On each node, run:
 
-**Do not** start the `puppet` service yet.
+    sudo apt-get install puppet-agent
 
 ## Configure critical agent settings
 
-You probably want to set the `server` setting to your Puppet master's hostname. The default value is `server = puppet`, so if your master is reachable at that address, you can skip this.
+Set the agent's [`server` setting][server_setting] to your Puppet master's hostname. The default value is `server = puppet`, so if your master's hostname is already `puppet`, you can skip this step.
 
-For other settings you might want to change, see [the list of agent-related settings][agent_settings].
+See the [list of agent-related settings][agent_settings] for more configuration options.
 
 ## Start the `puppet` service
 
-To start the Puppet service, run `sudo /opt/puppetlabs/bin/puppet resource service puppet ensure=running enable=true`.
+To start the `puppet` service, run:
 
-To manually launch and watch a Puppet run, run `sudo /opt/puppetlabs/bin/puppet agent --test`.
+    sudo /opt/puppetlabs/bin/puppet resource service puppet ensure=running enable=true
+
+By default, the service performs a Puppet run every 30 minutes. To manually launch and watch a Puppet run, run:
+
+    sudo /opt/puppetlabs/bin/puppet agent --test
 
 ## Sign certificates on the CA master
 
-As each Puppet agent runs for the first time, it submits a certificate signing request (CSR) to the certificate authority (CA) Puppet master. You must log into that server to check for and sign certificates. On the Puppet master:
+As each agent attempts its first run, it submits a certificate signing request (CSR) to the certificate authority (CA) Puppet master. The CA master must sign these certificates before it can manage the agents.
 
-1. Run `sudo /opt/puppetlabs/bin/puppet cert list` to see any outstanding requests.
-1. Run `sudo /opt/puppetlabs/bin/puppet cert sign <NAME>` to sign a request.
+To do this:
 
-After an agent's certificate is signed, it regularly fetches and applies configuration catalogs from the Puppet master.
+1.  Log into the CA Puppet master.
+
+2.  View outstanding requests by running:
+
+        sudo puppet cert list
+
+3.  Sign a request by running:
+
+        sudo puppet cert sign <NAME>
+
+    Once the Puppet master signs an agent's certificate, the agent regularly fetches and applies configuration catalogs from the master.
+
+> **Note:** The Puppet documentation includes a [detailed description of Puppet's agent/master communications](./subsystem_agent_master_comm.html).

--- a/source/puppet/4.4/reference/install_osx.md
+++ b/source/puppet/4.4/reference/install_osx.md
@@ -115,7 +115,7 @@ You can use the `hdiutil` and `installer` commands to mount the disk image, and 
 
 ### Upgrading with Puppet
 
-Puppet includes a [`pkgdmg` package provider](./type.html#package-provider-pkgdmg) that can install OS X installation packages (`.pkg` files) from a disk image (`.dmg` file). If you already have Puppet installed, you can use the `puppet resource` command to upgrade with fewer steps.
+If you already have Puppet installed, you can use the `puppet resource` command to upgrade with fewer steps.
 
 1.  Locate the `puppet-agent` disk image you downloaded, and note both the filename and its full path on disk.
 

--- a/source/puppet/4.4/reference/install_osx.md
+++ b/source/puppet/4.4/reference/install_osx.md
@@ -7,19 +7,28 @@ canonical: "/puppet/latest/reference/install_osx.html"
 [server_install]: {{puppetserver}}/install_from_packages.html
 [where]: ./whered_it_go.html
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
-[Puppet Collection]: ./puppet_collections.html
+[puppet_collections]: ./puppet_collections.html
+[server_setting]: ./configuration.html#server
+
+> **Note:** These instructions describe how to install the open source Puppet agent software on OS X.
+>
+> -   To install the Puppet Enterprise agent on supported operating systems, see [its documentation]({{pe}}/install_agents.html).
+> -   To install the open source agent on Linux distributions that don't have official packages, review [Puppet's prerequisites](./system_requirements.html#platforms-without-packages).
+> -   To install the open source agent on Windows operating systems, see the [Windows installation instructions](./install_windows.html).
+> -   To install the open source agent on Linux distributions, see the [Linux installation instructions](./install_linux.html).
+> -   To install open source Puppet Server on a Puppet master, see [its documentation][server_install].
 
 ## Make sure you're ready
 
-Before installing Puppet agent, read the [pre-install tasks](./install_pre.html) and [install Puppet Server][server_install].
+Before installing Puppet agent on any nodes, complete the [pre-install tasks](./install_pre.html) and [install Puppet Server][server_install] on your designated Puppet master.
 
-> **Note:** If you've used older Puppet versions, Puppet 4 changed the locations for a lot of the most important files and directories. [See this page for a summary of the changes.][where]
+> **Note:** Puppet 4 changes the locations for many of the most important files and directories. If you're familiar with Puppet 3 and earlier, read [a summary of the changes][where] and refer to the [full specification of Puppet directories](https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md).
 
 ## Review supported versions
 
-{% include pup43_platforms_osx.markdown %}
+Puppet agent is distributed in a package that includes all of Puppet's prerequisites. You don't need to download anything else to install Puppet agent on a node. These packages are tied to a [Puppet Collection][puppet_collections] (PC), which is a set of Puppet 4 software designed and tested to work well together.
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+{% include pup44_platforms_osx.markdown %}
 
 ## Download the OS X `puppet-agent` package
 
@@ -29,34 +38,32 @@ To install on other operating systems, see the pages linked in the navigation si
 {% include puppet-collections/_puppet_collection_1_osx1010.md %}
 {% include puppet-collections/_puppet_collection_1_osx1009.md %}
 
-You can also download [older versions of Puppet](https://downloads.puppetlabs.com/mac/); browse to `<OS X VERSION>/PC1/x86_64` for the most recently released packages.
-
-These packages are tied to Puppet Collection 1, which is a set of Puppet software designed to work well with Puppet 4. The `puppet-agent` package bundles all of Puppet's prerequisites, so you don't need to download anything else to install Puppet on an agent node.
+You can also download older versions of Puppet from [downloads.puppetlabs.com](https://downloads.puppetlabs.com/mac/). Browse to `<OS X VERSION>/PC1/x86_64` for the most recently released packages. For example, the path to the PC1 package for OS X 10.11 is `https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64`.
 
 ### Choosing a package
 
-OS X packages are named according to their `puppet-agent` version and compatible OS X version:
+Packages are named according to their `puppet-agent` version and compatible OS X version. They also contain a release number --- typically `1` --- that represents the iteration of that version's package.
 
-    puppet-agent-<PACKAGE VERSION>.osx<OS X VERSION>.dmg
+    puppet-agent-<PACKAGE VERSION>-<RELEASE NUMBER>.osx<OS X VERSION>.dmg
 
-For example:
+For example, the filename for the first release of the `puppet-agent` 1.4.2 package on OS X 10.11 is:
 
-    puppet-agent-1.3.2.osx10.11.dmg
+    puppet-agent-1.4.2-1.osx10.11.dmg
 
-To see which versions of Puppet and its related tools and components are in a given `puppet-agent` release, as well as release notes for each release, [see About Puppet Agent](./about_agent.html).
+To see which versions of Puppet, its related tools, and required components are in a given `puppet-agent` release, as well as release notes for each release, see [About Puppet agent](./about_agent.html).
 
 > #### Previous package names
 >
-> We used some different naming schemes in the puppet-agent 1.2 series before settling on the current convention in 1.2.5.
+> We used different naming schemes in the `puppet-agent` 1.2 series before settling on the current convention used since 1.2.5.
 >
-> * 1.2.0 through 1.2.2: `puppet-agent-<VERSION>-osx-<OS X VERSION>-<ARCH>.dmg`. Redundant; OS X only runs on x86_64.
-> * 1.2.4: `puppet-agent-<VERSION>-<OS X CODE NAME>.dmg`. This was too hard for automated tooling to deal with, because OS X's built-in CLI tools don't report the code name.
+> -   **1.2.0 through 1.2.2:** `puppet-agent-<PACKAGE VERSION>-osx-<OS X VERSION>-<ARCH>.dmg`. Redundant; OS X only runs on x86_64.
+> -   **1.2.4:** `puppet-agent-<PACKAGE VERSION>-<OS X CODE NAME>.dmg`. This was too hard for automated tooling to deal with, because OS X's built-in CLI tools don't report the code name.
 
 ## Make sure you can run Puppet executables
 
 The new location for Puppet's executables is `/opt/puppetlabs/bin/`, which is not in your `PATH` environment variable by default.
 
-This doesn't matter for Puppet services, so enabling or disabling Puppet agent with `launchctl` works fine. However, if you're running any interactive `puppet` commands, you need to either add the location to your `PATH` or refer to the executables by their full locations.
+This doesn't matter for Puppet services, so enabling or disabling Puppet agent with `launchctl` works fine. However, to run interactive `puppet` commands, either add the location to your `PATH` or refer to the executables by their full locations.
 
 For more information, see [our page about files and directories moved in Puppet 4][where].
 
@@ -64,59 +71,86 @@ For more information, see [our page about files and directories moved in Puppet 
 
 There are three ways to install Puppet on OS X:
 
-* With the GUI installer.
-* On the command line.
-* With Puppet (if upgrading).
+-   [With the GUI installer.](#installing-with-the-gui)
+-   [On the command line.](#installing-on-the-command-line)
+-   [With Puppet](#upgrading-with-puppet) (if upgrading).
 
-Regardless which you choose, installing the package will start the `puppet` and `mcollective` services. You can later disable these services with `launchctl` or with `sudo puppet resource service <NAME> ensure=stopped enable=false`.
+Regardless of which method you choose, the `puppet` and `mcollective` services launch automatically once they're installed. You can disable these services with `launchctl` or by running:
+
+    sudo puppet resource service <SERVICE NAME> ensure=stopped enable=false
 
 ### Installing with the GUI
 
-Double-click the `puppet-agent` disk image you downloaded. This mounts it at `/Volumes/<DMG NAME>`.
+To install Puppet with a graphic user interface:
 
-A Finder window appears showing the disk's contents: a single `puppet-agent-<VERSION>-installer.pkg` file. Double-click the package file, and follow the installer prompts to install it. When installation finishes, Puppet agent and MCollective will be running.
+1.  Double-click the `puppet-agent` disk image you downloaded.
 
-After installing, unmount and delete the disk image.
+    OS X verifies the image, and then mounts it at `/Volumes/<DMG NAME>`. A Finder window then appears showing the image's contents: a single `puppet-agent-<PACKAGE VERSION>-<RELEASE NUMBER>-installer.pkg` file.
+
+2.  Double-click the package file, and then follow the installer prompts.
+
+    Once the installation is complete, the `puppet` and `mcollective` services launch automatically.
+
+3.  Unmount the disk image. You can then delete the image.
 
 ### Installing on the command line
 
-Alternately, you can use the `hdiutil` and `installer` commands to mount the disk image and install the package from the command line.
+You can use the `hdiutil` and `installer` commands to mount the disk image, and then install the package from the command line.
 
-First, mount the disk image with:
+1.  Mount the disk image by running:
 
-    sudo hdiutil mount <DMG FILE>
+        sudo hdiutil mount <DMG FILE>
 
-Next, locate the `.pkg` file in the mounted volume and install it with:
+2.  Locate the `.pkg` file in the mounted volume and install it by running:
 
-    sudo installer -pkg /Volumes/<IMAGE>/<PKG FILE> -target /
+        sudo installer -pkg /Volumes/<IMAGE>/<PKG FILE> -target /
 
-When installation finishes, Puppet agent and MCollective will be running.
+        Once the installation is complete, the `puppet` and `mcollective` services launch automatically.
 
-After installing, unmount the disk image with:
+3.  Unmount the disk image by running:
 
-    sudo hdiutil unmount /Volumes/<IMAGE>
+        sudo hdiutil unmount /Volumes/<IMAGE>
 
-You can then delete the `.dmg` file.
+    You can then delete the disk image.
 
 ### Upgrading with Puppet
 
-Puppet includes a `package` resource provider for OS X that can install `.pkg` files from a disk image. If you already have Puppet installed, you can use the `puppet resource` command to upgrade with fewer steps.
+Puppet includes a [`pkgdmg` package provider](./type.html#package-provider-pkgdmg) that can install OS X installation packages (`.pkg` files) from a disk image (`.dmg` file). If you already have Puppet installed, you can use the `puppet resource` command to upgrade with fewer steps.
 
-Locate the disk image you downloaded, and note both the filename and its full path on disk. Then, run:
+1.  Locate the `puppet-agent` disk image you downloaded, and note both the filename and its full path on disk.
 
-    sudo puppet resource package "<NAME>.dmg" ensure=present source=<FULL PATH TO DMG>
+2.  Have Puppet install the package by running:
+
+        sudo puppet resource package "<IMAGE NAME>.dmg" ensure=present source=<FULL PATH TO IMAGE>
 
 ## Configure critical agent settings
 
-You probably want to set the `server` setting to your master's hostname. The default value is `server = puppet`, so if your master is reachable at that address, you can skip this.
+Set the agent's [`server` setting][server_setting] to your Puppet master's hostname. The default value is `server = puppet`, so if your master's hostname is already `puppet`, you can skip this step.
 
-For other settings you might want to change, see [the list of agent-related settings.][agent_settings]
+See the [list of agent-related settings][agent_settings] for more configuration options.
 
-## Sign certificates (on the CA master)
+## Test Puppet agent
 
-As each agent runs for the first time, it will submit a certificate signing request (CSR) to the certificate authority (CA) Puppet master. You'll need to log into that server to check for certs and sign them.
+By default, the `puppet` service performs a Puppet run every 30 minutes. To manually launch and watch a Puppet run, run:
 
-* Run `sudo /opt/puppetlabs/bin/puppet cert list` to see any outstanding requests.
-* Run `sudo /opt/puppetlabs/bin/puppet cert sign <NAME>` to sign a request.
+    sudo puppet agent --test
 
-After an agent's certificate is signed, it regularly fetches and applies configurations from the Puppet master.
+## Sign certificates on the CA master
+
+As each agent attempts its first run, it submits a certificate signing request (CSR) to the certificate authority (CA) Puppet master. The CA master must sign these certificates before it can manage the agents.
+
+To do this:
+
+1.  Log into the CA Puppet master.
+
+2.  View outstanding requests by running:
+
+        sudo puppet cert list
+
+3.  Sign a request by running:
+
+        sudo puppet cert sign <NAME>
+
+    Once the Puppet master signs an agent's certificate, the agent regularly fetches and applies configuration catalogs from the master.
+
+> **Note:** The Puppet documentation includes a [detailed description of Puppet's agent/master communications](./subsystem_agent_master_comm.html).

--- a/source/puppet/4.4/reference/install_pre.markdown
+++ b/source/puppet/4.4/reference/install_pre.markdown
@@ -6,8 +6,8 @@ canonical: "/puppet/latest/reference/install_pre.html"
 
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
-[ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[ruby]: ./system_requirements.html#requirements-and-prerequisites
+[architecture]: ./architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 
@@ -15,61 +15,55 @@ canonical: "/puppet/latest/reference/install_pre.html"
 
 Before you install Puppet, you should do the following tasks.
 
-## Decide on a Deployment Type
+## Decide on a deployment type
 
-Puppet usually uses an agent/master (client/server) architecture, but it can also run in a self-contained architecture. Your choice determines which packages you'll be installing, and what extra configuration you'll need to do.
+Puppet usually uses an agent/master (client/server) architecture, but it can also run in a self-contained architecture. Your choice determines which packages you need to install and what additional configuration you'll need to do. Puppet's documentation includes [an overview of Puppet's architecture][architecture] that can help you decide.
 
-Additionally, you should consider using [PuppetDB][], which enables extra Puppet features and makes it easy to query and analyze Puppet's data about your infrastructure.
+Additionally, consider using [PuppetDB][], which enables extra Puppet features and makes it easy to query and analyze Puppet's data about your infrastructure.
 
-[Learn more about Puppet's architectures here.][architecture]
+## Designate servers
 
-## Designate Servers
+If you choose the standard agent/master architecture, you'll need to decide which servers will act as the Puppet master (and the [PuppetDB][] server, if you choose to use it). In most installations, the Puppet master should run [Puppet Server]({{puppetserver}}), a high-performance implementation of the Puppet master service.
 
-If you choose the standard agent/master architecture, you'll need to decide which server(s) will act as the Puppet master (and the [PuppetDB][] server, if you choose to use it).
+You should completely install and configure Puppet or Puppet Server on your Puppet masters, and PuppetDB if you choose to use it, before installing Puppet on any agents. The master must run some form of \*nix; Windows and OS X systems can't run the master service.
 
-You should completely install and configure Puppet on any Puppet masters and PuppetDB servers before installing on any agent nodes. The master must be running some kind of \*nix. Windows machines can't be masters.
+## Check OS versions and system requirements
 
-A Puppet master should be a dedicated machine with a fast processor, lots of RAM, and a fast disk. It must also be reachable at a reliable hostname.
+The Puppet master service performs best on a dedicated server with multiple fast processor cores, lots of RAM, and a fast disk. The Puppet agent service, on the other hand, can run on nearly any system. Review Puppet's [system requirements][sysreqs] and consider the following:
 
-> Note: Agent nodes will default to contacting the master at the hostname `puppet`. If you make sure this hostname resolves to the master, you can skip changing [the `server` setting][server_setting] and reduce your setup time.
+-   Your Puppet masters should have the necessary resources to handle the number of agents they need to serve.
+-   It's easier to install Puppet on operating systems for which we provide official packages.
+-   Systems we don't provide packages for _might_ be able to run Puppet, as long as [Puppet's prerequisites, including Ruby][ruby], are installed. Puppet is also more difficult to install and maintain on these systems.
 
+## Check your network configuration
 
-## Check OS Versions and System Requirements
+In an agent/master deployment, your network must be prepared for Puppet's traffic.
 
-See the [system requirements](system_requirements.html) for the version of Puppet you are installing, and consider the following:
+-   **Firewalls:** The Puppet master must allow incoming connections on port 8140, and agents must be able to connect to the master on that port.
+-   **Name resolution:** Every node must have a unique hostname, and you **must** configure both forward _and_ reverse DNS resolution correctly on every node. (Instructions for configuring DNS are beyond the scope of this guide. If your site lacks DNS, you must configure the `hosts` file on each agent.)
 
-* Your Puppet master(s) should be able to handle the amount of agents they'll need to serve.
-* Systems we provide official packages for will have an easier install path.
-* Systems we don't provide packages for _might_ still be able to run Puppet, as long as the version of Ruby is suitable and the prerequisites are installed. See the [list of supported Ruby versions and prerequisites.][ruby] You'll also need to follow a more complex install path.
+    > **Note:** By default, the Puppet agent service attempts to contact a master at the hostname `puppet`. If you resolve this hostname on your network to the master, you can skip changing [the `server` setting][server_setting] and reduce your setup time.
 
-## Check Your Network Configuration
+## Check timekeeping on your Puppet master
 
-In an agent/master deployment, you must prepare your network for Puppet's traffic.
+The time must be set accurately on the Puppet master that will act as the infrastructure's certificate authority. You can configure agents and masters to synchronize their clocks via the [Network Time Protocol](http://www.ntp.org) (NTP). Consult your operating system's documentation to install and configure NTP synchronization on your nodes.
 
-* **Firewalls:** The Puppet master server must allow incoming connections on port 8140, and agent nodes must be able to connect to the master on that port.
-* **Name resolution:** Every node must have a unique hostname. **Forward and reverse DNS** must both be configured correctly. (Instructions for configuring DNS are beyond the scope of this guide. If your site lacks DNS, you must write an `/etc/hosts` file on each node.)
-    * **Note:** The default Puppet master hostname is `puppet`. Your agent nodes can be ready sooner if this hostname resolves to your Puppet master.
-
-## Check Timekeeping on Your Puppet Master Server
-
-The time must be set accurately on the Puppet master server that will be acting as the certificate authority. You should probably use NTP.
-
-(If the time is wrong, it might mistakenly issue agent certificates from the distant past or future, which other nodes will treat as expired.)
+If the time on the master falls out of sync with agents, it might mistakenly issue agent certificates from the distant past or future that other nodes will treat as expired.
 
 ## Next: Install Puppet
 
 Once these tasks are complete, you can install Puppet.
 
-Install Puppet Server before installing Puppet on your agent nodes.
+Install Puppet Server before installing Puppet on your agents.
 
-* [Installing Puppet Server]({{puppetserver}}/install_from_packages.html)
+-   [Installing Puppet Server]({{puppetserver}}/install_from_packages.html)
 
 If you're using PuppetDB, install it once Puppet Server is up and running.
 
-* [Installing PuppetDB]({{puppetdb}}/install_via_module.html)
+-   [Installing PuppetDB]({{puppetdb}}/install_via_module.html)
 
-Once Puppet Server is installed and configured, you can install agents:
+Once Puppet Server is installed and configured, you can install agents.
 
-* [Installing Puppet Agent on Linux](./install_linux.html)
-* [Installing Puppet Agent on Windows](./install_windows.html)
-* [Installing Puppet Agent on Mac OS X](./install_osx.html)
+-   [Installing Puppet agent on Linux](./install_linux.html)
+-   [Installing Puppet agent on Windows](./install_windows.html)
+-   [Installing Puppet agent on OS X](./install_osx.html)

--- a/source/puppet/4.4/reference/install_windows.markdown
+++ b/source/puppet/4.4/reference/install_windows.markdown
@@ -15,93 +15,103 @@ canonical: "/puppet/latest/reference/install_windows.html"
 [vardir]: ./dirs_vardir.html
 [server_install]: {{puppetserver}}/install_from_packages.html
 
-## Make Sure You're Ready
+> **Note:** These instructions describe how to install the open source Puppet agent software on OS X.
+>
+> -   To install the Puppet Enterprise agent on supported operating systems, see [its documentation]({{pe}}/install_agents.html).
+> -   To install the open source agent on Linux distributions that don't have official packages, review [Puppet's prerequisites](./system_requirements.html#platforms-without-packages).
+> -   To install the open source agent on Windows operating systems, see the [Windows installation instructions](./install_windows.html).
+> -   To install the open source agent on Linux distributions, see the [Linux installation instructions](./install_linux.html).
+> -   To install open source Puppet Server on a Puppet master, see [its documentation][server_install].
 
-Before installing Puppet on any agent nodes, make sure you've read the [pre-install tasks](./install_pre.html) and [installed Puppet Server][server_install].
+## Make sure you're ready
 
-> **Note:** If you've used older Puppet versions, Puppet 4 changed the locations for a lot of the most important files and directories. [See this page for a summary of the changes.][where]
+Before installing Puppet agent on any nodes, complete the [pre-install tasks](./install_pre.html) and [install Puppet Server][server_install] on your designated Puppet master.
 
-## Review Supported Versions
+> **Note:** Puppet 4 changes the locations for many of the most important files and directories. If you're familiar with Puppet 3 and earlier, read [a summary of the changes][where] and refer to the [full specification of Puppet directories](https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md).
 
-{% include pup43_platforms_windows.markdown %}
+## Review supported versions
 
-> **Deprecation Note:** Puppet 4.2 deprecated Windows Server 2003 and 2003 R2. The Windows installation package for `puppet-agent` 1.4.0, which contains Puppet 4.4, won't install on those versions of Windows Server.
+Puppet agent is distributed in a package that includes all of Puppet's prerequisites. You don't need to download anything else to install Puppet agent on a node. These packages are tied to a [Puppet Collection][puppet_collections] (PC), which is a set of Puppet 4 software designed and tested to work well together.
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+{% include pup44_platforms_windows.markdown %}
 
-## Download the Windows `puppet-agent` Package
+> **Deprecation Note:** Puppet 4.2 deprecated Windows Server 2003 and 2003 R2. The Windows installation packages for `puppet-agent` 1.4.0 and newer, which contains Puppet 4.4, won't install on those versions of Windows Server.
 
-[Puppet Labs' Windows packages can be found here.][downloads] You need the most recent package for your OS's architecture:
+## Download the Windows `puppet-agent` package
 
-* 64-bit versions of Windows can use `puppet-agent-<VERSION>-x64.msi` (recommended) or `puppet-agent-<VERSION>-x86.msi`.
-* 32-bit versions of Windows _must_ use `puppet-agent-<VERSION>-x86.msi`.
+Go to <https://downloads.puppetlabs.com/windows/> and download the most recent Windows Installer (MSI) package for your system's architecture.
 
-These packages bundle all of Puppet's prerequisites, so you don't need to download anything else.
+-   64-bit versions of Windows can use `puppet-agent-<VERSION>-x64.msi` (recommended) or `puppet-agent-<VERSION>-x86.msi`.
+-   32-bit versions of Windows _must_ use `puppet-agent-<VERSION>-x86.msi`.
 
-The list of Windows packages might include release candidates, whose filenames have something like `-rc1` after the version number. Use these only if you want to test upcoming Puppet versions.
+The list of Windows packages might include release candidates, with filenames that include something like `-rc1` after the version number. Use these only if you want to test upcoming Puppet versions.
 
 ## Install Puppet
 
 You can install Puppet [with a graphical wizard](#graphical-installation) or [on the command line](#automated-installation). The command-line installer provides more configuration options.
 
-### Graphical Installation
+### Graphical installation
 
 [server]: ./images/wizard_server.png
 
-Double-click the MSI package you downloaded, and follow the graphical wizard. The installer must be run with elevated privileges. Installing Puppet does not require a system reboot.
+To install Puppet agent using the graphical wizard:
 
-During installation, you will be asked for the hostname of your Puppet master server. This must be a \*nix node configured to act as a Puppet master.
+1.  Double-click the MSI package you downloaded to launch the wizard.
 
-For standalone Puppet nodes that won't connect to a master, use the default hostname (`puppet`). You might also want to install on the command line and set the agent startup mode to `Disabled`.
+    > **Note:** The installer requires elevated privileges. Installing Puppet does not require a system reboot.
 
-![Puppet master hostname selection][server]
+    Follow the wizard's instructions to continue the installation.
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured.
+2.  During the installation, the wizard requests your Puppet master's hostname. This must be the hostname of a \*nix node configured to act as a Puppet master.
 
-### Automated Installation
+    For standalone Puppet nodes that won't connect to a master, use the default hostname (`puppet`). In this case, you might want to use the [command-line installer](#automated-installation) instead so you can set the agent startup mode to `Disabled`.
 
-Use the `msiexec` command to install the Puppet package:
+    ![Puppet master hostname selection][server]
+
+    Once the installation is complete, the Puppet service will be running and at least partially configured.
+
+### Automated installation
+
+To install Puppet agent from the command line, or to automate installation, use the `msiexec` command to install the Puppet package.
 
     msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi
 
-If you don't specify any further options, this is the same as installing graphically with the default Puppet master hostname (`puppet`).
+If you don't specify any further options, this is the same as [installing graphically](#graphical-installation) with the default Puppet master hostname (`puppet`).
 
-You can specify `/l*v install.txt` to log the installation's progress to a file.
+> **Note:** You can optionally specify `/l*v install.txt` when running the installer in order to log the installation's progress to a file.
+>
+> You can also set several MSI properties to pre-configure Puppet as you install it. For example:
+>
+>     msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
+>
+> See [the MSI Properties section](#msi-properties) for information about these MSI properties.
 
-You can also set several MSI properties to pre-configure Puppet as you install it. For example:
+Once the installation is complete, the Puppet service will be running and at least partially configured.
 
-    msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
+### MSI properties
 
-See [the MSI Properties section](#msi-properties) for information about these MSI properties.
+These options are available only when [installing Puppet on the command line](#automated-installation).
 
-Once the installer finishes, Puppet will be installed, running, and at least partially configured.
+| MSI Property                                                   | Puppet Setting     | Introduced in            |
+|----------------------------------------------------------------|--------------------|--------------------------|
+| [`INSTALLDIR`](#installdir)                                    | n/a                | Puppet 2.7.12 / PE 2.5.0 |
+| [`PUPPET_MASTER_SERVER`](#puppetmasterserver)                  | [`server`][s]      | Puppet 2.7.12 / PE 2.5.0 |
+| [`PUPPET_CA_SERVER`](#puppetcaserver)                          | [`ca_server`][c]   | Puppet 2.7.12 / PE 2.5.0 |
+| [`PUPPET_AGENT_CERTNAME`](#puppetagentcertname)                | [`certname`][r]    | Puppet 2.7.12 / PE 2.5.0 |
+| [`PUPPET_AGENT_ENVIRONMENT`](#puppetagentenvironment)          | [`environment`][e] | Puppet 3.3.1  / PE 3.1.0 |
+| [`PUPPET_AGENT_STARTUP_MODE`](#puppetagentstartupmode)         | n/a                | Puppet 3.4.0  / PE 3.2   |
+| [`PUPPET_AGENT_ACCOUNT_USER`](#puppetagentaccountuser)         | n/a                | Puppet 3.4.0  / PE 3.2   |
+| [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2   |
+| [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2   |
 
-### MSI Properties
-
-These options are only available when installing Puppet on the command line (see above).
-
-The following MSI properties are available:
-
-MSI Property                                                   | Puppet Setting     | Introduced in
----------------------------------------------------------------|--------------------|-------------------------
-[`INSTALLDIR`](#installdir)                                    | n/a                | Puppet 2.7.12 / PE 2.5.0
-[`PUPPET_MASTER_SERVER`](#puppetmasterserver)                  | [`server`][s]      | Puppet 2.7.12 / PE 2.5.0
-[`PUPPET_CA_SERVER`](#puppetcaserver)                          | [`ca_server`][c]   | Puppet 2.7.12 / PE 2.5.0
-[`PUPPET_AGENT_CERTNAME`](#puppetagentcertname)                | [`certname`][r]    | Puppet 2.7.12 / PE 2.5.0
-[`PUPPET_AGENT_ENVIRONMENT`](#puppetagentenvironment)          | [`environment`][e] | Puppet 3.3.1  / PE 3.1.0
-[`PUPPET_AGENT_STARTUP_MODE`](#puppetagentstartupmode)         | n/a                | Puppet 3.4.0  / PE 3.2
-[`PUPPET_AGENT_ACCOUNT_USER`](#puppetagentaccountuser)         | n/a                | Puppet 3.4.0  / PE 3.2
-[`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
-[`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
-
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: ./configuration.html#server
+[c]: ./configuration.html#caserver
+[r]: ./configuration.html#certname
+[e]: ./configuration.html#environment
 
 #### `INSTALLDIR`
 
-Where Puppet and its dependencies should be installed.
+The path where Puppet and its dependencies should be installed.
 
 > **Note:** If you installed Puppet into a custom directory and are upgrading from a 32-bit version to a 64-bit version, you must re-specify the `INSTALLDIR` option when upgrading.
 >
@@ -109,26 +119,26 @@ Where Puppet and its dependencies should be installed.
 
 Puppet's program directory contains the following subdirectories:
 
-Directory   | Description
-------------|------------
-bin         | scripts for running Puppet and Facter
-facter      | Facter source
-hiera       | Hiera source
-mcollective | MCollective source
-misc        | resources
-puppet      | Puppet source
-service     | code to run puppet agent as a service
-sys         | Ruby and other tools
+| Directory   | Description                           |
+|-------------|---------------------------------------|
+| bin         | Scripts for running Puppet and Facter |
+| facter      | Facter source                         |
+| hiera       | Hiera source                          |
+| mcollective | MCollective source                    |
+| misc        | Resources                             |
+| puppet      | Puppet source                         |
+| service     | code to run Puppet agent as a service |
+| sys         | Ruby and other tools                  |
 
 **Default:**
 
 When using the architecture-appropriate installer, Puppet installs into `C:\Program Files\Puppet Labs\Puppet`.
 
-If you install the x86 package on a 64-bit system, it will install into `C:\Program Files (x86)\Puppet Labs\Puppet`.
+If you install the x86 package on a 64-bit system, it installs into `C:\Program Files (x86)\Puppet Labs\Puppet`.
 
 #### `PUPPET_MASTER_SERVER`
 
-The hostname where the Puppet master server can be reached. This sets a value for [the `server` setting][s] in the `[main]` section of [puppet.conf][].
+The hostname where the Puppet master server can be reached. This sets a value for the [`server` setting][s] in the `[main]` section of [puppet.conf][].
 
 **Default:** `puppet`
 
@@ -144,7 +154,7 @@ The hostname where the CA Puppet master server can be reached, if you are using 
 
 #### `PUPPET_AGENT_CERTNAME`
 
-The node's certificate name, and the name it uses when requesting catalogs. This sets a value for [the `certname` setting][r] in the `[main]` section of [puppet.conf][].
+The node's certificate name, and the name it uses when requesting catalogs. This sets a value for the [`certname` setting][r] in the `[main]` section of [puppet.conf][].
 
 For best compatibility, you should limit the value of `certname` to only use lowercase letters, numbers, periods, underscores, and dashes. (That is, it should match `/\A[a-z0-9._-]+\Z/`.)
 
@@ -164,19 +174,19 @@ The node's [environment][]. This sets a value for [the `environment` setting][e]
 
 Whether the Puppet agent service should run (or be allowed to run). Allowed values:
 
-* `Automatic` (**default**) --- Puppet agent starts with Windows and stays running in the background.
-* `Manual` --- Puppet agent won't run by default, but can be started in the services console or with `net start` on the command line.
-* `Disabled` --- Puppet agent is installed but disabled. You must change its startup type in the services console before you can start the service.
+-   `Automatic` (**default**): Puppet agent starts with Windows and stays running in the background.
+-   `Manual`: Puppet agent won't run by default, but can be started in the services console or with `net start` on the command line.
+-   `Disabled`: Puppet agent is installed but disabled. You must change its startup type in the services console before you can start the service.
 
 #### `PUPPET_AGENT_ACCOUNT_USER`
 
 Which Windows user account the Puppet agent service should use. This is important if the Puppet agent needs to access files on UNC shares, since the default `LocalSystem` account cannot access these network resources.
 
-* This user account **must already exist,** and can be a local or domain user. (The installer allows domain users even if they haven't accessed this machine before.)
-* If the user isn't already a local administrator, the installer adds it to the `Administrators` group.
-* The installer also grants the [`Logon as Service`](https://msdn.microsoft.com/en-us/library/ms813948.aspx) privilege to the user.
+-   This user account **must already exist,** and can be a local or domain user. (The installer allows domain users even if they haven't accessed this machine before.)
+-   If the user isn't already a local administrator, the installer adds it to the `Administrators` group.
+-   The installer also grants the [`Logon as Service`](https://msdn.microsoft.com/en-us/library/ms813948.aspx) privilege to the user.
 
-This property should be combined with `PUPPET_AGENT_ACCOUNT_PASSWORD` and `PUPPET_AGENT_ACCOUNT_DOMAIN`. For example, to assign the agent to a domain user `ExampleCorp\bob`, install with:
+This property should be combined with [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) and [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain). For example, to assign the agent to a domain user `ExampleCorp\bob`, install with:
 
     msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp PUPPET_AGENT_ACCOUNT_USER=bob PUPPET_AGENT_ACCOUNT_PASSWORD=password
 
@@ -196,15 +206,15 @@ The domain of the Puppet agent's user account. See the notes under [`PUPPET_AGEN
 
 #### Downgrades
 
-If you need to replace a 64-bit version of Puppet with a 32-bit version, you must **uninstall** Puppet before installing the new package. You must also uninstall if you are downgrading from 3.7 or later to 3.6 or earlier.
+If you need to replace a 64-bit version of Puppet with a 32-bit version, you must **uninstall** Puppet before installing the new package.
 
 ### Uninstalling
 
 You can uninstall Puppet through the "Add or Remove Programs" interface or from the command line.
 
-To uninstall Puppet from the command line, you must have the original MSI file or know the <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa370854(v=vs.85).aspx">ProductCode</a> of the installed MSI:
+To uninstall Puppet from the command line, you must have the original MSI file or know the [ProductCode](https://msdn.microsoft.com/en-us/library/windows/desktop/aa370854.aspx) of the installed MSI:
 
-    msiexec /qn /norestart /x puppet-agent-1.3.0-x64.msi
+    msiexec /qn /norestart /x puppet-agent-1.4.2-x64.msi
     msiexec /qn /norestart /x <PRODUCT CODE>
 
 When you uninstall Puppet, the uninstaller removes Puppet's program directory, the Puppet agent service, and all related registry keys. It leaves the [confdir][], [codedir][], and [vardir][] intact, including any SSL keys. To completely remove Puppet from the system, manually delete the confdir, codedir, and vardir.

--- a/source/puppet/4.4/reference/puppet_collections.md
+++ b/source/puppet/4.4/reference/puppet_collections.md
@@ -56,9 +56,15 @@ Puppet Collection 1 contains the following components:
 
 {% include puppet-collections/_puppet_collection_1_osx1009.md %}
 
+### Windows systems
+
+Microsoft Installer (MSI) packages for `puppet-agent` are distributed from [downloads.puppetlabs.com](https://downloads.puppetlabs.com/windows/) and aren't directly associated with Puppet Collections. For more information, see the [Windows Agent installation documentation](./install_windows.html).
+
+{% include pup44_platforms_windows.markdown %}
+
 ## Verifying Puppet packages
 
-At Puppet Labs, we sign most of our packages, Ruby gems, and release tarballs with GNU Privacy Guard (GPG). This helps prove that the packages originate from Puppet and have not been compromised.
+At Puppet, we sign most of our packages, Ruby gems, and release tarballs with GNU Privacy Guard (GPG). This helps prove that the packages originate from Puppet and have not been compromised.
 
 Security-conscious users can use GPG to verify signatures on our packages.
 

--- a/source/puppet/4.4/reference/system_requirements.markdown
+++ b/source/puppet/4.4/reference/system_requirements.markdown
@@ -4,87 +4,78 @@ title: "Puppet 4.4 System Requirements"
 canonical: "/puppet/latest/reference/system_requirements.html"
 ---
 
-> To install Puppet, first [view the pre-install tasks](./install_pre.html).
+[pe-requirements]: {{pe}}/install_system_requirements.html#supported-operating-systems
+[preinstall-network]: ./install_pre.html#check-your-network-configuration
 
-## Hardware
+Puppet can run on many operating systems and hardware configurations. Before installing Puppet, first [view the pre-install tasks](./install_pre.html).
 
-The Puppet agent service has no particular hardware requirements and can run on nearly anything.
+> **Note:** For [Puppet Enterprise's](/pe/) supported platforms, see its [system requirements][pe-requirements].
 
-However, the Puppet master service is fairly resource intensive, and should be installed on a robust dedicated server.
+## Puppet agent
 
-* At a minimum, your Puppet master server should have two processor cores and at least 1 GB of RAM.
-* To comfortably serve at least 1,000 nodes, it should have 2-4 processor cores and at least 4 GB of RAM.
+The Puppet agent service is lightweight enough to run on nearly any system capable of running a Ruby interpreter. To be managed by a Puppet master, the agent must be accessible from the master. See the [pre-installation instructions][preinstall-network] for details about the required DNS and port configuration for agents.
+
+For simple installation, Puppet builds and packages the open source agent and its prerequisites for 32-bit (i386) and 64-bit (x86_64 and amd64) versions of many Linux distributions, OS X, and Windows.
+
+-   For more information about the `puppet-agent` package, see [its documentation](./about_agent.html).
+-   For a list of platforms and architectures with official Puppet packages, see the [Puppet Collections documentation](./puppet_collections.html).
+
+## Puppet master and Puppet Server
 
 The demands on the Puppet master vary widely between deployments. The total needs are affected by the number of agents being served, how frequently those agents check in, how many resources are being managed on each agent, and the complexity of the manifests and modules in use.
 
+All Puppet masters must be available to agents over the network. See the [pre-installation instructions][preinstall-network] for details about the required DNS and port configuration for masters.
+
+The Puppet master service built into the `puppet-agent` package is a resource-intensive service that performs best on a robust dedicated server. To manage more than 10 nodes, the master server should have at least two processor cores and 1 GB of RAM. To manage more than 1,000 nodes, the server should have at least 4 processor cores and 4 GB of RAM.
+
+To scale Puppet beyond more than a few hundred nodes, however, we recommend using [Puppet Server]({{puppetserver}}) instead of the built-in Puppet master. Puppet Server is a much more efficient implementation of the Puppet master service. See [its documentation]({{puppetserver}}/install_from_packages.html#system-requirements) for system requirements and installation instructions.
+
 {% include agent_lifecycle.md %}
 
-## Platforms With Packages
+## Platforms without packages
 
-Puppet 4.4 and all of its prerequisites run on the following platforms, and Puppet provides official packages in [Puppet Collections](./upgrade_minor.html#puppet-collections-and-upgrading).
+Puppet and its prerequisites can also run on the following platforms, but we do not provide official open-source packages or perform automated testing of open source Puppet for them.
 
-### Red Hat Enterprise Linux (and Derivatives)
+### Linux
 
-{% include pup43_platforms_redhat_like.markdown %}
+-   SUSE Linux Enterprise Server, version 11 and higher
+-   Gentoo Linux
+-   Mandriva Corporate Server 4
+-   Arch Linux
 
-### Debian and Ubuntu
+### Unix
 
-{% include pup40_platforms_debian_like.markdown %}
+-   Oracle Solaris, version 10 and higher (Puppet performs limited automated testing on Solaris 11)
+-   AIX, version 5.3 and higher
+-   FreeBSD, version 4.7 and later
+-   OpenBSD, version 4.1 and later
+-   HP-UX
 
-### Fedora
+> **Note:** For platforms supported in Puppet Enterprise, see its [System Requirements][pe-requirements].
 
-{% include pup43_platforms_fedora.markdown %}
+Puppet also makes the `puppet-agent` packaging process available as an open source project. For information about building the package yourself, see the [`puppetlabs/puppet-agent` repository on GitHub](https://github.com/puppetlabs/puppet-agent).
 
-### Windows
+### Prerequisites
 
-{% include pup43_platforms_windows.markdown %}
+The official `puppet-agent` package either includes or instructs your operating system's package manager to install all prerequisites, including its own Ruby interpreter. When running Puppet from source, building your own `puppet-agent` package, or otherwise running Puppet binaries without installing the official package, Puppet services have the following prerequisites:
 
-### Mac OS X
-
-{% include pup43_platforms_osx.markdown %}
-
-## Platforms Without Packages
-
-Puppet and its prerequisites are known to run on the following platforms, but we do not provide official open source packages or perform automated testing. For platforms supported in Puppet Enterprise, see its [System Requirements]({{pe}}/install_system_requirements.html#supported-operating-systems).
-
-### Other Linux
-
-* SUSE Linux Enterprise Server, version 11 and higher
-* Gentoo Linux
-* Mandriva Corporate Server 4
-* Arch Linux
-
-### Other Unix
-
-* Oracle Solaris, version 10 and higher (Puppet performs limited automated testing on Solaris 11)
-* AIX, version 5.3 and higher
-* FreeBSD 4.7 and later
-* OpenBSD 4.1 and later
-* HP-UX
-
-## Basic Requirements
-
-If you're installing Puppet via the official packages, you won't need to worry about these prerequisites; your system's package manager handles all of them. These are only listed for those running Puppet from source or on unsupported systems.
-
-Puppet 4.4 has the following prerequisites:
-
-### Ruby
+#### Ruby
 
 Use one of the following versions of MRI (standard) Ruby:
 
-* 2.1.x
-* 2.0.x
-* 1.9.3
+-   2.1.x
+-   2.0.x
+-   1.9.3
 
-> **Note:** We currently only test and package with 2.1.x versions of Ruby, therefore we recommend you only use this version. Other interpreters and versions of Ruby are not covered by our tests.
+> **Note:** We package 2.1.x versions of MRI Ruby in `puppet-agent` and recommend that you use only this version. We perform little or no testing of Puppet with other interpreters and versions of Ruby.
 
-### Mandatory Libraries
+#### Mandatory libraries
 
-* [Facter](http://www.puppetlabs.com/puppet/related-projects/facter/) 2.4.3 or later
-* [Hiera]({{hiera}}/) 2.0.0 or later
-* The `json` gem (any modern version).
-* The [`rgen` gem](http://ruby-gen.org/downloads) version 0.6.6 or later is now required because Puppet [`parser = future` is enabled by default](./lang_updating_manifests.html).
+-   [Facter]({{facter}}/) 2.4.3 or later. Facter 3 is recommended.
+-   [Hiera]({{hiera}}/) 2.0.0 or later.
+-   The `json` gem (any modern version).
+-   The [`rgen` gem](http://ruby-gen.org/downloads) version 0.6.6 or later. If you're upgrading from Puppet 3, note that the "future parser" in Puppet 3 (which introduced the `rgen` dependency) is the default parser in Puppet 4. [Update your manifests appropriately.](./lang_updating_manifests.html)
 
-### Optional Libraries
+#### Optional libraries
 
-* The `msgpack` gem is required if you are using [msgpack serialization](./experiments_msgpack.html).
+-   The `msgpack` gem is required only if you are using [experimental msgpack serialization](./experiments_msgpack.html).

--- a/source/puppet/4.4/reference/system_requirements.markdown
+++ b/source/puppet/4.4/reference/system_requirements.markdown
@@ -13,7 +13,7 @@ Puppet can run on many operating systems and hardware configurations. Before ins
 
 ## Puppet agent
 
-The Puppet agent service is lightweight enough to run on nearly any system capable of running a Ruby interpreter. To be managed by a Puppet master, the agent must be accessible from the master. See the [pre-installation instructions][preinstall-network] for details about the required DNS and port configuration for agents.
+The Puppet agent service is lightweight enough to run on nearly any system capable of running a Ruby interpreter. To be managed by a Puppet master, the agent must be able to communicate with the master. See the [pre-installation instructions][preinstall-network] for details about the required DNS and port configuration for agents.
 
 For simple installation, Puppet builds and packages the open source agent and its prerequisites for 32-bit (i386) and 64-bit (x86_64 and amd64) versions of many Linux distributions, OS X, and Windows.
 
@@ -73,7 +73,7 @@ Use one of the following versions of MRI (standard) Ruby:
 
 -   [Facter]({{facter}}/) 2.4.3 or later. Facter 3 is recommended.
 -   [Hiera]({{hiera}}/) 2.0.0 or later.
--   The `json` gem (any modern version).
+-   The `json` gem (any modern version; included with Ruby).
 -   The [`rgen` gem](http://ruby-gen.org/downloads) version 0.6.6 or later. If you're upgrading from Puppet 3, note that the "future parser" in Puppet 3 (which introduced the `rgen` dependency) is the default parser in Puppet 4. [Update your manifests appropriately.](./lang_updating_manifests.html)
 
 #### Optional libraries


### PR DESCRIPTION
This supports work to eliminate the unversioned platforms and system requirements guides.

-   Update style and formatting on agent life cycle include and platforms guide.
-   Convert headings to sentence case.
-   Standardize common text in per-platform install docs.
-   Add information about Puppet Collections to per-platform install docs.
-   Add Puppet 4.4 PC1 includes for single-sourcing.
-   Use ordered lists when instructions consist of a list of steps.
-   As a temporary improvement, update formatting and brand references on the unversioned platforms guide.