### PR TITLE
Add type aliases documentation

### DIFF
--- a/source/puppet/4.7/reference/_puppet_toc.html
+++ b/source/puppet/4.7/reference/_puppet_toc.html
@@ -258,6 +258,7 @@
           <li><a href="{{ puppet_dir }}/lang_data_default.html">Default</a></li>
           <li><a href="{{ puppet_dir }}/lang_data_type.html">Data type syntax</a></li>
           <li><a href="{{ puppet_dir }}/lang_data_abstract.html">Abstract data types</a></li>
+          <li><a href="{{ puppet_dir }}/lang_data_aliases.html">Type aliases</a></li>
         </ul>
       </li>
       <li><strong>Templates</strong>

--- a/source/puppet/4.7/reference/lang_data.md
+++ b/source/puppet/4.7/reference/lang_data.md
@@ -45,3 +45,6 @@ For special abstract data types, which you can use to do more sophisticated or p
 
 * [Abstract Data Types](./lang_data_abstract.html)
 
+For data type aliases that can be defined by modules to refer to existing data types, see:
+
+* [Type Aliases](./lang_data_aliases.html)

--- a/source/puppet/4.7/reference/lang_data_aliases.md
+++ b/source/puppet/4.7/reference/lang_data_aliases.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: "Language: Data types: Type aliases"
+canonical: "/puppet/latest/reference/lang_data_aliases.html"
+---
+
+[built-in data types]: ./lang_data.html
+[modules]: ./modules_fundamentals.html
+[class parameters]: ./lang_classes.html#class-parameters-and-variables
+[environments]: ./environments.html
+[data type]: ./lang_data_type.html
+
+In addition to Puppet's [built-in data types][], [modules][] may define their own **type aliases** to shorten and avoid duplication when using complex data types (e.g. variants, enums).
+
+These aliases may be used in place of data types in any location --- [class parameters][], type comparisons and so on. Type aliases may also be used by other modules, allowing shared data types to be changed easily. The aliases defined will work identically to the assigned data type in all respects.
+
+## Defining type aliases
+
+### Syntax
+
+You can use a `type` statement to define a new type alias:
+
+``` puppet
+type MyModule::Foo = Array[Integer]
+```
+
+This defines a new data type called `MyModule::Foo` which is equivalent to the data type `Array[Integer]`.
+
+The general form of a type statement is:
+
+* The `type` keyword
+* The name of the type alias
+* An equals (`=`) sign
+* A [data type][] that the type alias will be equivalent to
+
+### Naming
+
+Type alias names must use namespace (prefix) when loaded from a module or environment.
+
+When loaded from the module `my_module`, the alias must be defined in the `MyModule::` namespace.
+
+When loaded from an environment, the alias must be in the fixed `Environment::` namespace.
+
+### Location
+
+Type aliases must be stored in [modules][] or [environments][]. Puppet is **automatically aware** of type aliases in modules and environments, and can autoload them by name.
+
+Type aliases must be stored in their module's or environment's `types/` directory (see [Module Fundamentals][modules]) with one alias per file, and each filename must reflect the lower case name of its alias. Underscores should not be used to separate words in a filename; the file for `MyType` should be `mytype.pp`, not `my_type.pp`.
+
+### Assigned data type
+
+Any [data type][] may be assigned to the type alias, even the alias being defined (creating a _self recursive type_).

--- a/source/puppet/4.7/reference/modules_fundamentals.markdown
+++ b/source/puppet/4.7/reference/modules_fundamentals.markdown
@@ -21,6 +21,7 @@ canonical: "/puppet/latest/reference/modules_fundamentals.html"
 [forge]: http://forge.puppetlabs.com
 [file_function]: ./function.html#file
 [reserved names]: ./lang_reserved.html
+[data type alias]: ./lang_data_aliases.html
 
 **Modules** are self-contained bundles of code and data. You can download pre-built modules from [the Puppet Forge][forge] or you can write your own modules.
 
@@ -75,6 +76,7 @@ On disk, a module is simply a directory tree with a specific, predictable struct
     * `facts.d`
     * `examples`
     * `spec`
+    * `types`
 
 > Note: As of Puppet 4.5, using [`puppet module generate`](#writing-modules) to create your module skeleton creates an `examples` directory instead of the deprecated `tests` directory.
 
@@ -101,6 +103,9 @@ This example module, `my_module`, shows the standard module layout in more detai
         * `init.pp`
         * `other_example.pp` --- Major use cases should have an example.
     * `spec/` --- Contains spec tests for any plugins in the lib directory.
+    * `types/` --- Contains [data type alias][] definitions.
+        * `foo.pp` --- Contains an alias called `MyModule::Foo`
+        * `otherexample.pp` --- Contains an alias called `MyModule::OtherExample`
 
 Each of the module's subdirectories has a specific function, as follows.
 


### PR DESCRIPTION
Available since Puppet 4.4, so could be copied down to that (and linked from its release notes?) if you wish.

See https://github.com/puppetlabs/puppet-specifications/blob/master/language/expressions.md#type-alias-expression for the specs.
