### PR TITLE
Mention users may want the Pattern type.

### DIFF
--- a/source/puppet/4.5/reference/lang_data_regexp.md
+++ b/source/puppet/4.5/reference/lang_data_regexp.md
@@ -65,7 +65,7 @@ These are not normal variables, and have some special behaviors:
 
 The [data type][] of regular expressions is `Regexp`.
 
-By default, `Regexp` matches any regular expression value.
+By default, `Regexp` matches any regular expression value. If you are looking for a type that matches strings which match arbitrary regular expressions, see the [Pattern][] type.
 
 You can use parameters to restrict which values `Regexp` will match.
 


### PR DESCRIPTION
The link I added might be wrong. I couldn't test this myself, I think you need to be a Puppet employee:

```
$ bundle exec rake generate
Fetching git://github.com/puppetlabs/marionette-collective.git
Fetching git://github.com/nfagerlund/marionette-collective.git
Fetching git@github.com:puppetlabs/pe-docs-private.git
Cloning into 'git@github_com_puppetlabs_pe-docs-private_git'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
```