### PR TITLE
(DOC-3078) As of Puppet 4.x, these options don't exist

### DIFF
--- a/source/puppet/4.9/config_print.markdown
+++ b/source/puppet/4.9/config_print.markdown
@@ -11,7 +11,6 @@ title: "Configuration: Checking values of settings"
 [confdir]: ./dirs_confdir.html
 [vardir]: ./dirs_vardir.html
 [modulepath]: ./dirs_modulepath.html
-[facts_and_trusted]: ./lang_facts_and_builtin_vars.html
 
 Puppet settings are highly dynamic, and their values can come from [several different places][setting_sources].
 
@@ -84,11 +83,11 @@ To see the effective [modulepath][] used in the `dev` environment:
     $ sudo puppet config print modulepath --section master --environment dev
     /etc/puppetlabs/code/environments/dev/modules:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules
 
-To see whether the [`$facts` and `$trusted` variables][facts_and_trusted] are enabled:
+To see whether PuppetDB is configured for exported resources:
 
-    $ sudo puppet config print trusted_node_data immutable_node_data --section master
-    trusted_node_data = true
-    immutable_node_data = true
+    $ sudo puppet config print storeconfigs storeconfigs_backend --section master
+    storeconfigs = true
+    storeconfigs_backend = puppetdb
 
 Imitating Puppet Agent
 -----

--- a/source/puppet/4.9/config_set.markdown
+++ b/source/puppet/4.9/config_set.markdown
@@ -61,7 +61,7 @@ If modifying the [system config file][confdir_sys], be sure to use `sudo` or run
 
 **Commands:**
 
-    $ sudo puppet config set trusted_node_data true --section master
+    $ sudo puppet config set reports puppetdb --section master
     $ sudo puppet config set ordering manifest
 
 **After:**
@@ -80,4 +80,4 @@ If modifying the [system config file][confdir_sys], be sure to use `sudo` or run
 
     [master]
     dns_alt_names = master,master.example.com,puppet,puppet.example.com
-    trusted_node_data = true
+    reports = puppetdb


### PR DESCRIPTION
These changes should probably be backported through the version history.
I didn't make those historical changes because I guessed that you had tools
to automate that already.