### PR TITLE
(docs) Remove version_range in sample outputs

### DIFF
--- a/source/puppet/3.7/modules_fundamentals.markdown
+++ b/source/puppet/3.7/modules_fundamentals.markdown
@@ -210,7 +210,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/3.8/modules_fundamentals.markdown
+++ b/source/puppet/3.8/modules_fundamentals.markdown
@@ -210,7 +210,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.1/modules_fundamentals.markdown
+++ b/source/puppet/4.1/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.2/modules_fundamentals.markdown
+++ b/source/puppet/4.2/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.3/modules_fundamentals.markdown
+++ b/source/puppet/4.3/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.4/modules_fundamentals.markdown
+++ b/source/puppet/4.4/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.5/modules_fundamentals.markdown
+++ b/source/puppet/4.5/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.6/modules_fundamentals.markdown
+++ b/source/puppet/4.6/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.7/modules_fundamentals.markdown
+++ b/source/puppet/4.7/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.8/modules_fundamentals.markdown
+++ b/source/puppet/4.8/modules_fundamentals.markdown
@@ -209,7 +209,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/source/puppet/4.9/modules_fundamentals.markdown
+++ b/source/puppet/4.9/modules_fundamentals.markdown
@@ -208,7 +208,7 @@ Where can others go to file issues about this module?
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_range": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Puppet 3.6.0 introduced an incorrect key name version_range when doing puppet module generate, rather than version_requirement.

This appears to have been fixed in Puppet 3.7.0 (PUP-2781)