### PR TITLE
Update links to avoid unnecessary redirects.

### DIFF
--- a/source/_includes/template/footer_en.html
+++ b/source/_includes/template/footer_en.html
@@ -24,7 +24,7 @@
             <ul>
               <li><a href="//puppet.com/support/customer-support">Get Help</a></li>
               <li><a href="//puppet.com/partners/partner-finder">Find a Partner</a></li>
-              <li><a href="//puppet.com/support/training">Training</a></li>
+              <li><a href="//puppet.com/support-services/training">Training</a></li>
               <li><a href="//puppet.com/download-puppet">Downloads</a></li>
               <li><a href="//puppet.com/sitemap">Site Map</a></li>
             </ul>

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -8,7 +8,7 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{{page.title}} — Documentation — Puppet</title>
     <link rel="alternate" type="application/atom+xml" title="Puppet Documentation Updates" href="https://github.com/puppetlabs/puppet-docs/commits/master.atom" />
-    <link rel="alternate" type="application/atom+xml" title="Puppet Blog Feed" href="http://puppetlabs.com/feed/" />
+    <link rel="alternate" type="application/atom+xml" title="Puppet Blog Feed" href="http://puppet.com/feed/" />
     <link rel='index' title='Puppet Documentation' href='https://docs.puppet.com' />
     <link rel='icon' href='/favicon.ico?v=20160406' />
 

--- a/source/_layouts/homepage.html
+++ b/source/_layouts/homepage.html
@@ -8,7 +8,7 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{{page.title}} — Documentation — Puppet</title>
     <link rel="alternate" type="application/atom+xml" title="Puppet Documentation Updates" href="https://github.com/puppetlabs/puppet-docs/commits/master.atom" />
-    <link rel="alternate" type="application/atom+xml" title="Puppet Blog Feed" href="http://puppetlabs.com/feed/" />
+    <link rel="alternate" type="application/atom+xml" title="Puppet Blog Feed" href="http://puppet.com/feed/" />
     <link rel='index' title='Puppet Documentation' href='https://docs.puppet.com' />
     <link rel='icon' href='/favicon.ico?v=20160406' />
 

--- a/source/index.html
+++ b/source/index.html
@@ -137,21 +137,21 @@ description: "Welcome to the Puppet Documentation Site: Curated documentation fo
                                           <a href="/puppet/latest/reference/lang_updating_manifests.html">Updating 3.x Manifests for Puppet 4.x</a>
                                       </li>
                                       <li>
-                                          <a href="/puppet/4.0/reference/whered_it_go.html">Puppet 4: New File Locations</a>
+                                          <a href="/puppet/latest/reference/whered_it_go.html">Puppet 4: New File Locations</a>
                                       </li>
                                   </ul>
                               </div>
                               <div class="hc-col-list-col col-md-6 col-xs-12">
                                   <ul>
                                       <li>
-                                          <a href="/puppetserver/latest">Puppet Server</a>
+                                          <a href="/puppetserver/latest/">Puppet Server</a>
                                       </li>
                                       <li>
-                                          <a href="/puppetdb/latest">PuppetDB</a>
+                                          <a href="/puppetdb/latest/">PuppetDB</a>
                                       </li>
 
                                       <li>
-                                          <a href="/hiera/latest">Hiera</a>
+                                          <a href="/hiera/latest/">Hiera</a>
                                       </li>
                                       <li>
                                           <a href="/facter/latest/">Facter</a>
@@ -178,18 +178,18 @@ description: "Welcome to the Puppet Documentation Site: Curated documentation fo
             <div class="hc-footer-box">
               <div class="hc-footer-list container-fluid">
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
-                  <li><a href="https://docs.puppet.com/pe/latest/api_index.html" class="hsf-link">Puppet APIs</a></li>
-                  <li><a href="https://docs.puppet.com/pe/latest/pe_versioning.html" class="hsf-link">Software Version Numbering</a></li>
+                  <li><a href="/pe/latest/api_index.html" class="hsf-link">Puppet APIs</a></li>
+                  <li><a href="/pe_versioning.html" class="hsf-link">Software Version Numbering</a></li>
                   <li><a href="/security/" class="hsf-link">Puppet Security Announcements</a></li>
                 </ul>
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
                   <li><a href="https://learn.puppet.com/?_ga=1.126222344.422025574.1442952075" class="hsf-link">Take a Class</a></li>
