### PR TITLE
Fix typo in language docs (esepecially -> especially)

### DIFF
--- a/source/puppet/3.7/reference/future_lang_data_abstract.md
+++ b/source/puppet/3.7/reference/future_lang_data_abstract.md
@@ -221,7 +221,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/3.8/reference/future_lang_data_abstract.md
+++ b/source/puppet/3.8/reference/future_lang_data_abstract.md
@@ -221,7 +221,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.1/reference/lang_data_abstract.md
+++ b/source/puppet/4.1/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.2/reference/lang_data_abstract.md
+++ b/source/puppet/4.2/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.3/reference/lang_data_abstract.md
+++ b/source/puppet/4.3/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.4/reference/lang_data_abstract.md
+++ b/source/puppet/4.4/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.5/reference/lang_data_abstract.md
+++ b/source/puppet/4.5/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.6/reference/lang_data_abstract.md
+++ b/source/puppet/4.6/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 

--- a/source/puppet/4.7/reference/lang_data_abstract.md
+++ b/source/puppet/4.7/reference/lang_data_abstract.md
@@ -263,7 +263,7 @@ Note that it doesn't match `default` or resource references.
 
 It takes no parameters.
 
-`Data` is esepecially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+`Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
 
 ### `Collection`
 


### PR DESCRIPTION
This commit fixes a minor typo in the language documentation