### PR TITLE
More narrowly redirect the Windows guide.

### DIFF
--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -299,9 +299,9 @@ rewrite /pe/(latest|201[6-9]\.\d+)/release_notes_security.html            /pe/$1
 rewrite /pe/(latest|201[6-9][\d\.]+)/code_mgr_upgrade.html           /pe/latest/code_mgr_config.html  permanent;
 
 # windows guide switch
-rewrite /windows/index.html /pe/latest/windows_installing.html permanent;
-rewrite /windows/ /pe/latest/windows_installing.html permanent;
-rewrite /windows/troubleshooting.html /pe/latest/windows_troubleshooting.html permanent;
+rewrite ^/windows/index.html /pe/latest/windows_installing.html permanent;
+rewrite ^/windows/ /pe/latest/windows_installing.html permanent;
+rewrite ^/windows/troubleshooting.html /pe/latest/windows_troubleshooting.html permanent;
 
 # faq
 rewrite /guides/faq.html https://puppet.com/product/faq permanent;


### PR DESCRIPTION
This should help with images breaking on pages like https://docs.puppet.com/pe/latest/windows_installing.html, which point to images at URLs containing `/windows/`.