### PR TITLE
Make Packaging and Platform guides obsolete in 3.8

### DIFF
--- a/source/_includes/pup38_platforms_debian_like.markdown
+++ b/source/_includes/pup38_platforms_debian_like.markdown
@@ -1,0 +1,13 @@
+Puppet publishes and tests open-source Puppet 3.8 packages for the following versions of Debian to [apt.puppetlabs.com](https://apt.puppetlabs.com):
+
+-   Debian 7 "Wheezy" (previous stable release)
+-   Debian 6 "Squeeze" (obsolete stable release)
+
+Puppet publishes and tests packages for the following versions of Ubuntu to [apt.puppetlabs.com](https://apt.puppetlabs.com):
+
+-   Ubuntu 14.04 LTS "Trusty Tahr"
+-   Ubuntu 12.04 LTS "Precise Pangolin"
+
+Ubuntu 10.04 LTS reached its end-of-life in April 2015.
+
+> **Puppet Enterprise support:** [PE 3.8](/pe/3.8/) supports these operating systems, but supports masters only on 64-bit editions of Ubuntu. [Newer versions of Puppet Enterprise](/pe/latest/) support more agents on more recent versions of Debian and Ubuntu, and masters on more recent versions of Ubuntu.

--- a/source/_includes/pup38_platforms_fedora.markdown
+++ b/source/_includes/pup38_platforms_fedora.markdown
@@ -1,0 +1,3 @@
+Puppet publishes and tests open-source Puppet 3.8 packages for Fedora 20 to [yum.puppetlabs.com](https://yum.puppetlabs.com).
+
+> **Puppet Enterprise support:** [PE 3.8](/pe/3.8/) supports only Red Hat Enterprise Linux (RHEL), CentOS, Oracle Linux, and Scientific Linux. [Newer versions of Puppet Enterprise](/pe/latest/) support recent versions of Fedora.

--- a/source/_includes/pup38_platforms_osx.markdown
+++ b/source/_includes/pup38_platforms_osx.markdown
@@ -1,0 +1,8 @@
+Puppet publishes and tests open-source Puppet 3.8 agent installers for the following versions of OS X to [downloads.puppetlabs.com/mac](https://downloads.puppetlabs.com/mac):
+
+-   10.10 "Yosemite"
+-   10.9 "Mavericks"
+
+The Puppet master service is not available on any version of OS X.
+
+> **Puppet Enterprise support:** [PE 3.8](/pe/3.8/) supports only OS X 10.9. [Newer versions of Puppet Enterprise](/pe/latest/) support more recent versions of OS X.

--- a/source/_includes/pup38_platforms_redhat_like.markdown
+++ b/source/_includes/pup38_platforms_redhat_like.markdown
@@ -1,0 +1,12 @@
+Puppet publishes and tests open-source Puppet 3.8 packages for the following versions of Red Hat Enterprise Linux (RHEL) to [yum.puppetlabs.com](https://yum.puppetlabs.com):
+
+-   Enterprise Linux 7
+-   Enterprise Linux 6
+-   Enterprise Linux 5
+-   Enterprise Linux 4
+
+This also applies to any distributions that maintain binary compatibility with RHEL, including but not limited to CentOS, Scientific Linux, and Oracle Linux.
+
+> **Puppet Enterprise support:** [PE 3.8](/pe/3.8/) supports 32-bit and 64-bit agents on these versions of RHEL and compatibile operating systems, but doesn't support masters on Enterprise Linux 4 and 5, or on 32-bit architectures.
+
+<!-- When updating these, also edit guides/puppetlabs_package_repositories.markdown and add/delete the repo packages as needed. -->

--- a/source/_includes/pup38_platforms_windows.markdown
+++ b/source/_includes/pup38_platforms_windows.markdown
@@ -1,0 +1,21 @@
+Puppet publishes and tests open-source Puppet 3.8 agent installers for the following versions of Microsoft Windows to [downloads.puppetlabs.com/windows](https://downloads.puppetlabs.com/windows):
+
+-   Windows Server 2012 R2
+-   Windows Server 2008 R2
+-   Windows Server 2003 R2
+
+Puppet also publishes, but does not automatically test, open-source Puppet 3.8 packages for the following versions of Windows:
+
+-   Windows Server 2012
+-   Windows Server 2008
+-   Windows Server 2003
+-   Windows 7
+-   Windows 8
+-   Windows 8.1
+-   Windows Vista
+
+The Puppet master service is not available on any version of Windows.
+
+> **Puppet Enterprise support:** [PE 3.8](/pe/3.8/) supports agents on 32-bit versions of Windows Server 2003 and 2003 R2, and on both 32-bit and 64-bit versions of Windows Server 2008, 2008 R2, 2012, and 2012 R2; Windows 7 Ultimate SP 1; and Windows 8 and 8.1 Pro. It does not support agents on any version of Windows Vista. [Newer versions of Puppet Enterprise](/pe/latest/) support more recent versions of Windows.
+
+<!-- When updating these, check the current version of the PE system requirements and make sure they don't need a bump as well. -->

--- a/source/puppet/3.8/reference/install_debian_ubuntu.markdown
+++ b/source/puppet/3.8/reference/install_debian_ubuntu.markdown
@@ -12,18 +12,18 @@ title: "Installing Puppet: Debian and Ubuntu"
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Supported Versions
 -----
 
-{% include platforms_debian_like.markdown %}
+{% include pup38_platforms_debian_like.markdown %}
 
-Users of out-of-production versions may have vendor packages of Puppet available, but cannot use the Puppet Labs packages.
+Users of out-of-production versions might have vendor packages of Puppet available, but can't use our provided packages.
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+To install on other operating systems, see the product navigation.
 
-Step 1: Enable the Puppet Labs Package Repository
+Step 1: Enable the Puppet Package Repository
 -----
 
 The newest versions of Puppet can be installed from the [apt.puppetlabs.com](https://apt.puppetlabs.com) package repository.
@@ -32,7 +32,7 @@ The newest versions of Puppet can be installed from the [apt.puppetlabs.com](htt
 
 ### Optionally: Enable Prereleases
 
-If you want to be able to test release candidate (RC) versions of Puppet and related projects, you can turn on the prerelease repo, which is disabled by default. Note that RCs may contain unexpected changes, so be careful.
+To test release candidate (RC) versions of Puppet and related projects, you can enable the prerelease repo, which is disabled by default. Note that RCs can contain unexpected changes, so be careful.
 
 {% include repo_pre_debian_ubuntu.markdown %}
 
@@ -41,42 +41,48 @@ Step 2: Install Puppet on the Puppet Master Server
 
 (Skip this step for a standalone deployment.)
 
-On your puppet master node, run:
+On your Puppet master, run:
 
-    $ sudo apt-get install puppetserver
-    
+    sudo apt-get install puppetserver
+
 This installs Puppet, its prerequisites, and [Puppet Server](/puppetserver/), a JVM-based Puppet master server that's ready for production.
+
+> **Note:** Puppet 3.8 is compatible with [Puppet Server 1.1](/puppetserver/1.1/). [Puppet Server 2 and newer](/puppetserver/latest/) require [Puppet 4](/puppet/latest/).
 
 Do not start Puppet Server yet.
 
 ### Upgrading
 
-> **Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet master to the latest version of Puppet 3, run:
 
-    $ sudo apt-get update
-    $ sudo puppet resource package puppetmaster ensure=latest
+    sudo apt-get update
+    sudo puppet resource package puppetmaster ensure=latest
 
-You'll need to restart the puppet master web server after upgrading.
+After upgrading, restart Puppet Server.
 
 Step 3: Install Puppet on Agent Nodes
 -----
 
-On your other nodes, run `sudo apt-get install puppet`. This will install Puppet and an init script (`/etc/init.d/puppet`) for running the puppet agent daemon.
+On your Puppet agents, run:
+
+    sudo apt-get install puppet
+
+This installs Puppet and an init script (`/etc/init.d/puppet`) that runs the Puppet agent daemon.
 
 Do not start the `puppet` service yet.
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet agent to the latest version of Puppet 3, run:
 
-    $ sudo apt-get update
-    $ sudo puppet resource package puppet ensure=latest
+    sudo apt-get update
+    sudo puppet resource package puppet ensure=latest
 
-You'll need to restart the `puppet` service after upgrading.
+After upgrading, restart the `puppet` service.
 
 Next
 ----

--- a/source/puppet/3.8/reference/install_el.markdown
+++ b/source/puppet/3.8/reference/install_el.markdown
@@ -12,21 +12,21 @@ title: "Installing Puppet: Red Hat Enterprise Linux (and Derivatives)"
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Supported Versions
 -----
 
-{% include platforms_redhat_like.markdown %}
+{% include pup38_redhat_like.markdown %}
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+To install on other operating systems, see the product navigation.
 
 Step 1: Enable Dependencies (RHEL Only)
 -----
 
 CentOS and other community forks have several packages Puppet depends on in their main repos, but RHEL itself is split into channels. If you're installing Puppet on RHEL, you'll want to make sure the "optional" channel is enabled. [Instructions are available here.](https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/supplementary-repos.html)
 
-Step 2: Enable the Puppet Labs Package Repository
+Step 2: Enable the Puppet Package Repository
 -----
 
 The newest versions of Puppet can be installed from the [yum.puppetlabs.com](https://yum.puppetlabs.com) package repository.
@@ -35,7 +35,7 @@ The newest versions of Puppet can be installed from the [yum.puppetlabs.com](htt
 
 ### Optionally: Enable Prereleases
 
-If you want to be able to test release candidate (RC) versions of Puppet and related projects, you can turn on the prerelease repo, which is disabled by default. Note that RCs may contain unexpected changes, so be careful.
+To test release candidate (RC) versions of Puppet and related projects, you can enable the prerelease repo, which is disabled by default. Note that RCs can contain unexpected changes, so be careful.
 
 {% include repo_pre_redhat.markdown %}
 
@@ -44,21 +44,23 @@ Step 3: Install Puppet on the Puppet Master Server
 
 (Skip this step for a standalone deployment.)
 
-On your puppet master node(s), run `sudo yum install puppetserver`. This will install Puppet and an init script (`/etc/init.d/puppetmaster`) for running a test-quality puppet master server.
+On your Puppet masters, run:
 
-> **Note:** Puppet 3.8 is compatible with Puppet Server 1.1. Puppet Server 2 and newer require Puppet 4.
+    sudo yum install puppetserver
 
-Do not start the puppet master service yet.
+This installs Puppet and an init script (`/etc/init.d/puppetmaster`) that runs a test-quality Puppet master server.
+
+Do not start the Puppet master service yet.
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet master to the latest version of Puppet 3, run:
 
-    $ sudo puppet resource package puppet-server ensure=latest
+    sudo puppet resource package puppet-server ensure=latest
 
-You'll need to restart the puppet master web server after upgrading.
+After upgrading, restart the Puppet master web server.
 
 Step 4: Install Puppet on Agent Nodes
 -----
@@ -71,11 +73,11 @@ Do not start the `puppet` service yet.
 
 **Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet agent to the latest version of Puppet 3, run:
 
-    $ sudo puppet resource package puppet ensure=latest
+    sudo puppet resource package puppet ensure=latest
 
-You'll need to restart the `puppet` service after upgrading.
+After upgrading, restart the `puppet` service.
 
 Next
 ----

--- a/source/puppet/3.8/reference/install_fedora.markdown
+++ b/source/puppet/3.8/reference/install_fedora.markdown
@@ -12,18 +12,18 @@ title: "Installing Puppet: Fedora"
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Supported Versions
 -----
 
-{% include platforms_fedora.markdown %}
+{% include pup38_platforms_fedora.markdown %}
 
-Users of out-of-production versions may have vendor packages of Puppet available, but cannot use the Puppet Labs packages.
+Users of out-of-production versions might have vendor packages of Puppet available, but can't use our provided packages.
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+To install on other operating systems, see the product navigation.
 
-Step 1: Enable the Puppet Labs Package Repository
+Step 1: Enable the Puppet Package Repository
 -----
 
 The newest versions of Puppet can be installed from the [yum.puppetlabs.com](https://yum.puppetlabs.com) package repository.
@@ -32,7 +32,7 @@ The newest versions of Puppet can be installed from the [yum.puppetlabs.com](htt
 
 ### Optionally: Enable Prereleases
 
-If you want to be able to test release candidate (RC) versions of Puppet and related projects, you can turn on the prerelease repo, which is disabled by default. Note that RCs may contain unexpected changes, so be careful.
+To test release candidate (RC) versions of Puppet and related projects, you can enable the prerelease repo, which is disabled by default. Note that RCs can contain unexpected changes, so be careful.
 
 {% include repo_pre_redhat.markdown %}
 
@@ -41,19 +41,23 @@ Step 2: Install Puppet on the Puppet Master Server
 
 (Skip this step for a standalone deployment.)
 
-On your puppet master node, run `sudo yum install puppet-server`. This will install Puppet and a systemd configuration (`/usr/lib/systemd/system/puppetmaster.service`) for running a test-quality puppet master server.
+On your Puppet master node, run:
 
-Do not start the puppet master service yet.
+    sudo yum install puppet-server
+
+This installs Puppet and a `systemd` configuration (`/usr/lib/systemd/system/puppetmaster.service`) to run a test-quality Puppet master server.
+
+Do not start the Puppet master service yet.
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet master to the latest version of Puppet 3, run:
 
-    $ sudo puppet resource package puppet-server ensure=latest
+    sudo puppet resource package puppet-server ensure=latest
 
-You'll need to restart the puppet master web server after upgrading.
+After upgrading, restart the Puppet master web server.
 
 Step 3: Install Puppet on Agent Nodes
 -----
@@ -68,12 +72,11 @@ Do not start the `puppet` service yet.
 
 **Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
 
-To upgrade to the latest version of Puppet, you can run:
+To upgrade a Puppet agent to the latest version of Puppet 3, run:
 
     $ sudo puppet resource package puppet ensure=latest
 
-You'll need to restart the `puppet` service after upgrading.
-
+After upgrading, restart the `puppet` service.
 
 Next
 ----

--- a/source/puppet/3.8/reference/install_gem.markdown
+++ b/source/puppet/3.8/reference/install_gem.markdown
@@ -3,7 +3,6 @@ layout: default
 title: "Installing Puppet: From Gems"
 ---
 
-
 [peinstall]: /pe/latest/install_basic.html
 [confdir]: /puppet/latest/reference/dirs_confdir.html
 [puppet.conf]: /puppet/latest/reference/config_file_main.html
@@ -15,83 +14,84 @@ title: "Installing Puppet: From Gems"
 
 > **Note:** This document covers open source releases of Puppet version 3.8 and lower. You might also want instructions for [installing Puppet Enterprise][peinstall] or [installing Puppet 4.0 or newer.][install-latest]
 
-On \*nix platforms without native packages available, you can install Puppet with Ruby's `gem` package manager. This isn't recommended unless there are no native packages for your OS.
+On \*nix platforms without native packages, you can install Puppet with Ruby's `gem` package manager. This isn't recommended unless there are no native packages for your OS.
 
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Step 1: Ensure Prerequisites are Installed
 -----
 
-Use your OS's package tools to install both Ruby and RubyGems. In some cases, you may need to compile and install these yourself.
+Use your OS's package tools to install both Ruby and RubyGems. You might need to compile and install these yourself.
 
-On Linux platforms, you should also ensure that the LSB tools are installed; at a minimum, we recommend installing `lsb_release`. See your OS's documentation for details about its LSB tools.
+On Linux platforms, ensure that the LSB tools are installed. We recommend installing at least `lsb_release`. See your OS's documentation for details about its LSB tools.
 
 Step 2: Install Puppet
 -----
 
 To install Puppet and its dependencies, run:
 
-    $ sudo gem install puppet
+    sudo gem install puppet
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
 To upgrade to the latest version of Puppet, you can run:
 
-    $ sudo puppet resource package puppet ensure=latest provider=gem
+    sudo puppet resource package puppet ensure=latest provider=gem
 
-You'll need to restart the `puppet` service and/or the puppet master web server after upgrading.
+After upgrading, restart the `puppet` service and, if applicable, the Puppet master web server.
 
 Step 3: Pre-Configure Puppet
 -----
 
-RubyGems lacks some of the conveniences that native packages have. To prepare for the post-install tasks, you should now do the following:
+RubyGems lacks some of the conveniences that native packages have. To prepare for the post-install tasks, do the following:
 
 ### Create Users
 
-The puppet master service needs a `puppet` user and group. If this node might ever act as a puppet master server, do the following now:
+The Puppet master service needs a `puppet` user and group. If this node might ever act as a Puppet master server, do the following now:
 
-1. Manually create a `puppet` group, by running `sudo puppet resource group puppet ensure=present`.
-2. Manually create a `puppet` user, by running `sudo puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'`.
+1.  Create a `puppet` group:
 
-This step is optional on agent nodes.
+        sudo puppet resource group puppet ensure=present
+
+2.  Create a `puppet` user:
+
+        sudo puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'
 
 ### Create an Init Script for Puppet Agent
 
-To run puppet agent as a service, you'll want an init script, or whatever your OS's equivalent is.
+To run Puppet agent as a service, you need an init script (or whatever your OS's equivalent is).
 
-Each platform handles init scripts a little differently, so you'll need to either find an OS-specific one or build one yourself based on what you know about your OS of choice. If you browse the `ext` directory in the Puppet source on GitHub, you can find several example init scripts or service configurations for various OSes:
+Because each platform handles init scripts differently, you must find one specific to your operating system or build one yourself based on what you know about your chosen operating system. The `ext` directory in the Puppet source includes several example init scripts or service configurations for various operating systems:
 
-* [Red Hat](https://github.com/puppetlabs/puppet/blob/master/ext/redhat)
-* [Debian](https://github.com/puppetlabs/puppet/blob/master/ext/debian)
-* [SUSE](https://github.com/puppetlabs/puppet/blob/master/ext/suse)
-* [systemd](https://github.com/puppetlabs/puppet/blob/master/ext/systemd)
-* [FreeBSD](https://github.com/puppetlabs/puppet/blob/master/ext/freebsd)
-* [Gentoo](https://github.com/puppetlabs/puppet/blob/master/ext/gentoo)
-* [Solaris](https://github.com/puppetlabs/puppet/blob/master/ext/solaris)
+-   [Red Hat](https://github.com/puppetlabs/puppet/blob/master/ext/redhat)
+-   [Debian](https://github.com/puppetlabs/puppet/blob/master/ext/debian)
+-   [SUSE](https://github.com/puppetlabs/puppet/blob/master/ext/suse)
+-   [systemd](https://github.com/puppetlabs/puppet/blob/master/ext/systemd)
+-   [FreeBSD](https://github.com/puppetlabs/puppet/blob/master/ext/freebsd)
+-   [Gentoo](https://github.com/puppetlabs/puppet/blob/master/ext/gentoo)
+-   [Solaris](https://github.com/puppetlabs/puppet/blob/master/ext/solaris)
 
-Do not start the `puppet` or puppet master services yet.
+Do not start the `puppet` or Puppet master services yet.
 
 ### Create a Confdir and Config Files
 
-When you install with gems, your [confdir][] may be empty or missing. You will need to populate it with the required files
+When you install with gems, your [confdir][] might be empty or missing. Populate it with these required files:
 
-* Make sure the [confdir][] exists. This directory is usually at `/etc/puppet/`.
-* Create a [puppet.conf][] file in the confdir. You can leave it empty until the post-install tasks.
-* If this node will ever act as a puppet master, it will need an [auth.conf][] file. Download [the default auth.conf file](https://raw.githubusercontent.com/puppetlabs/puppet/3.7.5/conf/auth.conf) from the Puppet source on GitHub, and put it in the confdir.
-* Create a [main manifest][] and a [module directory][]. Alternately, [enable directory environments][directory environments] in puppet.conf and create a `production` environment, as described in the [directory environments][] page.
+1.  Make sure the [confdir][] exists. This directory is usually at `/etc/puppet/`.
+2.  Create a [puppet.conf][] file in the confdir. You can leave it empty until the post-install tasks.
+3.  If this node will ever act as a Puppet master, it needs an [auth.conf][] file. Use [the default auth.conf file](https://raw.githubusercontent.com/puppetlabs/puppet/3.8.5/conf/auth.conf) from the Puppet source, and put it in the confdir.
+4.  Create a [main manifest][] and a [module directory][]. Alternately, [enable directory environments][directory environments] in puppet.conf and create a `production` environment, as described in the [directory environments][] page.
 
 ### Make Sure Puppet Can be Loaded
 
 Run `puppet --version`. This should output the version of Puppet you now have installed.
 
-
 Next
 ----
 
 At this point, Puppet is installed, but it isn't configured or running. You should now [do the post-install tasks](./post_install.html).
-

--- a/source/puppet/3.8/reference/install_osx.markdown
+++ b/source/puppet/3.8/reference/install_osx.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Installing Puppet: Mac OS X"
+title: "Installing Puppet: OS X"
 ---
 
 [peinstall]: /pe/latest/install_basic.html
@@ -11,25 +11,27 @@ title: "Installing Puppet: Mac OS X"
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Supported Versions
 -----
 
-Puppet Labs builds packages for OS X, but we don't run automated testing on them.
+Puppet builds packages for OS X, but we don't run automated testing on them.
 
-We recommend using Puppet on the newest version of OS X available, and we will tend to not fix bugs related to older versions. Our current packages are intended for OS X Mavericks (10.9) and later.
+{% include pup38_platforms_osx.markdown %}
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
+We recommend using Puppet on the newest version of OS X available, because we might not address bugs related to older versions. Our Puppet 3.8 packages are intended for OS X 10.9 (Mavericks) and later, and newer versions of Puppet are built and tested against newer versions of OS X.
+
+To install on other operating systems, see the product navigation.
 
 Step 1: Download Packages
 -----
 
-[Puppet Labs' OS X packages can be found here.](http://downloads.puppetlabs.com/mac/) You will need three packages total:
+Download Puppet's OS X installers from [downloads.puppetlabs.com/mac](http://downloads.puppetlabs.com/mac/). You need these three packages:
 
-* The most recent Facter package (`facter-<VERSION>.dmg`)
-* The most recent Hiera package (`hiera-<VERSION>.dmg`)
-* The most recent Puppet package (`puppet-<VERSION>.dmg`)
+-   The most recent Facter package (`facter-<VERSION>.dmg`)
+-   The most recent Hiera package (`hiera-<VERSION>.dmg`)
+-   The most recent Puppet package (`puppet-<VERSION>.dmg`)
 
 The list of OS X packages includes release candidates, whose filenames have something like `-rc1` after the version number. Only use these if you want to test upcoming Puppet versions.
 
@@ -52,7 +54,7 @@ Although OS X systems can act as puppet master servers, we don't ship separate p
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
 
 To upgrade to the latest versions of Puppet, Facter, and Hiera, download new packages and run the installers again.
 
@@ -143,7 +145,6 @@ See [the puppet agent man page](/puppet/latest/reference/man/agent.html) for det
 ### Don't Worry About Loading the Launchd Service
 
 As long as a service plist is in the `/Library/LaunchDaemons` directory, `puppet resource service` can manage it by name. You do not need to use `launchctl load` to enable the service.
-
 
 Next
 ----

--- a/source/puppet/3.8/reference/install_tarball.markdown
+++ b/source/puppet/3.8/reference/install_tarball.markdown
@@ -14,7 +14,7 @@ title: "Installing Puppet: From Source Tarballs"
 
 > **Note:** This document covers open source releases of Puppet version 3.8 and lower. You might also want instructions for [installing Puppet Enterprise][peinstall] or [installing Puppet 4.0 or newer.][install-latest]
 
-On \*nix platforms without native packages available, you can install Puppet with a tarball of source code. This is even more unwieldy than using RubyGems and is almost never recommended, but it may be necessary in some cases.
+On \*nix platforms without native packages available, you can install Puppet with a tarball of source code. This is even more unwieldy than using RubyGems and is almost never recommended, but it might be necessary in some cases.
 
 First
 -----
@@ -24,93 +24,85 @@ Before installing Puppet, make sure you've looked at the [pre-install tasks.](./
 Step 1: Ensure Prerequisites are Installed
 -----
 
-* Use your OS's package tools to install Ruby. In some cases, you may need to compile and install it yourself.
-* On Linux platforms, you should also ensure that the LSB tools are installed; at a minimum, we recommend installing `lsb_release`. See your OS's documentation for details about its LSB tools.
-* If you are running Ruby 1.8.7, you must also install the JSON library. If you have RubyGems installed, you can use `sudo gem install json_pure`, but if not, you'll need to [download the source from the project's site](http://flori.github.io/json/) and install it manually.
-
+1.  Use your OS's package tools to install Ruby. In some cases, you might need to compile and install it yourself.
+2.  On Linux platforms, ensure that the LSB tools are installed. We recommend installing at least `lsb_release`. See your OS's documentation for details about its LSB tools.
+3.  If you use Ruby 1.8.7, you must also install the JSON library. If you have RubyGems installed, you can use `sudo gem install json_pure`, but if not, you'll need to [download the source from the project's site](http://flori.github.io/json/) and install it manually.
 
 Step 2: Download Puppet and its Dependencies
 -----
 
-You will need the latest `.tar.gz` files for the Puppet source, the Facter source, and the Hiera source.
+Download the latest `.tar.gz` files containing the Puppet, Facter, and Hiera sources.
 
-* [Puppet downloads](https://downloads.puppetlabs.com/puppet/)
-* [Facter downloads](http://downloads.puppetlabs.com/facter/)
-* [Hiera downloads](https://downloads.puppetlabs.com/hiera/)
+-   [Puppet downloads](https://downloads.puppetlabs.com/puppet/)
+-   [Facter downloads](http://downloads.puppetlabs.com/facter/)
+-   [Hiera downloads](https://downloads.puppetlabs.com/hiera/)
 
-Optionally, you can also download the corresponding `.asc` files and [verify the signature](/guides/puppetlabs_package_verification.html) of each tarball.
+Optionally, you can also download the corresponding `.asc` files and [verify the signature](/puppet/latest/reference/puppet_collections.html#verifying-puppet-packages) of each tarball.
 
-Step 3: Install Facter
+Step 3: Install Facter, Hiera, and Puppet
 -----
 
-Unarchive the Facter tarball, navigate to the resulting directory, and run:
+Unarchive the Facter, Hiera, and Puppet tarballs, then navigate to each resulting directory and run:
 
-    $ sudo ruby install.rb
-
-Step 4: Install Hiera
------
-
-Unarchive the Hiera tarball, navigate to the resulting directory, and run:
-
-    $ sudo ruby install.rb
-
-Step 5: Install Puppet
------
-
-Unarchive the Puppet tarball, navigate to the resulting directory, and run:
-
-    $ sudo ruby install.rb
+    sudo ruby install.rb
 
 ### Upgrading
 
-**Note:** Be sure to read our [tips on upgrading](./upgrading.html) before upgrading your whole Puppet deployment.
+> **Note:** Read our [tips on upgrading](./upgrading.html) before upgrading your Puppet deployment.
 
 To upgrade to the latest versions of Puppet, Facter, and Hiera, download new tarballs and run the install scripts again.
 
-You'll need to restart the `puppet` service and/or the puppet master web server after upgrading.
+After upgrading, restart the `puppet` service and, if applicable, the Puppet master web server.
 
 Step 6: Pre-Configure Puppet
 -----
 
-Source tarballs lack some of the conveniences that native packages have. To prepare for the post-install tasks, you should now do the following:
+Source tarballs lack some of the conveniences that native packages have. To prepare for the post-install tasks, do the following:
 
 ### Create Users
 
-The puppet master service needs a `puppet` user and group. If this node might ever act as a puppet master server, do the following now:
+The Puppet master service needs a `puppet` user and group. If this node might ever act as a Puppet master server, do the following:
 
-1. Manually create a `puppet` group, by running `sudo puppet resource group puppet ensure=present`.
-2. Manually create a `puppet` user, by running `sudo puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'`.
+1.  Create a `puppet` group:
 
-This step is optional on agent nodes.
+        sudo puppet resource group puppet ensure=present
+
+2.  Create a `puppet` user:
+
+        sudo puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'
+
+This step is optional on agents.
 
 ### Create an Init Script for Puppet Agent
 
-To run puppet agent as a service, you'll want an init script, or whatever your OS's equivalent is.
+To run Puppet agent as a service, you need an init script (or whatever your OS's equivalent is).
 
-Each platform handles init scripts a little differently, so you'll need to either find an OS-specific one or build one yourself based on what you know about your OS of choice. If you browse the `ext` directory in the Puppet source on GitHub, you can find several example init scripts or service configurations for various OSes:
+Because each platform handles init scripts differently, you must find one specific to your operating system or build one yourself based on what you know about your chosen operating system. The `ext` directory in the Puppet source includes several example init scripts or service configurations for various operating systems:
 
-* [Red Hat](https://github.com/puppetlabs/puppet/blob/master/ext/redhat)
-* [Debian](https://github.com/puppetlabs/puppet/blob/master/ext/debian)
-* [SUSE](https://github.com/puppetlabs/puppet/blob/master/ext/suse)
-* [systemd](https://github.com/puppetlabs/puppet/blob/master/ext/systemd)
-* [FreeBSD](https://github.com/puppetlabs/puppet/blob/master/ext/freebsd)
-* [Gentoo](https://github.com/puppetlabs/puppet/blob/master/ext/gentoo)
-* [Solaris](https://github.com/puppetlabs/puppet/blob/master/ext/solaris)
+-   [Red Hat](https://github.com/puppetlabs/puppet/blob/master/ext/redhat)
+-   [Debian](https://github.com/puppetlabs/puppet/blob/master/ext/debian)
+-   [SUSE](https://github.com/puppetlabs/puppet/blob/master/ext/suse)
+-   [systemd](https://github.com/puppetlabs/puppet/blob/master/ext/systemd)
+-   [FreeBSD](https://github.com/puppetlabs/puppet/blob/master/ext/freebsd)
+-   [Gentoo](https://github.com/puppetlabs/puppet/blob/master/ext/gentoo)
+-   [Solaris](https://github.com/puppetlabs/puppet/blob/master/ext/solaris)
 
-Do not start the `puppet` or puppet master services yet.
+Do not start the `puppet` or Puppet master services yet.
 
 ### Create a Confdir and Config Files
 
-When you install with tarballs, your [confdir][] may be empty or missing. You will need to populate it with the required files
+When you install with tarballs, your [confdir][] might be empty or missing. Populate it with these required files:
 
-* Make sure the [confdir][] exists. This directory is usually at `/etc/puppet/`.
-* Create a [puppet.conf][] file in the confdir. You can leave it empty until the post-install tasks.
-* If this node will ever act as a puppet master, it will need an [auth.conf][] file. Download [the default auth.conf file](https://raw.githubusercontent.com/puppetlabs/puppet/master/conf/auth.conf) from the Puppet source on GitHub, and put it in the confdir.
-* Create a [main manifest][] and a [module directory][]. Alternately, [enable directory environments][directory environments] in puppet.conf and create a `production` environment, as described in the [directory environments][] page.
+1.  Make sure the [confdir][] exists. This directory is usually at `/etc/puppet/`.
+2.  Create a [puppet.conf][] file in the confdir. You can leave it empty until the post-install tasks.
+3.  If this node will ever act as a Puppet master, it needs an [auth.conf][] file. Use [the default auth.conf file](https://raw.githubusercontent.com/puppetlabs/puppet/3.8.5/conf/auth.conf) from the Puppet source, and put it in the confdir.
+4.  Create a [main manifest][] and a [module directory][]. Alternately, [enable directory environments][directory environments] in puppet.conf and create a `production` environment, as described in the [directory environments][] page.
 
+### Make Sure Puppet Can be Loaded
+
+Run `puppet --version`. This should output the version of Puppet you now have installed.
 
 Next
 ----
 
 At this point, Puppet is installed, but it isn't configured or running. You should now [do the post-install tasks](./post_install.html).
-

--- a/source/puppet/3.8/reference/install_windows.markdown
+++ b/source/puppet/3.8/reference/install_windows.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Installing Puppet: Microsoft Windows"
 ---
 
-[downloads]: http://downloads.puppetlabs.com/windows
+[downloads]: https://downloads.puppetlabs.com/windows
 [peinstall]: /pe/latest/install_windows.html
 [pre_install]: ./pre_install.html
 [puppet.conf]: /puppet/latest/reference/config_file_main.html
@@ -17,34 +17,33 @@ title: "Installing Puppet: Microsoft Windows"
 First
 -----
 
-Before installing Puppet, make sure you've looked at the [pre-install tasks.](./pre_install.html)
+Before installing Puppet, review the [pre-install tasks.](./pre_install.html)
 
 Supported Versions
 -----
 
-{% include platforms_windows.markdown %}
+{% include pup38_platforms_windows.markdown %}
 
-To install on other operating systems, see the pages linked in the navigation sidebar.
-
+To install on other operating systems, see the product navigation.
 
 Step 1: Configure a Puppet Master Server
 -----
 
-Windows machines can't act as puppet master servers. Before installing any Windows agent nodes, be sure that you have a \*nix puppet master installed and configured, and that you know its permanent hostname.
+Windows machines can't act as Puppet master servers. Before installing Puppet agent on any Windows nodes, install and configure a \*nix Puppet master and note its permanent hostname.
 
-If you haven't done this yet, go back to the [pre-install tasks][pre_install], make any necessary decisions, and follow the install instructions and post-install tasks for your puppet master's OS.
+If you haven't done this yet, go back to the [pre-install tasks][pre_install], make any necessary decisions, and follow the install instructions and post-install tasks for your Puppet master's OS.
 
-Step 2: Download Package
+Step 2: Download Installer
 -----
 
-[Puppet Labs' Windows packages can be found here.][downloads] You will need the most recent package for your OS's architecture:
+Windows installers for Puppet agent are available at [downloads.puppetlabs.com/windows][downloads]. You need the most recent Puppet 3.8 package for your OS's architecture:
 
-* 64-bit versions of Windows Vista/2008 and higher should use `puppet-<VERSION>-x64.msi`.
-* 32-bit versions of Windows, as well as the 64-bit version of Windows Server 2003, should use `puppet-<VERSION>.msi`.
+-   64-bit versions of Windows Vista/2008 and higher should use `puppet-<VERSION>-x64.msi`.
+-   32-bit versions of Windows, as well as the 64-bit version of Windows Server 2003, should use `puppet-<VERSION>.msi`.
 
 These packages bundle all of Puppet's prerequisites, so you don't need to download anything else.
 
-The list of Windows packages may include release candidates, whose filenames have something like `-rc1` after the version number. Only use these if you want to test upcoming Puppet versions.
+The list of Windows packages might include release candidates, whose filenames have something like `-rc1` after the version number. Only use these if you want to test upcoming Puppet versions.
 
 Step 3: Install Puppet
 -----

--- a/source/puppet/3.8/reference/system_requirements.markdown
+++ b/source/puppet/3.8/reference/system_requirements.markdown
@@ -14,36 +14,44 @@ The Puppet agent service has no particular hardware requirements and can run on 
 However, the Puppet master service is fairly resource intensive, and should be installed on a robust dedicated server.
 
 * At minimum, your Puppet master server should have two processor cores and at least 1 GB RAM.
-* To comfortably serve at least 1000 nodes, it should have 2-4 processor cores and at least 4 GB RAM.
+* To comfortably serve at least 1,000 nodes, it should have 2-4 processor cores and at least 4 GB RAM.
 
 The demands on the Puppet master will vary widely between different deployments. The total needs are affected by the number of agents being served, how frequently those agents check in, how many resources are being managed on each agent, and the complexity of the manifests and modules in use.
 
 Platforms With Packages
 -----
 
-Puppet 3.8 and all of its prerequisites will run on the following platforms, and Puppet Labs provides official packages in [our package repositories.](/guides/puppetlabs_package_repositories.html)
+Puppet provides official packages or repositories for Puppet 3.8 and its prerequisites on the following operating systems.
 
 ### Red Hat Enterprise Linux (and Derivatives)
 
-{% include platforms_redhat_like.markdown %}
+{% include pup38_platforms_redhat_like.markdown %}
 
-### Debian and Ubuntu
-
-{% include platforms_debian_like.markdown %}
+See the [Enterprise Linux installation instructions](./install_el.html) for details.
 
 ### Fedora
 
-{% include platforms_fedora.markdown %}
+{% include pup38_platforms_fedora.markdown %}
+
+See the [Fedora installation instructions](./install_fedora.html) for details.
+
+### Debian and Ubuntu
+
+{% include pup38_platforms_debian_like.markdown %}
+
+See the [Debian and Ubuntu installation instructions](./install_debian_ubuntu.html) for details.
 
 ### Windows
 
-{% include platforms_windows.markdown %}
+{% include pup38_platforms_windows.markdown %}
 
-### Mac OS X
+See the [Windows agent installation instructions](./install_windows.html) for details.
 
-Although we publish packages for Mac OS X, we do not run automated testing on it.
+### OS X
 
-- Mac OS X, version 10.9 (Mavericks) and higher
+{% include pup38_platforms_osx.markdown %}
+
+See the [OS X agent installation instructions](./install_osx.html) for details.
 
 Platforms Without Packages
 -----
@@ -52,18 +60,18 @@ Puppet and its prerequisites are known to run on the following platforms, but we
 
 ### Other Linux
 
-- SUSE Linux Enterprise Server, version 11 and higher
-- Gentoo Linux
-- Mandriva Corporate Server 4
-- ArchLinux
+-   SUSE Linux Enterprise Server, version 11 and higher
+-   Gentoo Linux
+-   Mandriva Corporate Server 4
+-   Arch Linux
 
 ### Other Unix
 
-- Oracle Solaris, version 10 and higher (Puppet Labs performs limited automated testing on Solaris 11.)
-- AIX, version 5.3 and higher
-- FreeBSD 4.7 and later
-- OpenBSD 4.1 and later
-- HP-UX
+-   Oracle Solaris, version 10 and higher (Puppet performs limited automated testing on Solaris 11.)
+-   AIX, version 5.3 and higher
+-   FreeBSD 4.7 and later
+-   OpenBSD 4.1 and later
+-   HP-UX
 
 Basic Requirements
 -----
@@ -85,11 +93,11 @@ Other interpreters and versions of Ruby are not covered by our tests, and may or
 
 ### Mandatory Libraries
 
-- [Facter](http://www.puppetlabs.com/puppet/related-projects/facter/) 1.7.0 or later
-- [Hiera](/hiera/latest/) 1.0 or later
-- The `json` gem (any modern version).
+-   [Facter](http://www.puppetlabs.com/puppet/related-projects/facter/) 1.7.0 or later
+-   [Hiera](/hiera/latest/) 1.0 or later
+-   The `json` gem (any modern version).
 
 ### Optional Libraries
 
-- The [`rgen` gem](http://ruby-gen.org/downloads) version 0.6.1 or later is required when using Puppet [with `parser = future` enabled](./experiments_future.html).
-- The `msgpack` gem is required if you are using [msgpack serialization](./experiments_msgpack.html).
+-   The [`rgen` gem](http://ruby-gen.org/downloads) version 0.6.1 or later is required when using Puppet [with `parser = future` enabled](./experiments_future.html).
+-   The `msgpack` gem is required if you are using [msgpack serialization](./experiments_msgpack.html).


### PR DESCRIPTION
-   Point links to packaging, package verification, and platform guides
    to appropriate versioned documentation.
-   Align content and structure of Puppet 3.8's platform includes to
    match Puppet 4's.
-   Update PE-specific platform notes.
-   Edit the Puppet 3.8 installation guides.
-   Update and edit Puppet 3.8's system requirements.