### PR TITLE
Fix typos in `environment_isolation.md` files

### DIFF
--- a/source/puppet/4.6/reference/environment_isolation.md
+++ b/source/puppet/4.6/reference/environment_isolation.md
@@ -24,9 +24,9 @@ The result of the compilation (the catalog) will be identical irrespective of us
 
 ## Generation of Metadata
 
-A new command-line utility `generate type` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
+A new command-line utility `generate types` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
 
-Each time `generate type` is executed it will sync the files in the `.resource_types` directory such that:
+Each time `generate types` is executed it will sync the files in the `.resource_types` directory such that:
 * Types that have been removed in modules are removed from `resource_types`.
 * Types that are added are added.
 * Types that are unchanged (based on timestamp) are kept as is.
@@ -42,7 +42,7 @@ A `--force` flag can be used to make `generate` overwrite all generated data for
 
 The generated metadata is using another experimental feature in Puppet called Pcore. Pcore is the name we have given to the Puppet type system including new extensions that make it possible to describe objects in the Puppet language and to map them to implementation types (for now Ruby classes, later other possible runtime languages).
 
-As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate type --environment <env> --force` should be executed).
+As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate types --environment <env> --force` should be executed).
 
 The generated Pcore uses the `.pp` extension because it is regular Puppet logic that is parsed by the regular parser and evaluated by the regular evaluator. The expressions used in the generated files should however not be used in regular manifests.
 
@@ -50,13 +50,13 @@ At this time, the generated Pcore is undocumented and is considered a private im
 
 ## Opting in to using this experimental feature
 
-Opting in to using the new feature is done by running the `generate type` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
+Opting in to using the new feature is done by running the `generate types` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
 
 Opting out is performed by removing the `<env_root>/.resource_types` directory and its content.
 
 ## Suggested workflow
 
-It is suggested that a run of `generate type --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
+It is suggested that a run of `generate types --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
 
 ## The future of this experimental feature
 

--- a/source/puppet/4.7/reference/environment_isolation.md
+++ b/source/puppet/4.7/reference/environment_isolation.md
@@ -24,9 +24,9 @@ The result of the compilation (the catalog) will be identical irrespective of us
 
 ## Generation of Metadata
 
-A new command-line utility `generate type` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
+A new command-line utility `generate types` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
 
-Each time `generate type` is executed it will sync the files in the `.resource_types` directory such that:
+Each time `generate types` is executed it will sync the files in the `.resource_types` directory such that:
 * Types that have been removed in modules are removed from `resource_types`.
 * Types that are added are added.
 * Types that are unchanged (based on timestamp) are kept as is.
@@ -42,7 +42,7 @@ A `--force` flag can be used to make `generate` overwrite all generated data for
 
 The generated metadata is using another experimental feature in Puppet called Pcore. Pcore is the name we have given to the Puppet type system including new extensions that make it possible to describe objects in the Puppet language and to map them to implementation types (for now Ruby classes, later other possible runtime languages).
 
-As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate type --environment <env> --force` should be executed).
+As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate types --environment <env> --force` should be executed).
 
 The generated Pcore uses the `.pp` extension because it is regular Puppet logic that is parsed by the regular parser and evaluated by the regular evaluator. The expressions used in the generated files should however not be used in regular manifests.
 
@@ -50,13 +50,13 @@ At this time, the generated Pcore is undocumented and is considered a private im
 
 ## Opting in to using this experimental feature
 
-Opting in to using the new feature is done by running the `generate type` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
+Opting in to using the new feature is done by running the `generate types` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
 
 Opting out is performed by removing the `<env_root>/.resource_types` directory and its content.
 
 ## Suggested workflow
 
-It is suggested that a run of `generate type --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
+It is suggested that a run of `generate types --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
 
 ## The future of this experimental feature
 

--- a/source/puppet/4.8/reference/environment_isolation.md
+++ b/source/puppet/4.8/reference/environment_isolation.md
@@ -24,9 +24,9 @@ The result of the compilation (the catalog) will be identical irrespective of us
 
 ## Generation of Metadata
 
-A new command-line utility `generate type` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
+A new command-line utility `generate types` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
 
-Each time `generate type` is executed it will sync the files in the `.resource_types` directory such that:
+Each time `generate types` is executed it will sync the files in the `.resource_types` directory such that:
 * Types that have been removed in modules are removed from `resource_types`.
 * Types that are added are added.
 * Types that are unchanged (based on timestamp) are kept as is.
@@ -42,7 +42,7 @@ A `--force` flag can be used to make `generate` overwrite all generated data for
 
 The generated metadata is using another experimental feature in Puppet called Pcore. Pcore is the name we have given to the Puppet type system including new extensions that make it possible to describe objects in the Puppet language and to map them to implementation types (for now Ruby classes, later other possible runtime languages).
 
-As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate type --environment <env> --force` should be executed).
+As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate types --environment <env> --force` should be executed).
 
 The generated Pcore uses the `.pp` extension because it is regular Puppet logic that is parsed by the regular parser and evaluated by the regular evaluator. The expressions used in the generated files should however not be used in regular manifests.
 
@@ -50,13 +50,13 @@ At this time, the generated Pcore is undocumented and is considered a private im
 
 ## Opting in to using this experimental feature
 
-Opting in to using the new feature is done by running the `generate type` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
+Opting in to using the new feature is done by running the `generate types` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
 
 Opting out is performed by removing the `<env_root>/.resource_types` directory and its content.
 
 ## Suggested workflow
 
-It is suggested that a run of `generate type --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
+It is suggested that a run of `generate types --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
 
 ## The future of this experimental feature
 


### PR DESCRIPTION
The command is `puppet generate types` not `puppet generate type`.
https://github.com/puppetlabs/puppet/blob/4.6.0/lib/puppet/face/generate.rb#L11