### PR TITLE
Modernise usage of facts in language references

### DIFF
--- a/source/puppet/4.6/reference/lang_conditional.markdown
+++ b/source/puppet/4.6/reference/lang_conditional.markdown
@@ -30,10 +30,10 @@ Puppet supports "if" and "unless" statements, case statements, and selectors.
 An "if" statement:
 
 ``` puppet
-if $is_virtual {
+if $facts[is_virtual] {
   warning('Tried to include class ntp on virtual machine; this node may be misclassified.')
 }
-elsif $operatingsystem == 'Darwin' {
+elsif $facts[os][family] == 'Darwin' {
   warning('This NTP module does not yet work on our Mac laptops.')
 }
 else {
@@ -44,7 +44,7 @@ else {
 An "unless" statement:
 
 ``` puppet
-unless $memorysize > 1024 {
+unless $facts[memory][system][totalbytes] > 1073741824 {
   $maxclient = 500
 }
 ```
@@ -52,7 +52,7 @@ unless $memorysize > 1024 {
 A case statement:
 
 ``` puppet
-case $operatingsystem {
+case $facts[os][name] {
   'Solaris':          { include role::solaris }
   'RedHat', 'CentOS': { include role::redhat  }
   /^(Debian|Ubuntu)$/:{ include role::debian  }
@@ -63,7 +63,7 @@ case $operatingsystem {
 A selector:
 
 ``` puppet
-$rootgroup = $osfamily ? {
+$rootgroup = $facts[os][family] ? {
     'Solaris'          => 'wheel',
     /(Darwin|FreeBSD)/ => 'wheel',
     default            => 'root',
@@ -85,11 +85,11 @@ file { '/etc/passwd':
 ### Syntax
 
 ``` puppet
-if $is_virtual {
+if $facts[is_virtual] {
   # Our NTP module is not supported on virtual machines:
   warning( 'Tried to include class ntp on virtual machine; this node may be misclassified.' )
 }
-elsif $operatingsystem == 'Darwin' {
+elsif $facts[os][name] == 'Darwin' {
   warning( 'This NTP module does not yet work on our Mac laptops.' )
 }
 else {
@@ -140,7 +140,7 @@ Static values may also be conditions, although doing this would be pointless.
 If you use the regular expression match operator in a condition, any captures from parentheses in the pattern will be available inside the associated code block as numbered variables (`$1, $2`, etc.), and the entire match will be available as `$0`:
 
 ``` puppet
-if $hostname =~ /^www(\d+)\./ {
+if $trusted[certname] =~ /^www(\d+)\./ {
   notice("Welcome to web server number $1")
 }
 ```
@@ -160,7 +160,7 @@ These are not normal variables, and have some special behaviors:
 ### Syntax
 
 ``` puppet
-unless $memorysize > 1024 {
+unless $facts[memory][system][totalbytes] > 1073741824 {
   $maxclient = 500
 }
 ```
@@ -210,7 +210,7 @@ Like "if" statements, **case statements** choose one of several blocks of arbitr
 ### Syntax
 
 ``` puppet
-case $operatingsystem {
+case $facts[os][name] {
   'Solaris':          { include role::solaris } # apply the solaris class
   'RedHat', 'CentOS': { include role::redhat  } # apply the redhat class
   /^(Debian|Ubuntu)$/:{ include role::debian  } # apply the debian class
@@ -278,7 +278,7 @@ The value of a `case` expression is the value of the last expression in the exec
 If you use regular expression cases, any captures from parentheses in the pattern will be available inside the associated code block as numbered variables (`$1, $2`, etc.), and the entire match will be available as `$0`:
 
 ``` puppet
-case $hostname {
+case $trusted[hostname] {
   /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
@@ -325,7 +325,7 @@ Selectors can be used wherever a **value** is expected. This includes:
 Selectors resemble a cross between a case statement and the ternary operator found in other languages.
 
 ``` puppet
-$rootgroup = $osfamily ? {
+$rootgroup = $facts[os][family] ? {
     'Solaris'          => 'wheel',
     /(Darwin|FreeBSD)/ => 'wheel',
     default            => 'root',
@@ -338,7 +338,7 @@ file { '/etc/passwd':
 }
 ```
 
-In the example above, the value of `$rootgroup` is determined using the value of `$osfamily`.
+In the example above, the value of `$rootgroup` is determined using the value of `$facts[os][family]`.
 
 The general form of a selector is:
 
@@ -383,7 +383,7 @@ A case can be any expression that resolves to a value. (This includes literal va
 If you use regular expression cases, any captures from parentheses in the pattern will be available inside the associated value as numbered variables (`$1, $2`, etc.), and the entire match will be available as `$0`:
 
 ``` puppet
-$system = $operatingsystem ? {
+$system = $facts[os][name] ? {
   /(RedHat|Debian)/ => "our system is ${1}",
   default           => "our system is unknown",
 }
@@ -393,4 +393,3 @@ These are not normal variables, and have some special behaviors:
 
 * The values of the numbered variables do not persist outside the value associated with the pattern that set them.
 * In nested conditionals, each conditional has its own set of values for the set of numbered variables. At the end of an interior statement, the numbered variables are reset to their previous values for the remainder of the outside statement. (This causes conditional statements to act like [local scopes][local], but only with regard to the numbered variables.)
-

--- a/source/puppet/4.6/reference/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.6/reference/lang_facts_and_builtin_vars.markdown
@@ -24,12 +24,13 @@ canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
 [strings]: ./lang_data_string.html
 [datatypes]: ./lang_data.html
 [qualified_var_names]: ./lang_variables.html#accessing-out-of-scope-variables
+[hashaccess]: ./lang_data_hash.html#accessing-values
 
 Before requesting a [catalog][] (or compiling one with `puppet apply`), Puppet will collect system information with [Facter][]. Puppet receives this information as **facts,** which are **pre-set variables** you can use anywhere in your manifests.
 
 Puppet also pre-sets some **other special variables** which behave a lot like facts.
 
-This page describes how to use facts, and lists all of the special variables added by Puppet.
+This page describes how to use facts and lists all of the special variables added by Puppet.
 
 ## Which facts?
 
@@ -100,14 +101,14 @@ if $osfamily == 'redhat' {
 >
 > Since Puppet 3.0, `$::fact` has never been strictly necessary, but some people still use it to alert readers that they're using a top-scope variable, as described above.
 
-### The `$facts['fact_name']` hash
+### The `$facts[fact_name]` hash
 
-Facts also appear in a `$facts` hash. They can be accessed in manifests as `$facts['fact_name']`. The variable name `$facts` is reserved, so local scopes cannot re-use it.
+Facts also appear in a `$facts` hash. They can be accessed in manifests as `$facts[fact_name]`. The variable name `$facts` is reserved, so local scopes cannot re-use it. Structured facts show up as a nested structure inside the `$facts` namespace, and can be accessed using Puppet's normal [hash access syntax][hashaccess]. Due to ambiguity with function invocation, the dot-separated access syntax that is available at the Facter command line is not available in manifests.
 
-Example, with the osfamily fact:
+Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['osfamily'] == 'redhat' {
+if $facts[os][family] == 'redhat' {
   # ...
 }
 ```


### PR DESCRIPTION
Prior to this commit, the example code around conditionals and the section on facts did not make use of structured facts.

This commit updates a couple of sections to show examples with modern structured-fact equivalents of old single value facts. It also describes how to access deeply nested fact values using hash syntax.

(Potentially controversial: I've opted to not quote hash keys, because doing so on 'puppet apply' leads to backslash-itis, and I find it visually noisy. AFAIK it is not semantically necessary but this might be making a unilateral style guide call that's not 100% OK)