### PR TITLE
Remove invalid Hash type example

### DIFF
--- a/source/puppet/4.5/reference/lang_data_hash.md
+++ b/source/puppet/4.5/reference/lang_data_hash.md
@@ -99,7 +99,6 @@ Position | Parameter        | Data Type | Default Value | Description
 ### Examples
 
 * `Hash` --- matches a hash of any length; any keys must match `Scalar` and any values must match `Data`.
-* `Hash[String]` --- matches any hash that uses only strings as keys.
 * `Hash[Integer, String]` --- matches a hash that uses integers for keys and strings for values.
 * `Hash[Integer, String, 1]` --- same as above, but requires a non-empty hash.
 * `Hash[Integer, String, 1, 8]` --- same as above, but with a maximum size of eight key-value pairs.


### PR DESCRIPTION
As stated above:  "you must specify _both_ key type and value type if you're going to specify one of them"