-                  <li><a href="https://docs.puppet.com/community/community_guidelines.html">Puppet Community Guidelines</a></li>
-                  <li><a href="https://docs.puppet.com/contribute.html" class="hsf-link">Report Errors and Suggest Changes</a></li>
+                  <li><a href="/community/community_guidelines.html">Puppet Community Guidelines</a></li>
+                  <li><a href="/contribute.html" class="hsf-link">Report Errors and Suggest Changes</a></li>
                 </ul>
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
-                  <li><a href="https://docs.puppet.com/download/" class="hsf-link">Download the Docs</a></li>
-                  <li><a href="https://docs.puppet.com/pe/latest/localization.html" class="hsf-link">Contribute to Localization</a></li>
+                  <li><a href="/download/" class="hsf-link">Download the Docs</a></li>
+                  <li><a href="/pe/latest/localization.html" class="hsf-link">Contribute to Localization</a></li>
                 </ul>
               </div>
             </div>

--- a/source/ja/index.html
+++ b/source/ja/index.html
@@ -137,21 +137,21 @@ description: "Welcome to the Puppet Documentation Site: Curated documentation fo
                                           <a href="/puppet/latest/reference/lang_updating_manifests.html">Puppet 4.x向けの3.xマニフェストのアップデート</a>
                                       </li>
                                       <li>
-                                          <a href="/puppet/4.0/reference/whered_it_go.html">Puppet 4: 新しいファイルの保存場所</a>
+                                          <a href="/puppet/latest/reference/whered_it_go.html">Puppet 4: 新しいファイルの保存場所</a>
                                       </li>
                                   </ul>
                               </div>
                               <div class="hc-col-list-col col-md-6 col-xs-12">
                                   <ul>
                                       <li>
-                                          <a href="/puppetserver/latest">Puppet Server</a>
+                                          <a href="/puppetserver/latest/">Puppet Server</a>
                                       </li>
                                       <li>
-                                          <a href="/puppetdb/latest">PuppetDB</a>
+                                          <a href="/puppetdb/latest/">PuppetDB</a>
                                       </li>
 
                                       <li>
-                                          <a href="/hiera/latest">Hiera</a>
+                                          <a href="/hiera/latest/">Hiera</a>
                                       </li>
                                       <li>
                                           <a href="/facter/latest/">Facter</a>
@@ -178,18 +178,18 @@ description: "Welcome to the Puppet Documentation Site: Curated documentation fo
             <div class="hc-footer-box">
               <div class="hc-footer-list container-fluid">
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
-                  <li><a href="https://docs.puppet.com/pe/latest/api_index.html" class="hsf-link">PuppetのAPI</a></li>
-                  <li><a href="https://docs.puppet.com/pe/latest/pe_versioning.html" class="hsf-link">ソフトウェアバージョンの番号付け</a></li>
+                  <li><a href="/pe/latest/api_index.html" class="hsf-link">PuppetのAPI</a></li>
+                  <li><a href="/pe/latest/pe_versioning.html" class="hsf-link">ソフトウェアバージョンの番号付け</a></li>
                   <li><a href="/security/" class="hsf-link">Puppet Security Announcements</a></li>
                 </ul>
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
                   <li><a href="https://learn.puppet.com/?_ga=1.126222344.422025574.1442952075" class="hsf-link">トレーニングコース</a></li>
-                  <li><a href="https://docs.puppet.com/community/community_guidelines.html">Puppetコミュニティのガイドライン</a></li>
-                  <li><a href="https://docs.puppet.com/contribute.html" class="hsf-link">エラーの報告と変更の提案</a></li>
+                  <li><a href="/community/community_guidelines.html">Puppetコミュニティのガイドライン</a></li>
+                  <li><a href="/contribute.html" class="hsf-link">エラーの報告と変更の提案</a></li>
                 </ul>
                 <ul class="hc-footer-list-col col-md-4 col-xs-12">
-                  <li><a href="https://docs.puppet.com/download/" class="hsf-link">マニュアルのダウンロード</a></li>
-                  <li><a href="https://docs.puppet.com/pe/latest/localization.html" class="hsf-link">翻訳へのご協力</a></li>
+                  <li><a href="/download/" class="hsf-link">マニュアルのダウンロード</a></li>
+                  <li><a href="/pe/latest/localization.html" class="hsf-link">翻訳へのご協力</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
-   Update another puppetlabs.com URL, for blog RSS feeds.
-   Point the whereditgo doc link on the homepage to latest, instead of 4.0.
-   Add trailing slashes to avoid unnecessary 301s.
-   Convert fully qualified homepage links pointing to the docs site into relative links.
-   Point links to pages on the main site to their canonical URLs.