### PR TITLE
Fix setting jruby-puppet.use-legacy-auth-conf value

### DIFF
--- a/source/puppet/4.4/file_serving.markdown
+++ b/source/puppet/4.4/file_serving.markdown
@@ -68,7 +68,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 

--- a/source/puppet/4.5/file_serving.markdown
+++ b/source/puppet/4.5/file_serving.markdown
@@ -68,7 +68,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 

--- a/source/puppet/4.6/file_serving.markdown
+++ b/source/puppet/4.6/file_serving.markdown
@@ -68,7 +68,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 

--- a/source/puppet/4.7/file_serving.markdown
+++ b/source/puppet/4.7/file_serving.markdown
@@ -68,7 +68,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 

--- a/source/puppet/4.8/file_serving.markdown
+++ b/source/puppet/4.8/file_serving.markdown
@@ -70,7 +70,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 

--- a/source/puppet/4.9/file_serving.markdown
+++ b/source/puppet/4.9/file_serving.markdown
@@ -70,7 +70,7 @@ If necessary, you can restrict access to a custom mount point in [`auth.conf`][a
 
 ### New-style `auth.conf`
 
-If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: true`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
+If you've [disabled the legacy `auth.conf` file by setting `jruby-puppet.use-legacy-auth-conf: false`][disable_legacy], you'll be adding a rule to [Puppet Server's HOCON-format `auth.conf` file][auth.conf], located at `/etc/puppetlabs/puppetserver/conf.d/auth.conf`.
 
 Your new auth rule must meet the following requirements:
 


### PR DESCRIPTION
Hello

I noticed a small mistake in the documentation.

Excerpt from the documentation :

>use-legacy-auth-conf in the jruby-puppet section: If true, Puppet Server
>uses the Ruby authorization methods and Puppet auth.conf rule format and
>warns you that this is deprecated. If false, Puppet Server uses the new
>authorization method and HOCON auth.conf format. Default: true.