### PR TITLE
revised environment isolation pages for 4.8 and 4.9

### DIFF
--- a/source/puppet/4.8/_puppet_toc.html
+++ b/source/puppet/4.8/_puppet_toc.html
@@ -97,6 +97,7 @@
     * [Assigning environments to nodes]({{puppet}}/environments_assigning.html)
     * [Suggestions for use]({{puppet}}/environments_suggestions.html)
     * [Limitations of environments]({{puppet}}/environments_limitations.html)
+    * [Environment isolation]({{puppet}}/environment_isolation.html)
     * [Environments and Puppet's HTTPS interface]({{puppet}}/environments_https.html)
 * **Modules**
     * [Fundamentals]({{puppet}}/modules_fundamentals.html)
@@ -354,6 +355,5 @@
 * **Experimental features**
     * [Overview]({{puppet}}/experiments_overview.html)
     * [Msgpack support]({{puppet}}/experiments_msgpack.html)
-    * [Environment isolation]({{puppet}}/environment_isolation.html)
 
 {% endmd %}

--- a/source/puppet/4.8/environment_isolation.md
+++ b/source/puppet/4.8/environment_isolation.md
@@ -1,63 +1,95 @@
 ---
 layout: default
-title: "Environment Isolation"
-canonical: "/puppet/latest/reference/environment_isolation.html"
+title: "Isolating resources in multiple environments"
+canonical: "/puppet/latest/environment_isolation.html"
+description: "Generating metadata to isolate resources in environments in Puppet"
 ---
 
+[code_mgr_env]: {{pe}}/code_mgr.html#environment-isolation-metadata
 
-Beginning in Puppet 4.6.0, there is a new experimental feature aiming to solve a problem with the isolation of multiple versions of the same Ruby resource type implementation being used in different environments. This is a problem because the Ruby resource type implementations are constructed in a way that binds Ruby constructs to constants and these bindings are global in the Ruby runtime. Thus, the first loaded version of a resource type implementation will win and subsequent requests to compile in other environments will get the first loaded version.
 
-There are other environment isolation cases that this new experimental feature does not solve (external helper logic, different versions of required gems, and similar).
+If you have multiple environments, environment isolation prevents resource types from leaking between your various environments. To use environment isolation, you'll generate metadata files that Puppet can use in place of the normal Ruby resource type implementations.
 
-## How it works
+In open source Puppet, enable environment isolation with the `generate types` command. In Puppet Enterprise, environment isolation is automatically provided by [Code Manager][code_mgr_env]. Environment isolation is not supported for r10k with Puppet Enterprise.
 
-The experimental feature consists of two parts:
+## Preventing resource types leaks in multiple environments
 
-* A utility that generates loadable metadata describing the resource type implementation.
-* The ability to load and use this metadata instead of the Ruby resource type implementation when compiling.
+If you use multiple environments with Puppet, you might encounter issues with multiple versions of the same resource type leaking between your various environments. This doesn't happen with Puppet's built-in resource types, but it can happen with any other resource types.
 
-### The agent logic is unchanged
+This problem occurs because Ruby resource type bindings are global in the Ruby runtime. Thus, the first loaded version of a Ruby resource type takes priority, and then subsequent requests to compile in other environments get that first loaded version.
 
-The result of the compilation (the catalog) will be identical irrespective of using the metadata based version of the resource type or the Ruby implementation. The agent acting on the catalog continues to use the Ruby based implementation. Isolation is not a problem there because it is using one and only one version of the logic.
+Environment isolation solves this issue by generating and using metadata that describes the resource type implementation, instead of using the Ruby resource type implementation when compiling catalogs. 
 
-(Note: It is untested what happens when an agent is changed to be in different environments and the agent runs as a daemon; if it does not spawn new processes it would be subject to isolation problems).
+> **Note**: Other environment isolation cases, such as external helper logic issues or varying versions of required gems, are not solved with the `generate types` command.
 
-## Generation of Metadata
+### Agent logic is unchanged
 
-A new command-line utility `generate types` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
+Catalog compilation results are exactly the same whether you use the metadata-based version of the resource type or the Ruby implementation. The agent acting on the catalog continues to use the Ruby-based implementation. Because the agent uses one, and only one, version of the logic, isolation is not a problem for the agent.
 
-Each time `generate types` is executed it will sync the files in the `.resource_types` directory such that:
+## Enable environment isolation in open source Puppet
+
+With open source Puppet, enable environment isolation by running the `generate types` command:
+
+1. On the command line, run `puppet generate types --environment <envname>` for each of your environments.
+
+For example, to generate metadata for your production environment, run:
+
+`puppet generate types --environment production`
+
+Whenever you deploy a new version of Puppet, overwrite previously generated metadata with `puppet generate types --environment <envname> --force`.
+
+### Enable environment isolation with r10k
+
+To use environment isolation with open source Puppet and r10k, generate types for each environment every time r10k deploys new code. (Environment isolation is not supported with r10k in Puppet Enterprise.)
+
+To generate types with r10k, either:
+
+* Modify your existing r10k hook to run the `generate types` command after code deployment.
+* Create and use a script that first runs r10k for an environment, and then runs `generate types` as a postrun command.
+
+If you have enabled environment level purging in r10k, whitelist the `resource_types` folder so that r10k doesn't purge it.
+
+### Results of `generate types`
+
+When you run the `generate types` command, it scans the entire environment for resource type implementations, excluding the resource types shipped in core Puppet. For each resource type implementation it finds, the command generates a corresponding metadata file named after the resource type in the directory `<env-root>/.resource_types`.
+
+It also syncs the files in the `.resource_types` directory so that:
+
 * Types that have been removed in modules are removed from `resource_types`.
-* Types that are added are added.
-* Types that are unchanged (based on timestamp) are kept as is.
+* Types that have been added are added to `resource_types`.
+* Types that have not changed (based on timestamp) are kept as is.
 * Types that have changed (based on timestamp) are overwritten with freshly generated metadata.
 
-The environment to generate in is given on the command line using `--environment <env_name>`.
+The generated metadata files, which have a `.pp` extension, appear in the code directory. (If you are using Puppet Enterprise with Code Manager and file sync, these files appear in both the staging and live code directories.) These generated files are **read-only**: do not delete them, modify them, nor use expressions from them in regular manifests.
 
-The environment will be the configured default environment if not given on the command line (typically `production`).
+## Troubleshooting environment isolation
 
-A `--force` flag can be used to make `generate` overwrite all generated data for the environment.
+If `generate types` cannot generate certain types, if the type generated has missing or inaccurate information, or if the generation itself errors or fails, this can cause a catalog compilation error of "type not found" or "attribute not found". These issues can also be caused by manual changes in metadata files, incorrect permissions, or incorrectly implemented resource types.
 
-## The metadata is in Pcore
+To diagnose or repair issues:
 
-The generated metadata is using another experimental feature in Puppet called Pcore. Pcore is the name we have given to the Puppet type system including new extensions that make it possible to describe objects in the Puppet language and to map them to implementation types (for now Ruby classes, later other possible runtime languages).
+1. Ensure that your Puppet resource types are correctly implemented. Refactor any problematic resource types.
 
-As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate types --environment <env> --force` should be executed).
+1. Regenerate the metadata by removing the `<env>/.resource_types` directory and running `generate types` for each environment.
 
-The generated Pcore uses the `.pp` extension because it is regular Puppet logic that is parsed by the regular parser and evaluated by the regular evaluator. The expressions used in the generated files should however not be used in regular manifests.
+1. If you continue to get catalog compilation errors, disable environment isolation to help you isolate the error.
 
-At this time, the generated Pcore is undocumented and is considered a private implementation detail.
+   * To disable environment isolation in open source Puppet:
 
-## Opting in to using this experimental feature
+     1. Remove the `generate types` command from any r10k hooks.
+     1. Remove the `.resource_types` directory.
 
-Opting in to using the new feature is done by running the `generate types` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
+  * To disable environment isolation in Puppet Enterprise:
 
-Opting out is performed by removing the `<env_root>/.resource_types` directory and its content.
+     1. In `/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf`, remove the `pre-commit-hook-commands` setting.
+     1. In [Hiera](./config_intro.html#configure-settings-with-hiera), set `puppet_enterprise::master::puppetserver::pre_commit_hook_commands: []`. 
+     1. On the command line, run `service pe-puppetserver reload`.
+     1. Delete the `.resource_types` directories from your staging code directory (`/etc/puppetlabs/code-staging`).
+     1. Deploy environments.
 
-## Suggested workflow
+## Reference: `generate types`
 
-It is suggested that a run of `generate types --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
+The `generate types` command accepts the following options:
 
-## The future of this experimental feature
-
-The primary purpose of this experimental feature is to solve the lack of isolation between resource type implementations of different versions in different environments. It is also the foundation for further exploration towards the goal of being able to express resource types completely in the Puppet language. The Pcore format used in the initial release of this experimental version is driven completely by the existing 3.x API and is not considered to be a temporary bridge that helps us separate the compilation and agent apply logic code paths. We may base additional features on top of this 3.x based format such as validating attribute types, making it possible to use the puppet type system to validate attributes (parameters and properties) also on the agent side, validate the names of providers and similar features.
+* `--environment <env_name>`: The environment in which to generate metadata. If not specified on the command line, the metadata is configured for the default environment (typically `production`).
+* `--force`: The `generate types` command overwrites all generated data for the environment.

--- a/source/puppet/4.9/_puppet_toc.html
+++ b/source/puppet/4.9/_puppet_toc.html
@@ -97,6 +97,7 @@
     * [Assigning environments to nodes]({{puppet}}/environments_assigning.html)
     * [Suggestions for use]({{puppet}}/environments_suggestions.html)
     * [Limitations of environments]({{puppet}}/environments_limitations.html)
+    * [Environment isolation]({{puppet}}/environment_isolation.html)
     * [Environments and Puppet's HTTPS interface]({{puppet}}/environments_https.html)
 * **Modules**
     * [Fundamentals]({{puppet}}/modules_fundamentals.html)
@@ -354,6 +355,5 @@
 * **Experimental features**
     * [Overview]({{puppet}}/experiments_overview.html)
     * [Msgpack support]({{puppet}}/experiments_msgpack.html)
-    * [Environment isolation]({{puppet}}/environment_isolation.html)
-
+    
 {% endmd %}

--- a/source/puppet/4.9/environment_isolation.md
+++ b/source/puppet/4.9/environment_isolation.md
@@ -1,62 +1,95 @@
 ---
 layout: default
-title: "Environment Isolation"
+title: "Isolating resources in multiple environments"
+canonical: "/puppet/latest/environment_isolation.html"
+description: "Generating metadata to isolate resources in environments in Puppet"
 ---
 
+[code_mgr_env]: {{pe}}/code_mgr.html#environment-isolation-metadata
 
-Beginning in Puppet 4.6.0, there is a new experimental feature aiming to solve a problem with the isolation of multiple versions of the same Ruby resource type implementation being used in different environments. This is a problem because the Ruby resource type implementations are constructed in a way that binds Ruby constructs to constants and these bindings are global in the Ruby runtime. Thus, the first loaded version of a resource type implementation will win and subsequent requests to compile in other environments will get the first loaded version.
 
-There are other environment isolation cases that this new experimental feature does not solve (external helper logic, different versions of required gems, and similar).
+If you have multiple environments, environment isolation prevents resource types from leaking between your various environments. To use environment isolation, you'll generate metadata files that Puppet can use in place of the normal Ruby resource type implementations.
 
-## How it works
+In open source Puppet, enable environment isolation with the `generate types` command. In Puppet Enterprise, environment isolation is automatically provided by [Code Manager][code_mgr_env]. Environment isolation is not supported for r10k with Puppet Enterprise.
 
-The experimental feature consists of two parts:
+## Preventing resource types leaks in multiple environments
 
-* A utility that generates loadable metadata describing the resource type implementation.
-* The ability to load and use this metadata instead of the Ruby resource type implementation when compiling.
+If you use multiple environments with Puppet, you might encounter issues with multiple versions of the same resource type leaking between your various environments. This doesn't happen with Puppet's built-in resource types, but it can happen with any other resource types.
 
-### The agent logic is unchanged
+This problem occurs because Ruby resource type bindings are global in the Ruby runtime. Thus, the first loaded version of a Ruby resource type takes priority, and then subsequent requests to compile in other environments get that first loaded version.
 
-The result of the compilation (the catalog) will be identical irrespective of using the metadata based version of the resource type or the Ruby implementation. The agent acting on the catalog continues to use the Ruby based implementation. Isolation is not a problem there because it is using one and only one version of the logic.
+Environment isolation solves this issue by generating and using metadata that describes the resource type implementation, instead of using the Ruby resource type implementation when compiling catalogs. 
 
-(Note: It is untested what happens when an agent is changed to be in different environments and the agent runs as a daemon; if it does not spawn new processes it would be subject to isolation problems).
+> **Note**: Other environment isolation cases, such as external helper logic issues or varying versions of required gems, are not solved with the `generate types` command.
 
-## Generation of Metadata
+### Agent logic is unchanged
 
-A new command-line utility `generate types` has been added to Puppet. This command will scan the entire environment for resource type implementations (it skips the resource types shipped in core Puppet). For each found resource type implementation it will write the corresponding metadata in a file named after the resource type in the directory `<env-root>/.resource_types`.
+Catalog compilation results are exactly the same whether you use the metadata-based version of the resource type or the Ruby implementation. The agent acting on the catalog continues to use the Ruby-based implementation. Because the agent uses one, and only one, version of the logic, isolation is not a problem for the agent.
 
-Each time `generate types` is executed it will sync the files in the `.resource_types` directory such that:
+## Enable environment isolation in open source Puppet
+
+With open source Puppet, enable environment isolation by running the `generate types` command:
+
+1. On the command line, run `puppet generate types --environment <envname>` for each of your environments.
+
+For example, to generate metadata for your production environment, run:
+
+`puppet generate types --environment production`
+
+Whenever you deploy a new version of Puppet, overwrite previously generated metadata with `puppet generate types --environment <envname> --force`.
+
+### Enable environment isolation with r10k
+
+To use environment isolation with open source Puppet and r10k, generate types for each environment every time r10k deploys new code. (Environment isolation is not supported with r10k in Puppet Enterprise.)
+
+To generate types with r10k, either:
+
+* Modify your existing r10k hook to run the `generate types` command after code deployment.
+* Create and use a script that first runs r10k for an environment, and then runs `generate types` as a postrun command.
+
+If you have enabled environment level purging in r10k, whitelist the `resource_types` folder so that r10k doesn't purge it.
+
+### Results of `generate types`
+
+When you run the `generate types` command, it scans the entire environment for resource type implementations, excluding the resource types shipped in core Puppet. For each resource type implementation it finds, the command generates a corresponding metadata file named after the resource type in the directory `<env-root>/.resource_types`.
+
+It also syncs the files in the `.resource_types` directory so that:
+
 * Types that have been removed in modules are removed from `resource_types`.
-* Types that are added are added.
-* Types that are unchanged (based on timestamp) are kept as is.
+* Types that have been added are added to `resource_types`.
+* Types that have not changed (based on timestamp) are kept as is.
 * Types that have changed (based on timestamp) are overwritten with freshly generated metadata.
 
-The environment to generate in is given on the command line using `--environment <env_name>`.
+The generated metadata files, which have a `.pp` extension, appear in the code directory. (If you are using Puppet Enterprise with Code Manager and file sync, these files appear in both the staging and live code directories.) These generated files are **read-only**: do not delete them, modify them, nor use expressions from them in regular manifests.
 
-The environment will be the configured default environment if not given on the command line (typically `production`).
+## Troubleshooting environment isolation
 
-A `--force` flag can be used to make `generate` overwrite all generated data for the environment.
+If `generate types` cannot generate certain types, if the type generated has missing or inaccurate information, or if the generation itself errors or fails, this can cause a catalog compilation error of "type not found" or "attribute not found". These issues can also be caused by manual changes in metadata files, incorrect permissions, or incorrectly implemented resource types.
 
-## The metadata is in Pcore
+To diagnose or repair issues:
 
-The generated metadata is using another experimental feature in Puppet called Pcore. Pcore is the name we have given to the Puppet type system including new extensions that make it possible to describe objects in the Puppet language and to map them to implementation types (for now Ruby classes, later other possible runtime languages).
+1. Ensure that your Puppet resource types are correctly implemented. Refactor any problematic resource types.
 
-As of Puppet 4.6.0, the generated Pcore logic is considered to be write only, and it may change in a future Puppet release. (When you're deploying a new Puppet version, a `generate types --environment <env> --force` should be executed).
+1. Regenerate the metadata by removing the `<env>/.resource_types` directory and running `generate types` for each environment.
 
-The generated Pcore uses the `.pp` extension because it is regular Puppet logic that is parsed by the regular parser and evaluated by the regular evaluator. The expressions used in the generated files should however not be used in regular manifests.
+1. If you continue to get catalog compilation errors, disable environment isolation to help you isolate the error.
 
-At this time, the generated Pcore is undocumented and is considered a private implementation detail.
+   * To disable environment isolation in open source Puppet:
 
-## Opting in to using this experimental feature
+     1. Remove the `generate types` command from any r10k hooks.
+     1. Remove the `.resource_types` directory.
 
-Opting in to using the new feature is done by running the `generate types` command. It is important to run this command in all environments in use - or at a minimum in those environments where resource types clash.
+  * To disable environment isolation in Puppet Enterprise:
 
-Opting out is performed by removing the `<env_root>/.resource_types` directory and its content.
+     1. In `/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf`, remove the `pre-commit-hook-commands` setting.
+     1. In [Hiera](./config_intro.html#configure-settings-with-hiera), set `puppet_enterprise::master::puppetserver::pre_commit_hook_commands: []`. 
+     1. On the command line, run `service pe-puppetserver reload`.
+     1. Delete the `.resource_types` directories from your staging code directory (`/etc/puppetlabs/code-staging`).
+     1. Deploy environments.
 
-## Suggested workflow
+## Reference: `generate types`
 
-It is suggested that a run of `generate types --environment <envname>` is performed in a hook whenever new code is deployed with r10k as that ensures that the generated meta data is up to date for new code deploys.
+The `generate types` command accepts the following options:
 
-## The future of this experimental feature
-
-The primary purpose of this experimental feature is to solve the lack of isolation between resource type implementations of different versions in different environments. It is also the foundation for further exploration towards the goal of being able to express resource types completely in the Puppet language. The Pcore format used in the initial release of this experimental version is driven completely by the existing 3.x API and is not considered to be a temporary bridge that helps us separate the compilation and agent apply logic code paths. We may base additional features on top of this 3.x based format such as validating attribute types, making it possible to use the puppet type system to validate attributes (parameters and properties) also on the agent side, validate the names of providers and similar features.
+* `--environment <env_name>`: The environment in which to generate metadata. If not specified on the command line, the metadata is configured for the default environment (typically `production`).
+* `--force`: The `generate types` command overwrites all generated data for the environment.


### PR DESCRIPTION
Rewritten + topicized environment_isolation pages for Puppet 4.8 and 4.9. @gguillotte or @jtappa , can you give these an editorial look? Looking to get this merged and live by tomorrow for the related Everett release.