### PR TITLE
Update nav and redirects to add a product.conf doc to Server

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -247,7 +247,7 @@ documents:
     my_versions:
       facter: 3.5
       hiera: 3.2
-      puppetserver: 2.6
+      puppetserver: 2.7
   /puppet/4.7/reference:
     doc: puppet
     version: 4.7
@@ -424,6 +424,18 @@ documents:
     version: 1
     nav: /_includes/hiera1.html
 
+  /puppetserver/2.7:
+    doc: puppetserver
+    version: 2.7
+    nav: /puppet/4.8/reference/_puppet_toc.html
+    external_source:
+      repo: git://github.com/puppetlabs/puppetserver.git
+      commit: 4b9f214382e690a8c62317fab3a499d79694aae7
+      subdirectory: documentation
+    my_versions:
+      puppet: 4.8
+      facter: 3.5
+      hiera: 3.2
   /puppetserver/2.6:
     doc: puppetserver
     version: 2.6

--- a/source/nginx_rewrite.conf
+++ b/source/nginx_rewrite.conf
@@ -381,3 +381,6 @@ rewrite ^/guides/rest_api.html /puppet/latest/reference/http_api/http_api_index.
 # Redirect guides related to Puppet Collections and Puppet 3.8 repositories
 rewrite ^/guides/puppetlabs_package_verification.html /puppet/latest/reference/puppet_collections.html permanent;
 rewrite ^/guides/puppetlabs_package_repositories.html /puppet/latest/reference/puppet_collections.html permanent;
+
+# Redirect product.conf nav links in previous versions to Server 2.7 release note.
+rewrite ^/puppetserver/(2\.[0-6]|1\.\d)/config_file_product.html /puppetserver/2.7/release_notes.html#new-feature-disable-update-checking-and-telemetry-data-collection permanent;

--- a/source/puppet/4.8/reference/_puppet_toc.html
+++ b/source/puppet/4.8/reference/_puppet_toc.html
@@ -100,6 +100,7 @@
           <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">global.conf: Trapperkeeper settings</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">ca.conf: CA service access control (deprecated)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP header (deprecated)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_product.html">product.conf: Configuring Product-level Interactions (optional)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging level and location</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced logging configuration</a></li>
           <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap upgrade notes</a></li>


### PR DESCRIPTION
~~PLEASE DO NOT MERGE YET. This depends on a decision being made on puppetserver PR #1260. Because of the narrow proposed time window of go/no-go and release, I'm filing this now in case it's approved.~~

-   Adds a link to the Puppet 4.8 navigation pointing to a proposed new `product.conf` file in Puppet Server (see discussion on puppetserver PR #1260).
-   Adds a redirect to point people who stumble on past versions of the page via the version switcher to the release note where the feature is introduced.