### PR TITLE
(DOC-3133) Update Supported External CA Documentation

### DIFF
--- a/source/puppet/4.1/config_ssl_external_ca.markdown
+++ b/source/puppet/4.1/config_ssl_external_ca.markdown
@@ -1,88 +1,41 @@
 ---
 layout: default
-title: "SSL Configuration: External CA Support"
-canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
+title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
 [verify_header]: ./configuration.html#sslclientverifyheader
 [client_header]: ./configuration.html#sslclientheader
 [ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: /puppetdb/latest
+[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
-This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet Labs so we can learn more about it.
+This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
 
 > **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-## Supported External CA Configurations
+## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
-These are fully supported by Puppet Labs, which means:
+These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+## General notes and requirements
 
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
-## General Notes and Requirements
-
-### Rack Webserver is Required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
-
-### PEM Encoding of Credentials is Mandatory
+### PEM encoding of credentials is mandatory
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet Master Certificate Requirements Still Apply
+### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN Request Header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If Unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If Used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -103,7 +56,11 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       |                 |                |                |
       +-----------------+                +----------------+
 
-### Puppet Master
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
+
+### Puppet master
 
 {% capture master_basic %}
 Configure the Puppet master in four steps:
@@ -115,11 +72,11 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-~~~
+```
 [master]
 ca = false
 certname = <some static string, e.g. 'puppetmaster'>
-~~~
+```
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
@@ -135,62 +92,11 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{% capture master_config_ru %}
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-~~~ ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-~~~
-{% endcapture %}
-
-{{ master_config_ru }}
-
-### Puppet Agent
+### Puppet agent
 
 You don't need to change any settings.
 
@@ -201,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single Intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+### Puppet master
 
-### Puppet Master
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-{{ master_basic }}
+In order to configure the puppet master you will need the following files placed:
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
 
-~~~ bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
-~~~
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
 
-With these files in place, the web server should be configured to:
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
 
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
 
-An example of this configuration for Apache:
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
 
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+```
 
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+### Puppet agent
 
-    DocumentRoot "/etc/puppetlabs/puppet/public"
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
 
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
 
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
 
-{{ master_config_ru }}
+Example error:
 
-### Puppet Agent
+```
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
+```
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
-~~~
+```
+certificate_revocation = false
+```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two Intermediate CAs Issued by One Root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet Master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-~~~ bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-~~~
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{{ master_config_ru }}
-
-### Puppet Agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
-
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
-~~~
-
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.

--- a/source/puppet/4.1/config_ssl_external_ca.markdown
+++ b/source/puppet/4.1/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.2/config_ssl_external_ca.markdown
+++ b/source/puppet/4.2/config_ssl_external_ca.markdown
@@ -1,88 +1,41 @@
 ---
 layout: default
-title: "SSL Configuration: External CA Support"
-canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
+title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
 [verify_header]: ./configuration.html#sslclientverifyheader
 [client_header]: ./configuration.html#sslclientheader
 [ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: /puppetdb/latest
+[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
-This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet Labs so we can learn more about it.
+This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
 
 > **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-## Supported External CA Configurations
+## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
-These are fully supported by Puppet Labs, which means:
+These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+## General notes and requirements
 
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
-## General Notes and Requirements
-
-### Rack Webserver is Required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
-
-### PEM Encoding of Credentials is Mandatory
+### PEM encoding of credentials is mandatory
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet Master Certificate Requirements Still Apply
+### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN Request Header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If Unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If Used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -103,7 +56,11 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       |                 |                |                |
       +-----------------+                +----------------+
 
-### Puppet Master
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
+
+### Puppet master
 
 {% capture master_basic %}
 Configure the Puppet master in four steps:
@@ -115,11 +72,11 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-~~~
+```
 [master]
 ca = false
 certname = <some static string, e.g. 'puppetmaster'>
-~~~
+```
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
@@ -135,62 +92,11 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{% capture master_config_ru %}
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-~~~ ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-~~~
-{% endcapture %}
-
-{{ master_config_ru }}
-
-### Puppet Agent
+### Puppet agent
 
 You don't need to change any settings.
 
@@ -201,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single Intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+### Puppet master
 
-### Puppet Master
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-{{ master_basic }}
+In order to configure the puppet master you will need the following files placed:
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
 
-~~~ bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
-~~~
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
 
-With these files in place, the web server should be configured to:
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
 
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
 
-An example of this configuration for Apache:
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
 
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+```
 
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+### Puppet agent
 
-    DocumentRoot "/etc/puppetlabs/puppet/public"
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
 
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
 
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
 
-{{ master_config_ru }}
+Example error:
 
-### Puppet Agent
+```
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
+```
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
-~~~
+```
+certificate_revocation = false
+```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two Intermediate CAs Issued by One Root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet Master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-~~~ bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-~~~
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{{ master_config_ru }}
-
-### Puppet Agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
-
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
-~~~
-
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.

--- a/source/puppet/4.2/config_ssl_external_ca.markdown
+++ b/source/puppet/4.2/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.3/config_ssl_external_ca.markdown
+++ b/source/puppet/4.3/config_ssl_external_ca.markdown
@@ -1,88 +1,41 @@
 ---
 layout: default
-title: "SSL Configuration: External CA Support"
-canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
+title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
 [verify_header]: ./configuration.html#sslclientverifyheader
 [client_header]: ./configuration.html#sslclientheader
 [ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: /puppetdb/latest
+[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
-This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet Labs so we can learn more about it.
+This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
 
 > **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-## Supported External CA Configurations
+## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
-These are fully supported by Puppet Labs, which means:
+These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+## General notes and requirements
 
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
-## General Notes and Requirements
-
-### Rack Webserver is Required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
-
-### PEM Encoding of Credentials is Mandatory
+### PEM encoding of credentials is mandatory
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet Master Certificate Requirements Still Apply
+### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN Request Header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If Unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If Used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -103,7 +56,11 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       |                 |                |                |
       +-----------------+                +----------------+
 
-### Puppet Master
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
+
+### Puppet master
 
 {% capture master_basic %}
 Configure the Puppet master in four steps:
@@ -115,11 +72,11 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-~~~
+```
 [master]
 ca = false
 certname = <some static string, e.g. 'puppetmaster'>
-~~~
+```
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
@@ -135,62 +92,11 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{% capture master_config_ru %}
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-~~~ ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-~~~
-{% endcapture %}
-
-{{ master_config_ru }}
-
-### Puppet Agent
+### Puppet agent
 
 You don't need to change any settings.
 
@@ -201,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single Intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+### Puppet master
 
-### Puppet Master
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-{{ master_basic }}
+In order to configure the puppet master you will need the following files placed:
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
 
-~~~ bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
-~~~
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
 
-With these files in place, the web server should be configured to:
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
 
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
 
-An example of this configuration for Apache:
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
 
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+```
 
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+### Puppet agent
 
-    DocumentRoot "/etc/puppetlabs/puppet/public"
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
 
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
 
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
 
-{{ master_config_ru }}
+Example error:
 
-### Puppet Agent
+```
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
+```
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
-~~~
+```
+certificate_revocation = false
+```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two Intermediate CAs Issued by One Root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet Master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-~~~ bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-~~~
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{{ master_config_ru }}
-
-### Puppet Agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
-
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
-~~~
-
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.

--- a/source/puppet/4.3/config_ssl_external_ca.markdown
+++ b/source/puppet/4.3/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.4/config_ssl_external_ca.markdown
+++ b/source/puppet/4.4/config_ssl_external_ca.markdown
@@ -1,7 +1,6 @@
 ---
 layout: default
-title: "SSL Configuration: External CA Support"
-canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
+title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
@@ -16,73 +15,27 @@ This page describes the supported and tested configurations for external CAs in 
 
 > **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
-## Supported External CA Configurations
+## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
-These are fully supported by Puppet Labs, which means:
+These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+## General notes and requirements
 
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
-## General Notes and Requirements
-
-### Rack Webserver is Required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
-
-### PEM Encoding of Credentials is Mandatory
+### PEM encoding of credentials is mandatory
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet Master Certificate Requirements Still Apply
+### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN Request Header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If Unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If Used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -103,7 +56,11 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       |                 |                |                |
       +-----------------+                +----------------+
 
-### Puppet Master
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
+
+### Puppet master
 
 {% capture master_basic %}
 Configure the Puppet master in four steps:
@@ -115,11 +72,11 @@ Configure the Puppet master in four steps:
 
 On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
 
-~~~
+```
 [master]
 ca = false
 certname = <some static string, e.g. 'puppetmaster'>
-~~~
+```
 
 * The internal CA service must be disabled using `ca = false`.
 * The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
@@ -135,62 +92,11 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{% capture master_config_ru %}
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-~~~ ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-~~~
-{% endcapture %}
-
-{{ master_config_ru }}
-
-### Puppet Agent
+### Puppet agent
 
 You don't need to change any settings.
 
@@ -201,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single Intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+### Puppet master
 
-### Puppet Master
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-{{ master_basic }}
+In order to configure the puppet master you will need the following files placed:
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
 
-~~~ bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
-~~~
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
 
-With these files in place, the web server should be configured to:
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
 
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
 
-An example of this configuration for Apache:
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
 
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+```
 
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+### Puppet agent
 
-    DocumentRoot "/etc/puppetlabs/puppet/public"
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
 
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
 
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
 
-{{ master_config_ru }}
+Example error:
 
-### Puppet Agent
+```
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
+```
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
-~~~
+```
+certificate_revocation = false
+```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two Intermediate CAs Issued by One Root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet Master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-~~~ bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-~~~
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-~~~ apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-~~~
-
-{{ master_config_ru }}
-
-### Puppet Agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
-
-~~~
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
-~~~
-
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.

--- a/source/puppet/4.4/config_ssl_external_ca.markdown
+++ b/source/puppet/4.4/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.5/config_ssl_external_ca.markdown
+++ b/source/puppet/4.5/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.6/config_ssl_external_ca.markdown
+++ b/source/puppet/4.6/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.7/config_ssl_external_ca.markdown
+++ b/source/puppet/4.7/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.8/config_ssl_external_ca.markdown
+++ b/source/puppet/4.8/config_ssl_external_ca.markdown
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: "SSL configuration: External CA support"
-canonical: "/puppet/latest/reference/config_ssl_external_ca.html"
 ---
 
 [conf]: ./config_file_main.html
@@ -21,35 +20,14 @@ This page describes the supported and tested configurations for external CAs in 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
-
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
 ## General notes and requirements
-
-### Rack web server is required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
 
 ### PEM encoding of credentials is mandatory
 
@@ -58,31 +36,6 @@ Puppet always expects its SSL credentials to be in `.pem` format.
 ### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN request header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -102,6 +55,10 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       | Master SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
+
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
 ### Puppet master
 
@@ -135,61 +92,9 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{% capture master_config_ru %}
-
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-``` ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-```
-{% endcapture %}
-
-{{ master_config_ru }}
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
 ### Puppet agent
 
@@ -202,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
 ### Puppet master
 
-{{ master_basic }}
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+In order to configure the puppet master you will need the following files placed:
 
-``` bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
 ```
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-With these files in place, the web server should be configured to:
-
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{{ master_config_ru }}
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
+
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
+
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+
+Example error:
 
 ```
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
 ```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two intermediate CAs issued by one root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-``` bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-```
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{{ master_config_ru }}
-
-### Puppet agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
 ```
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
+certificate_revocation = false
 ```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.

--- a/source/puppet/4.8/config_ssl_external_ca.markdown
+++ b/source/puppet/4.8/config_ssl_external_ca.markdown
@@ -4,23 +4,17 @@ title: "SSL configuration: External CA support"
 ---
 
 [conf]: ./config_file_main.html
-[verify_header]: ./configuration.html#sslclientverifyheader
-[client_header]: ./configuration.html#sslclientheader
-[ca_auth]: ./configuration.html#sslclientcaauth
-[puppetdb]: {{puppetdb}}/
 
 In lieu of its built-in certificate authority (CA) and public key infrastructure (PKI) tools, Puppet can use an existing external CA for all of its secure socket layer (SSL) communications.
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
-
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
 
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
+2. [Puppet Server functioning as an intermediate CA of a root self-signed CA.](#option-2-puppet-server-functioning-as-an-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
@@ -33,9 +27,9 @@ These are fully supported by Puppet, which means:
 
 Puppet always expects its SSL credentials to be in `.pem` format.
 
-### Normal Puppet master certificate requirements still apply
+### Normal Puppet certificate requirements still apply
 
-Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
+Any Puppet Server certificate must contain the DNS name at which agent nodes will attempt to contact that server, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
 
 ## Option 1: Single CA
 
@@ -52,7 +46,7 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
                v                                  v
       +-----------------+                +----------------+
       |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
+      | Server SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
 
@@ -60,41 +54,40 @@ This configuration is all-or-nothing rather than mix-and-match. When using an ex
 
 Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
-### Puppet master
+### Puppet server
 
-{% capture master_basic %}
-Configure the Puppet master in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the master, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Master SSL certificate             | `puppet master --configprint hostcert`
-Master SSL certificate private key | `puppet master --configprint hostprivkey`
-Root CA certificate                | `puppet master --configprint localcacert`
-{% endcapture %}
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-{{ master_basic }}
-
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -104,73 +97,80 @@ Put the external credentials into the correct filesystem locations. You can run 
 
 Credential                        | File location
 ----------------------------------|-----------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Root CRL certificate              | `puppet agent --configprint hostcrl`
+Agent SSL certificate             | `puppet config print hostcert --section agent`
+Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
+Root CA certificate               | `puppet config print localcacert --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
-## Option 2: Puppet master functioning as an intermediate CA
+## Option 2: Puppet server functioning as an intermediate CA
 
-The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
-### Puppet master
+### Puppet Server
 
-Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure the puppet master you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
-ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
-root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+1. Put the following files in place:
 
-> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
-Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
+
+[regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.9/config_ssl_external_ca.markdown
+++ b/source/puppet/4.9/config_ssl_external_ca.markdown
@@ -123,9 +123,9 @@ To configure Puppet Server:
    Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
    Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-   All of these files should have their ownership set to `puppet:puppet` and have permissions of `0600`.
+   All of these files should be owned by `puppet:puppet` and have permissions of `0600`.
 
-   > Note: Although root_crt.pem can be placed anywhere (since Puppet Server doesn't use it directly), the rest of this page assumes you placed it as shown.
+   > Note: Although root_crt.pem can be named anything (since Puppet Server doesn't use it directly), the file needs to be stored in the location shown.
 
    > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 

--- a/source/puppet/4.9/config_ssl_external_ca.markdown
+++ b/source/puppet/4.9/config_ssl_external_ca.markdown
@@ -9,8 +9,6 @@ In lieu of its built-in certificate authority (CA) and public key infrastructure
 
 This page describes the supported and tested configurations for external CAs in this version of Puppet. If you have an external CA use case that isn't covered here, please contact Puppet so we can learn more about it.
 
-> **Note:** This page uses RFC 2119 style semantics for MUST, SHOULD, and MAY.
-
 ## Supported external CA configurations
 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
@@ -58,35 +56,38 @@ Additionally, Puppet cannot automatically distribute certificates in this config
 
 ### Puppet server
 
-Configure Puppet Server in four steps:
+Configure Puppet Server in three steps:
 
-1. Disable the internal CA service
-2. Ensure that the certname will never change
-3. Put certificates/keys in place on disk
-4. Configure the web server
+* Disable the internal CA service
+* Ensure that the certname will never change
+* Put certificates/keys in place on disk
 
-On the Puppet Server node, in [`puppet.conf`][conf], make sure the following settings are configured:
+1. Edit Puppet Server's `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file to disable the internal CA. Comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as follows:
 
-```
-[master]
-ca = false
-certname = <some static string, e.g. 'puppetmaster'>
-```
+   ```
+   # To enable the CA service, leave the following line uncommented
+   # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+   # To disable the CA service, comment out the above line and uncomment the line below
+   puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+   ```
+2. Set a static value for the `certname` setting in [`puppet.conf`][conf]:
 
-* The internal CA service must be disabled using `ca = false`.
-* The certname must be set to a static value. This can still be the machine's FQDN, but you must not leave the setting blank. (A static certname will keep Puppet from getting confused if the machine's hostname ever changes.)
+   ```
+   [master]
+   certname = puppetserver.example.com
+   ```
 
-Once this configuration is set, put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
+   Setting a static value keeps Puppet from getting confused if the machine's hostname ever changes. The value must be whatever certname you'll use to issue the server's certificate. It must not be blank.
+3. Put the credentials from your external CA on disk in the correct locations. These locations must match what's configured in your [webserver.conf file]({{puppetserver}}/config_file_webserver.html). If you haven't changed those settings, you can run the following commands to find the default locations:
 
-Credential                         | File location
------------------------------------|-------------------------------------------
-Server SSL certificate             | `puppet config print hostcert --section master`
-Server SSL certificate private key | `puppet config print hostprivkey --section master`
-Root CA certificate                | `puppet config print localcacert --section master`
+   Credential                         | File location
+   -----------------------------------|-------------------------------------------
+   Server SSL certificate             | `puppet config print hostcert --section master`
+   Server SSL certificate private key | `puppet config print hostprivkey --section master`
+   Root CA certificate                | `puppet config print localcacert --section master`
+   Root certificate revocation list   | `puppet config print hostcrl --section master`
 
-With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
-
-[disablepuppetserverca]: {{puppetserver}}/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
+If you've put the credentials in the correct locations, you shouldn't need to change any additional settings.
 
 ### Puppet agent
 
@@ -99,71 +100,77 @@ Credential                        | File location
 Agent SSL certificate             | `puppet config print hostcert --section agent`
 Agent SSL certificate private key | `puppet config print hostprivkey --section agent`
 Root CA certificate               | `puppet config print localcacert --section agent`
-Root CRL certificate              | `puppet config print hostcrl --section agent`
+Root certificate revocation list  | `puppet config print hostcrl --section agent`
 
 ## Option 2: Puppet server functioning as an intermediate CA
 
-Puppet Server can operate as an intermediate CA to an external Root CA.  The server cannot be an intermediate to an intermediate.  In this mode the Puppet CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
+Puppet Server can operate as an intermediate CA to an external root CA.  (The server cannot be an intermediate to an intermediate.)  In this mode, the Puppet CA is left enabled; it can automatically accept CSRs and distribute certificates to agents, and can use the standard `puppet cert` command to sign certificates. However, there are some limitations:
 
-* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
-* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
+* Agent-side CRL checking is not possible, although Puppet Server still verifies the CRL.
+* The CA certificate bundle (the external root CA combined with the intermediate CA certificate) must be distributed to the agents manually, ideally before puppet runs
 
 ### Puppet Server
 
-Before configuring Puppet Server, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
+Before configuring Puppet Server, you must obtain the intermediate CA certificate from your external root CA.  Generating the intermediate CA cert is outside the scope of this guide, since it depends on your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing server and are starting over.  Also, you should stop all Puppet related services on the server before this process.
 
-In order to configure Puppet Server you will need the following files placed:
+To configure Puppet Server:
 
-Certificate     | Purpose                     | File Location
-----------------|--------------------------------------------
-`ca_crt.pem`    | Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
-`ca_key.pem`    | Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
-`root_crt.pem`  | Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
+1. Put the following files in place:
 
-> Note: Although root_crt.pem can be placed anywhere (since it isn't used directly by Puppet Server), the rest of this page assumes you placed it as shown.
+   Credential                  | File Location
+   ----------------------------|--------------
+   Intermediate CA Certificate | `/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem`
+   Intermediate CA Key         | `/etc/puppetlabs/puppet/ssl/ca/ca_key.pem`
+   Root CA Certificate         | `/etc/puppetlabs/puppet/ssl/ca/root_crt.pem`
 
-> Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
+   All of these files should have their ownership set to `puppet:puppet` and have permissions of `0600`.
 
-All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+   > Note: Although root_crt.pem can be placed anywhere (since Puppet Server doesn't use it directly), the rest of this page assumes you placed it as shown.
 
-Next, you have to generate the CA bundle to be placed on the server as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+   > Note: ca_key.pem must not have a passphrase, since the Puppet CA cannot provide one when using the key.
 
-```
-cd /etc/puppetlabs/puppet/ssl/ca
-cat ca_cert.pem root_crt.pem > ../certs/ca.pem
-```
+2. Generate the CA bundle, which you'll place on the server and on every agent node.  Combine the root CA and intermediate CA certificates into one PEM file:
 
-> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+   ```
+   cd /etc/puppetlabs/puppet/ssl/ca
+   cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+   ```
 
-You now need to generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
+   > Note: You also need to install a CRL file.  If you don't have one pre-generated from the root CA, you can easily create one by first running `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL, install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
 
-```
-puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
-```
+3. Generate a new certificate for Puppet Server to use.  Remember to include the `dns_alt_names` that this server will need to service.
 
-You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
+   ```
+   puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
+   ```
+
+You can now restart the puppetserver process and confirm that it successfully starts.
+
+If your deployment includes other non-agent Puppet services that need new certificates (for example, PuppetDB), please see [Regenerating all Certificates for a Puppet deployment][regen] for specific instructions.
 
 [regen]: ./ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-In order for the puppet agent to work properly with this CA configuration you need to do two things:
+You need to do two things to prepare Puppet agent for this CA configuration:
 
-* Copy the CA bundle in place prior to a puppet run (ideally)
-* Disable certificate revocation validation
+* Copy the CA bundle in place prior to a Puppet run.
+* Disable certificate revocation validation.
 
-The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain.
+1. Copy the CA bundle you created to `/etc/puppetlabs/puppet/ssl/certs/ca.pem` on every agent node.
 
-Example error:
+   If you copy this file into place before the first Puppet run, you will not recieve any errors.  If you attempt a Puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file doesn't include the root CA..
 
-```
-Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
-```
+   Example error:
 
-Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
+   ```
+   Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<server>]
+   ```
+2. Set `certificate_revocation = false` in the `[main]` section of puppet.conf on every agent node:
 
-```
-certificate_revocation = false
-```
+   ```
+   [main]
+   certificate_revocation = false
+   ```
 
-Once you've completed both of these steps the agent will run successfully.
+Once you've completed both of these steps, the agent can run successfully.

--- a/source/puppet/4.9/config_ssl_external_ca.markdown
+++ b/source/puppet/4.9/config_ssl_external_ca.markdown
@@ -20,35 +20,14 @@ This page describes the supported and tested configurations for external CAs in 
 This version of Puppet supports _some_ external CA configurations, but not every possible arrangement. We fully support the following setups:
 
 1. [Single self-signed CA which directly issues SSL certificates.](#option-1-single-ca)
-2. [Single, intermediate CA issued by a root self-signed CA.](#option-2-single-intermediate-ca) The intermediate
-   CA directly issues SSL certificates; the root CA doesn't.
-3. [Two intermediate CAs, both issued by the same root self-signed CA.](#option-3-two-intermediate-cas-issued-by-one-root-ca)
-    * One intermediate CA issues SSL certificates for Puppet master servers.
-    * The other intermediate CA issues SSL certificates for agent nodes.
-    * Agent certificates can't act as servers, and master certificates can't act as clients.
+2. [Puppet master functioning as an intermediate CA of a root self-signed CA.](#option-2-intermediate-ca)
 
 These are fully supported by Puppet, which means:
 
 * Issues that arise in one of these three arrangements are considered **bugs,** and we'll fix them ASAP.
 * Issues that arise in any _other_ external CA setup are considered **feature requests,** and we'll consider whether to expand our support.
 
-These configurations are all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
-
-Additionally, Puppet cannot automatically distribute certificates in these configurations --- you must have your own complete system for issuing and distributing certificates.
-
 ## General notes and requirements
-
-### Rack web server is required
-
-The Puppet master must be running inside of a Rack-enabled web server, not the built-in Webrick server.
-
-In practice, this means Apache or Nginx. We fully support any web server that can:
-
-* Terminate SSL
-* Verify the authenticity of a client SSL certificate
-* Set two request headers for:
-    * Whether the client was verified
-    * The client's distinguished name
 
 ### PEM encoding of credentials is mandatory
 
@@ -57,31 +36,6 @@ Puppet always expects its SSL credentials to be in `.pem` format.
 ### Normal Puppet master certificate requirements still apply
 
 Any Puppet master certificate must contain the DNS name at which agent nodes will attempt to contact that master, either as the subject common name (CN) or as a Subject Alternative Name (DNS).
-
-### Format of X-Client-DN request header
-
-Rack web servers must set a client request header, which the Puppet master will check based on the [`ssl_client_header` setting][client_header].
-
-This header should conform to the following specifications:
-
-* The value of the client certificate's distinguished name (DN) should be in [RFC-2253](http://www.ietf.org/rfc/rfc2253.txt) format. The format of the `SSL_CLIENT_S_DN` environment variable (set by `mod_ssl` in Apache 2.2 and newer) is fully supported.
-* Alternatively, the value of this request header may be in "OpenSSL" format.
-
-### Revocation
-
-Certificate revocation list (CRL) checking works in all three supported configurations as long as the CRL file is distributed to the agents and masters using an "out of band" process. Puppet won't automatically update the CRL on any of the system's components.
-
-#### If unused:
-
-If revocation lists are **not** being used by the external CA, you must disable CRL checking on the agent. Set `certificate_revocation = false` in the `[agent]` section of [puppet.conf][conf] on **every agent node.**
-
-(If it's not set to false and the agent doesn't already have a CRL file, it will try to download one from the master. This will fail, because the master must have the CA service disabled.)
-
-#### If used:
-
-If revocation lists **are** being used by the external CA, then the CRL file must be manually distributed to **every agent node** as a Privacy Enhanced Mail (PEM) encoded bundle. Puppet will not automatically distribute this file.
-
-To determine where to put the CRL file, run `puppet agent --configprint hostcrl`.
 
 ## Option 1: Single CA
 
@@ -101,6 +55,10 @@ When Puppet uses its internal CA, it defaults to a single CA configuration. A si
       | Master SSL Cert |                | Agent SSL Cert |
       |                 |                |                |
       +-----------------+                +----------------+
+
+This configuration is all-or-nothing rather than mix-and-match. When using an external CA, the built-in Puppet CA service **must** be disabled and cannot be used to issue SSL certificates.
+
+Additionally, Puppet cannot automatically distribute certificates in this configurations --- you must have your own complete system for issuing and distributing certificates.
 
 ### Puppet master
 
@@ -134,61 +92,9 @@ Root CA certificate                | `puppet master --configprint localcacert`
 
 {{ master_basic }}
 
-With these files in place, the web server should be configured to:
+With these files in place, the puppetserver needs to be configured to use an external CA.  Follow the steps here ["Disable the Internal Puppet CA Service"][disablepuppetserverca]
 
-* Use the root CA certificate, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca.pem"
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 1
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{% capture master_config_ru %}
-
-The `config.ru` file for Rack has no special configuration when using an external CA. Please follow the standard Rack documentation for using Puppet with Rack. The following example will work with this version of Puppet:
-
-``` ruby
-$0 = "master"
-ARGV << "--rack"
-ARGV << "--confdir=/etc/puppetlabs/puppet"
-ARGV << "--vardir=/opt/puppetlabs/server/data/puppetserver"
-require 'puppet/util/command_line'
-run Puppet::Util::CommandLine.new.execute
-```
-{% endcapture %}
-
-{{ master_config_ru }}
+[disablepuppetserverca]: https://docs.puppet.com/puppetserver/latest/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
 ### Puppet agent
 
@@ -201,230 +107,70 @@ Credential                        | File location
 Agent SSL certificate             | `puppet agent --configprint hostcert`
 Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
 Root CA certificate               | `puppet agent --configprint localcacert`
+Root CRL certificate              | `puppet agent --configprint hostcrl`
 
-## Option 2: Single intermediate CA
+## Option 2: Puppet master functioning as an intermediate CA
 
-The single intermediate CA configuration builds from the single self-signed CA
-configuration and introduces one additional intermediate CA.
+The puppet master can operate as an intermediate CA to an external Root CA.  The puppet master cannot be an intermediate to an intermediate.  In this mode the puppet master CA is left enabled and generation of agent certificates can remain automated, however there are some limitations:
 
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +-----------+------------+
-                               |
-                               |
-                               v
-                   +------------------------+
-                   |                        |
-                   |    Intermediate CA     |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-The Root CA does not issue SSL certificates in this configuration. The intermediate CA issues SSL certificates for clients and servers alike.
+* Agent-side CRL checking is not possible however CRL verification will still happen on the puppetserver
+* The CA certificate bundle (ie the external Root CA combined with the Intermediate CA certificate) must be distributed to the agents manually - ideally before puppet runs
 
 ### Puppet master
 
-{{ master_basic }}
+Before configuring the puppet master, you will need to obtain the intermediate CA certificate from your external Root CA.  Generating the Intermediate CA cert is outside the scope of the doc, since it will depend your external certificate authority solution.  This guide assumes you are either starting with a fresh installation or have removed all SSL files from your existing master and are starting over.  Also, you should stop all puppet related services on the master server before this process.
 
-You must also create a **CA bundle** for the web server. Append **the two CA certificates** together; the Root CA certificate must be located after the intermediate CA certificate within the file.
+In order to configure the puppet master you will need the following files placed:
 
-``` bash
-cat intermediate_ca.pem root_ca.pem > ca_bundle.pem
+Certificate     | Purpose                     | File Location
+----------------|--------------------------------------------
+ca_crt.pem      | Intermediate CA Certificate | /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem
+ca_key.pem      | Intermediate CA Key         | /etc/puppetlabs/puppet/ssl/ca/ca_key.pem
+root_crt.pem    | Root CA Certificate         | /etc/puppetlabs/puppet/ssl/ca/root_crt.pem
+
+> Note: The root_crt.pem can actually be placed anywhere, however this doc assumes you placed it as shown
+
+> Note: The ca_key.pem needs to have any passphrase removed to match the expectations of the Puppet CA
+
+All of the files placed should have owner set to `puppet:puppet` and permissions of `0600`.
+
+Next, you have to generate the CA bundle to be placed on the master as well as any agents you create.  This is achieved by combining the Root CA and Intermediate CA certificates into one PEM file.
+
+```
+cd /etc/puppetlabs/puppet/ssl/ca
+cat ca_cert.pem root_crt.pem > ../certs/ca.pem
+```
+> Note: You also need to install a CRL file for the CA.  If you do not have one pre-generated from the Root CA you can easily create one by first executing `puppet cert generate fakehost` and then revoking this certificate with `puppet cert clean fakehost`.  If you do have a pre-generated CRL install it into `/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem.
+
+You now need to generate a new certificate for the puppet master to use.  Remember to include the `dns_alt_names` that this puppet master will need to service.
+
+```
+puppet cert generate puppetserver.my.domain.net --dns_alt_names=puppetserver,puppet
 ```
 
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
+You can now restart the puppetserver process and validate it successfully has started.  For other puppet services, please see ["Regenerating all Certificates for a Puppet deployment"][regen] for specific instructions.
 
-With these files in place, the web server should be configured to:
-
-* Use the intermediate+Root CA bundle, the master's certificate, and the master's key
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header])
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header])
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet CA"  Replace "Puppet CA" with the CN of your
-    # intermediate CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{{ master_config_ru }}
+[regen]: https://docs.puppet.com/puppet/latest/ssl_regenerate_certificates.html
 
 ### Puppet agent
 
-With an intermediate CA, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+In order for the puppet agent to work properly with this CA configuration you need to do two things:
+
+* Copy the CA bundle in place prior to a puppet run (ideally)
+* Disable certificate revocation validation
+
+The CA bundle needs to be copied to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.  If you copy this file in place prior to the first puppet execution you will not recieve any errors.  If you attempt to execute a puppet run prior to this file being present you will receive errors since the auto-distributed ca.pem file will not be the entire CA certificate chain. 
+
+Example error:
 
 ```
-[agent]
-ssl_client_ca_auth = $certdir/issuer.pem
+Error: Could not request certificate: SSL_connect returned=1 errno=0 state=error: certificate verify failed: [unable to get local issuer certificate for /CN=<master>]
 ```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Intermediate CA certificate       | `puppet agent --configprint ssl_client_ca_auth`
-
-## Option 3: Two intermediate CAs issued by one root CA
-
-This configuration uses different CAs to issue Puppet master certificates and Puppet agent
-certificates. This makes them easily distinguishable, and prevents any agent certificate from being
-usable for a Puppet master.
-
-                   +------------------------+
-                   |                        |
-                   |  Root self-signed CA   |
-                   |                        |
-                   +------+----------+------+
-                          |          |
-               +----------+          +------------+
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      |    Master CA    |                |    Agent CA    |
-      |                 |                |                |
-      +--------+--------+                +--------+-------+
-               |                                  |
-               |                                  |
-               v                                  v
-      +-----------------+                +----------------+
-      |                 |                |                |
-      | Master SSL Cert |                | Agent SSL Cert |
-      |                 |                |                |
-      +-----------------+                +----------------+
-
-In this configuration, Puppet agents are configured to only authenticate peer certificates issued by the Master CA. Puppet masters are configured to only authenticate peer certificates issued by the Agent CA.
-
-> **Note:** If you're using this configuration, you can't use the ActiveRecord inventory service backend with multiple Puppet master servers. Use [PuppetDB][] for the inventory service instead.
-
-### Puppet master
-
-{{ master_basic }}
-
-You must also create a **CA bundle** for the web server. Append the **Agent CA certificate and Root CA certificate** together; the Root CA certificate must be located after the Agent CA certificate within the file.
-
-``` bash
-cat agent_ca.pem root_ca.pem > ca_bundle_for_master.pem
-```
-
-Put this file somewhere predictable. Puppet doesn't use it directly, but it can live alongside Puppet's copies of the certificates.
-
-With these files in place, the web server should be configured to:
-
-* Use the Agent+Root CA bundle, the master's certificate, and the master's key.
-* Set the verification header (as specified in the master's [`ssl_client_verify_header` setting][verify_header]).
-* Set the client DN header (as specified in the master's [`ssl_client_header` setting][client_header]).
-
-An example of this configuration for Apache:
-
-``` apache
-Listen 8140
-<VirtualHost *:8140>
-    SSLEngine on
-    SSLProtocol ALL -SSLv2
-    SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
-
-    # Replace with the value of `puppet master --configprint hostcert`
-    SSLCertificateFile "/path/to/master.pem"
-    # Replace with the value of `puppet master --configprint hostprivkey`
-    SSLCertificateKeyFile "/path/to/master.key"
-
-    # Replace with the value of `puppet master --configprint localcacert`
-    SSLCACertificateFile "/path/to/ca_bundle_for_master.pem"
-    SSLCertificateChainFile "/path/to/ca_bundle_for_master.pem"
-
-    # Allow only clients with a SSL certificate issued by the intermediate CA with
-    # common name "Puppet Agent CA"  Replace "Puppet Agent CA" with the CN of your
-    # Agent CA certificate.
-    <Location />
-        SSLRequire %{SSL_CLIENT_I_DN_CN} eq "Puppet Agent CA"
-    </Location>
-
-    SSLVerifyClient optional
-    SSLVerifyDepth 2
-    SSLOptions +StdEnvVars
-    RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
-    RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
-
-    DocumentRoot "/etc/puppetlabs/puppet/public"
-
-    PassengerRoot /usr/share/gems/gems/passenger-3.0.17
-    PassengerRuby /usr/bin/ruby
-
-    RackAutoDetect On
-    RackBaseURI /
-</VirtualHost>
-```
-
-{{ master_config_ru }}
-
-### Puppet agent
-
-With split CAs, Puppet agent needs a modified value for [the `ssl_client_ca_auth` setting][ca_auth] in its [`puppet.conf`][conf]:
+Once the CA file is in place, disable certificate revocation validation by adding the following to the main section of puppet.conf:
 
 ```
-[agent]
-ssl_client_ca_auth = $certdir/ca_master.pem
+certificate_revocation = false
 ```
 
-The value should point to somewhere in the `$certdir`.
-
-Put the external credentials into the correct filesystem locations. You can run the following commands to find the appropriate locations:
-
-Credential                        | File location
-----------------------------------|------------------------------------------------
-Agent SSL certificate             | `puppet agent --configprint hostcert`
-Agent SSL certificate private key | `puppet agent --configprint hostprivkey`
-Root CA certificate               | `puppet agent --configprint localcacert`
-Master CA certificate             | `puppet agent --configprint ssl_client_ca_auth`
+Once you've completed both of these steps the agent will run successfully.


### PR DESCRIPTION
This PR replaces all of the 4.x documentation for External CA support.  Prior to this PR all of the documented CA strategies applied to the older (3.x and older) RACK based puppet master configuration. 