### PR TITLE
Update lang_data_string.md

### DIFF
--- a/source/puppet/4.9/lang_data_string.md
+++ b/source/puppet/4.9/lang_data_string.md
@@ -259,7 +259,7 @@ By default, heredocs end with a trailing line break, but you can exclude this li
 For example, Puppet would read this as a string with no line breaks:
 
 ```
-$mytext = @(EOT)
+$mytext = @("EOT")
     This's too inconvenient for ${double} or ${single} quotes, but needs to be one line.
     |-EOT
 ```


### PR DESCRIPTION
As noted in the enabling interpolation section you must include double quotes in order for a heredoc to allow interpolation.