### PR TITLE
(maint) Update docs to use new signing key

### DIFF
--- a/source/guides/puppetlabs_package_verification.markdown
+++ b/source/guides/puppetlabs_package_verification.markdown
@@ -35,31 +35,32 @@ Before you can verify signatures, you must import the Puppet Labs public key and
 
 To import the release signing key, run:
 
-    $ gpg --recv-key 1054b7a24bd6ec30
-    gpg: requesting key 4BD6EC30 from hkp server pool.sks-keyservers.net
-    gpg: key 4BD6EC30: public key "Puppet Labs Release Key " imported
+    $ gpg --recv-key 7F438280EF8D349F
+    gpg: requesting key EF8D349F from hkp server pool.sks-keyservers.net
+    gpg: key EF8D349F: public key "Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>" imported
     gpg: no ultimately trusted keys found
     gpg: Total number processed: 1
     gpg:               imported: 1  (RSA: 1)
 
-The key is also [available here](http://pool.sks-keyservers.net:11371/pks/lookup?op=get&search=0x1054B7A24BD6EC30).
+The key is also [available here](http://pool.sks-keyservers.net:11371/pks/lookup?op=get&search=0x7F438280EF8D349F).
 
 ### Verify the Fingerprint
 
 The fingerprint of the Puppet Labs release signing key is **`47B3 20EB 4C7C 375A A9DA  E1A0 1054 B7A2 4BD6 EC30`**. Run the following and ensure the fingerprints match:
 
-    $ gpg --list-key --fingerprint 1054b7a24bd6ec30
-      pub   4096R/4BD6EC30 2010-07-10 [expires: 2016-07-08]
-            Key fingerprint = 47B3 20EB 4C7C 375A A9DA  E1A0 1054 B7A2 4BD6 EC30
-      uid                  Puppet Labs Release Key (Puppet Labs Release Key)
+    $ gpg --list-key --fingerprint 7F438280EF8D349F
+      pub   4096R/EF8D349F 2016-08-18 [expires: 2021-08-17]
+            Key fingerprint = 6F6B 1550 9CF8 E59E 6E46  9F32 7F43 8280 EF8D 349F
+      uid                  Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>
+      sub   4096R/656674AE 2016-08-18 [expires: 2021-08-17]
 
 ### Verify a Source Tarball
 
 To verify a source tarball, you must download both the tarball itself and the corresponding `.asc` file. Then, run:
 
     $ gpg --verify puppet-3.2.2.tar.gz.asc puppet-3.2.2.tar.gz
-      gpg: Signature made Tue 18 Jun 2013 10:05:25 AM PDT using RSA key ID 4BD6EC30
-      gpg: Good signature from "Puppet Labs Release Key (Puppet Labs Release Key) "
+      gpg: Signature made Tue 18 Jun 2013 10:05:25 AM PDT using RSA key ID EF8D349F
+      gpg: Good signature from "Puppet, Inc. Release Key (Puppet, Inc. Release Key) "
 
 If you have not taken the necessary steps to build a trust path, through the web of trust, to one of the signatures on the release key, you will see a warning similar to the following when you verify the signature:
 


### PR DESCRIPTION
We're switching out the gpg key that we're using to sign packages. This
commit updates the docs to reference this new key rather than the old
one