### PR TITLE
Add links to reference for functions

### DIFF
--- a/source/puppet/4.10/lang_template.md
+++ b/source/puppet/4.10/lang_template.md
@@ -48,6 +48,8 @@ Embedded Ruby (ERB)   | `template` | `inline_template`
 
 You can put template files in the `templates` directory of a [module][]. EPP files should have the `.epp` extension, and ERB files should have the `.erb` extension.
 
+`template` function reference can be found here [https://docs.puppet.com/puppet/latest/function.html#template], and for `epp` [https://docs.puppet.com/puppet/latest/function.html#epp]
+
 To use a template file, evaluate it with the `template` (ERB) or `epp` function as follows:
 
 ``` puppet
@@ -94,6 +96,8 @@ The keys of the hash must be [valid local variable names][] (minus the `$`). Ins
 The `template` function can take any number of additional template files, and will concatenate their outputs together to produce the final string.
 
 ### With a template string: `inline_template` and `inline_epp`
+
+`inline_template` function reference can be found here [https://docs.puppet.com/puppet/latest/function.html#inlinetemplate], and for `inline_epp` [https://docs.puppet.com/puppet/latest/function.html#inlineepp]
 
 If you have a [string][] value that contains template content, you can evaluate it with the `inline_template` (ERB) or `inline_epp` functions as follows:
 


### PR DESCRIPTION
I thought this would improve the documentation. Maybe it needs adding in older versions as well?

The links are definitely wrong, help on the correct format would be greatly appreciated. I will investigate further when time allows.