### PR TITLE
(DOCUMENT-662) Add rack deprecation warning

### DIFF
--- a/source/puppet/4.10/passenger.markdown
+++ b/source/puppet/4.10/passenger.markdown
@@ -4,6 +4,11 @@ title: "Configuring a Puppet Master Server with Passenger and Apache"
 ---
 
 
+> ## Important: Deprecation warning
+>
+> [The Rack Puppet master server is deprecated][http://links.puppetlabs.com/deprecate-rack-webrick-servers] and will be removed in a future Puppet release.
+
+
 Puppet includes a basic Puppet master web server based on Ruby's WEBrick library. (This is what Puppet uses if you run `puppet master` on the command line or use most `puppetmaster` init scripts.)
 
 You **cannot** use this default server for real-life loads, as it can't handle concurrent connections; it is only suitable for small tests with ten nodes or fewer. You must configure a production quality web server before you start managing your nodes with Puppet.

--- a/source/puppet/4.9/passenger.markdown
+++ b/source/puppet/4.9/passenger.markdown
@@ -4,6 +4,11 @@ title: "Configuring a Puppet Master Server with Passenger and Apache"
 ---
 
 
+> ## Important: Deprecation warning
+>
+> [The Rack Puppet master server is deprecated][http://links.puppetlabs.com/deprecate-rack-webrick-servers] and will be removed in a future Puppet release.
+
+
 Puppet includes a basic Puppet master web server based on Ruby's WEBrick library. (This is what Puppet uses if you run `puppet master` on the command line or use most `puppetmaster` init scripts.)
 
 You **cannot** use this default server for real-life loads, as it can't handle concurrent connections; it is only suitable for small tests with ten nodes or fewer. You must configure a production quality web server before you start managing your nodes with Puppet.


### PR DESCRIPTION
The deprecation warning was on the top-level rack explanation page, but
not on the passenger install page. This was a problem due to deep links
that bypass the rack intro and people still are installing passenger
setups because they don't know better.