### PR TITLE
Add PuppetConf link and adjust header margin to docs site

### DIFF
--- a/source/_includes/template/header_en.html
+++ b/source/_includes/template/header_en.html
@@ -4,6 +4,7 @@
         <div id="navbar-top" class="row navbar-collapse collapse">
           <ul class="nav navbar-nav">
             <li><a href="//puppet.com" class="home">Home</a></li>
+            <li><a href="//puppet.com/puppetconf" class="offsite">PuppetConf</a></li>
             <li><a href="//forge.puppet.com" class="offsite forge">Forge</a></li>
             <li class="active"><a href="/" class="offsite docs">Docs</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">Learn</a></li>

--- a/source/_includes/template/header_fr.html
+++ b/source/_includes/template/header_fr.html
@@ -5,6 +5,7 @@
           <ul class="nav navbar-nav">
             <li><a href="//puppet.com" class="home">Accueil</a></li>
             <li><a href="//forge.puppet.com" class="offsite forge">Forge</a></li>
+            <li><a href="//puppet.com/puppetconf" class="offsite">PuppetConf</a></li>
             <li class="active"><a href="/" class="offsite docs">Documents</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">Apprentissage</a></li>
             <li class="navbar-gap"><a href="//puppet.com/support">Support &amp; Services</a></li>

--- a/source/_includes/template/header_ja.html
+++ b/source/_includes/template/header_ja.html
@@ -5,6 +5,7 @@
           <ul class="nav navbar-nav">
             <li><a href="//puppet.com" class="home">ホーム</a></li>
             <li><a href="//forge.puppet.com" class="offsite forge">Forge</a></li>
+            <li><a href="//puppet.com/puppetconf" class="offsite">PuppetConf</a></li>
             <li class="active"><a href="/" class="offsite docs">マニュアル</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">トレーニング</a></li>
             <li class="navbar-gap"><a href="//puppet.com/support">サポート</a></li>

--- a/source/files/stylesheets/adjustments.css
+++ b/source/files/stylesheets/adjustments.css
@@ -98,6 +98,13 @@ img#search-icon {
 
 }
 
+@media screen and (max-width: 992px) {
+  /* Style wide nav options */
+  div#navbar-container div#navbar-top.row {
+    margin-left: 1.25rem;
+  }
+}
+
 @media screen and (max-width: 767px) {
   img#search-icon {
     position: absolute;


### PR DESCRIPTION
-   Add a PuppetConf link to each language's header.
-   Reduce the left margin on the header on medium (992px and smaller) viewports to avoid awkward wrapping.