### PR TITLE
We don't need SPF/DKIM/DMARC security reports

### DIFF
--- a/source/security/vulnerability_submission_process.md
+++ b/source/security/vulnerability_submission_process.md
@@ -30,6 +30,7 @@ We do not need to receive reports on the following types of issues:
 - Disclosure or discovery of known public files or directories (for example, robots.txt, simple DNS enumeration)
 - Brute force attempts (for example, log-in and forgot password pages don't have lockouts)
 - Account enumeration (for example, enumerating login or reset fields for valid accounts without lockouts)
+- SPF, DMARC, or DKIM settings on our domains
 
 To contact the Puppet infrastructure team, use the following email address: [security-infrastructure@puppet.com](mailto:security-infrastructure@puppet.com).
 


### PR DESCRIPTION
We get a ton of these and they're always super low value. Recent
example:

    Email Spoofing

    There are few email spoofing tool is available free.one them is

    http://emkei.cz/

    when I tried to send a email from security-infrastructure@puppet.com
    and many more email id  to my email ,it was successful but when i
    tried to send the another from (reporter's name)@facebook.com , i
    did not receive any email.Hence, there might be some configuration
    missing in your mail servers

    This can be dangerous ,as attacker can send some fake bounty amount
    to some hacker,then hacker will claim back for the money (a sample
    mail attached),can lead to reputation loss :).Also the attacker can
    send mail to your customer regarding fake information about the
    products and many more things.

    You will get this message in the inbox as u can see in my POC

    I believe after reading this http://en.wikipedia.org/wiki/DMARC ,
    DMARC/DKIM can do the work !

They never have more context than "I spoofed this email, so you don't
have DMARC/DKIM/SPF".