### PR TITLE
(layout) Add download docs link to header

### DIFF
--- a/source/_includes/template/header_en.html
+++ b/source/_includes/template/header_en.html
@@ -8,9 +8,10 @@
             <li><a href="//forge.puppet.com" class="offsite forge">Forge</a></li>
             <li class="active"><a href="/" class="offsite docs">Docs</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">Learn</a></li>
-            <li class="navbar-gap"><a href="//puppet.com/support">Support & services</a></li>
+
+            <li class="navbar-gap"><a href="/download/">Download docs</a></li>
+            <li><a href="//puppet.com/support">Support &amp; services</a></li>
             <li><a href="//puppet.com/contact">Contact us</a></li>
-            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/_includes/template/header_en.html
+++ b/source/_includes/template/header_en.html
@@ -10,6 +10,7 @@
             <li><a href="//learn.puppet.com" class="offsite learn">Learn</a></li>
             <li class="navbar-gap"><a href="//puppet.com/support">Support & services</a></li>
             <li><a href="//puppet.com/contact">Contact us</a></li>
+            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/_includes/template/header_fr.html
+++ b/source/_includes/template/header_fr.html
@@ -8,9 +8,10 @@
             <li><a href="//puppet.com/puppetconf" class="offsite">PuppetConf</a></li>
             <li class="active"><a href="/" class="offsite docs">Documents</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">Apprentissage</a></li>
-            <li class="navbar-gap"><a href="//puppet.com/support">Support &amp; Services</a></li>
+
+            <li class="navbar-gap"><a href="/download/">Download docs</a></li>
+            <li><a href="//puppet.com/support">Support &amp; services</a></li>
             <li><a href="//puppet.com/contact">Nous contacter</a></li>
-            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/_includes/template/header_fr.html
+++ b/source/_includes/template/header_fr.html
@@ -10,6 +10,7 @@
             <li><a href="//learn.puppet.com" class="offsite learn">Apprentissage</a></li>
             <li class="navbar-gap"><a href="//puppet.com/support">Support &amp; Services</a></li>
             <li><a href="//puppet.com/contact">Nous contacter</a></li>
+            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/_includes/template/header_ja.html
+++ b/source/_includes/template/header_ja.html
@@ -10,6 +10,7 @@
             <li><a href="//learn.puppet.com" class="offsite learn">トレーニング</a></li>
             <li class="navbar-gap"><a href="//puppet.com/support">サポート</a></li>
             <li><a href="//puppet.com/contact">お問い合わせ</a></li>
+            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/_includes/template/header_ja.html
+++ b/source/_includes/template/header_ja.html
@@ -8,9 +8,10 @@
             <li><a href="//puppet.com/puppetconf" class="offsite">PuppetConf</a></li>
             <li class="active"><a href="/" class="offsite docs">マニュアル</a></li>
             <li><a href="//learn.puppet.com" class="offsite learn">トレーニング</a></li>
-            <li class="navbar-gap"><a href="//puppet.com/support">サポート</a></li>
+
+            <li class="navbar-gap"><a href="/download/">Download docs</a></li>
+            <li><a href="//puppet.com/support">サポート</a></li>
             <li><a href="//puppet.com/contact">お問い合わせ</a></li>
-            <li><a href="/download/">Download docs</a></li>
           </ul>
         </div><!--/.nav-collapse -->
 

--- a/source/files/stylesheets/adjustments.css
+++ b/source/files/stylesheets/adjustments.css
@@ -66,7 +66,7 @@ img#search-icon {
   }
 
   li.navbar-gap {
-    margin-left: 3.75rem;
+    margin-left: 3.25rem;
   }
 
   ul.navbar-nav li:last-child a {


### PR DESCRIPTION
![screen shot 2016-11-21 at 5 36 33 pm](https://cloud.githubusercontent.com/assets/484309/20507692/209183da-b011-11e6-9e09-6803e5b09595.png)

This adjusts the gap between the two groups of nav items, because there was
a 'dead spot' as you shrank the window where the line would wrap onto two
lines.

Still need appropriate translations for fr and ja.