### PR TITLE
(DOCS-2790) Return 410 status with wiki redirect catch-all

### DIFF
--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -1,5 +1,18 @@
 error_page 404 /files/errors/404.html;
 
+# DOC-2790: page for projects.puppetlabs.com wiki catch-all redirect. Use
+# status 410 to drop those pages from Google.
+error_page 410 /internal/wiki_redirect.html;
+
+location = /wiki_redirect.html {
+  return 410;
+}
+
+location = /internal/wiki_redirect.html {
+  internal;
+  try_files /wiki_redirect.html =404;
+}
+
 #^/(.*) https://docs.puppetlabs.com/$1 permanent;
 rewrite /guides/language_tutorial.html /guides/language_guide.html permanent;
 


### PR DESCRIPTION
This ensures the wiki_redirect.html page never shows up in Google, and anything that redirects to it will fall out of Google too.