### PR TITLE
Fix incorrect link to environment isolation doc

### DIFF
--- a/source/puppet/4.6/reference/_puppet_toc.html
+++ b/source/puppet/4.6/reference/_puppet_toc.html
@@ -501,7 +501,7 @@
     <ul>
       <li><a href="{{ puppet_dir }}/experiments_overview.html">Overview</a></li>
       <li><a href="{{ puppet_dir }}/experiments_msgpack.html">Msgpack support</a></li>
-      <li><a href="{{ puppet_dir }}/environmental_isolation.html">Environmental isolation</a></li>
+      <li><a href="{{ puppet_dir }}/environment_isolation.html">Environment isolation</a></li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
The current link is 404.