### PR TITLE
Replace hiera %{server_facts.environment} with %{environment}

### DIFF
--- a/source/puppet/4.10/hiera_interpolation.md
+++ b/source/puppet/4.10/hiera_interpolation.md
@@ -68,7 +68,7 @@ Most people should only use the following variables:
 
 These three hashes have all the information that's most useful to Hiera. They also behave very predictably, which makes them the easiest to work with.
 
-> **Tip:** Most people need a hierarchy level that references the name of a node. The best way to get a node's name is with `trusted.certname`. If you need to reference a node's [environment][], use `server_facts.environment`.
+> **Tip:** Most people need a hierarchy level that references the name of a node. The best way to get a node's name is with `trusted.certname`. If you need to reference a node's [environment][], use `environment`.
 
 #### Avoid local variables
 


### PR DESCRIPTION
When testing with `sudo puppet lookup [name] --environment acceptance --node [fqdn] --explain`, I found that `%{server_facts.environment}` wasn't working. It produced an empty replacement. When replaced with `%{environment}`, it worked. I'm on 4.10, but it could be that other versions are affected as well.