### PR TITLE
(DOC-3095) Update/correct example - Sensitive

### DIFF
--- a/source/puppet/4.9/lang_data_sensitive.md
+++ b/source/puppet/4.9/lang_data_sensitive.md
@@ -26,10 +26,10 @@ It is therefore not possible to have detailed data types and expect that the dat
 
 ## Example
 
-If you assign a value to a sensitive type, and call notice:
+If you assign a sensitive value, and call notice:
 
 ```puppet
-$secret = 'myPassword'
+$secret = Sensitive('myPassword')
 notice($secret)
 ```
 
@@ -38,7 +38,7 @@ This outputs `Notice: Scope(Class[main]): Sensitive [value redacted]`.
 However, you can still unwrap this with the `unwrap` function and gain access to the original data. 
 
 ```
-$secret = 'myPassword'
+$secret = Sensitive('myPassword')
 $processed = $secret.unwrap
 notice $processed
 ```


### PR DESCRIPTION
The fix ensures that the code sample shown on the doc page is an
example, however simple, of how to use encrypt the value before storing
it in a variable, using the Sensitive type.

This does not seek to make the example or the doc page perfect, just
better.