### PR TITLE
Clarify Defined Resource Type Example

### DIFF
--- a/source/puppet/4.7/reference/lang_defined_types.markdown
+++ b/source/puppet/4.7/reference/lang_defined_types.markdown
@@ -36,27 +36,28 @@ Defines can be used as simple macros or as a lightweight way to develop fairly s
 
 You can use a `define` statement to create a new defined resource type.
 
-``` puppet
+```puppet
 # /etc/puppetlabs/puppet/modules/apache/manifests/vhost.pp
 define apache::vhost (
-  integer $port, 
-  string[1] $docroot, 
-  string[1] $servername = $title, 
-  string $vhost_name = '*'
+  Integer $port,
+  String[1] $docroot,
+  String[1] $servername = $title,
+  String $vhost_name = '*',
 ) {
-  include apache # contains package['httpd'] and service['httpd']
-  include apache::params # contains common config settings
+  include ::apache # contains package['httpd'] and service['httpd']
+  include ::apache::params # contains common config settings
 
   $vhost_dir = $apache::params::vhost_dir
 
   # the template used below can access all of the parameters and variable from above.
   file { "${vhost_dir}/${servername}.conf":
-    content => template('apache/vhost-default.conf.erb'),
+    ensure  => file,
     owner   => 'www',
     group   => 'www',
-    mode    => '644',
-    require => package['httpd'],
-    notify  => service['httpd'],
+    mode    => '0644',
+    content => template('apache/vhost-default.conf.erb'),
+    require => Package['httpd'],
+    notify  => Service['httpd'],
   }
 }
 ```

--- a/source/puppet/4.7/reference/lang_defined_types.markdown
+++ b/source/puppet/4.7/reference/lang_defined_types.markdown
@@ -38,18 +38,25 @@ You can use a `define` statement to create a new defined resource type.
 
 ``` puppet
 # /etc/puppetlabs/puppet/modules/apache/manifests/vhost.pp
-define apache::vhost (Integer $port, String[1] $docroot, String[1] $servername = $title, String $vhost_name = '*') {
-  include apache # contains Package['httpd'] and Service['httpd']
+define apache::vhost (
+  integer $port, 
+  string[1] $docroot, 
+  string[1] $servername = $title, 
+  string $vhost_name = '*'
+) {
+  include apache # contains package['httpd'] and service['httpd']
   include apache::params # contains common config settings
+
   $vhost_dir = $apache::params::vhost_dir
+
+  # the template used below can access all of the parameters and variable from above.
   file { "${vhost_dir}/${servername}.conf":
     content => template('apache/vhost-default.conf.erb'),
-      # This template can access all of the parameters and variables from above.
     owner   => 'www',
     group   => 'www',
     mode    => '644',
-    require => Package['httpd'],
-    notify  => Service['httpd'],
+    require => package['httpd'],
+    notify  => service['httpd'],
   }
 }
 ```


### PR DESCRIPTION
The current example for defined resource types is unclear, due to the
coding style used.

In general, listing all defined type parameters on one line is
considered poor style and very difficult to read.

In addition, comments in-line in a resource, between parameters, are
also viewed as poor style, and make the resource harder to read,
especially for new users who are just learning.

Hopefully this refactor clarifies the example.

Even as an "expert" Puppet user, I found the original fairly hard to
read.