### PR TITLE
Line edit pass on pdk docs

### DIFF
--- a/source/pdk/1.0/index.md
+++ b/source/pdk/1.0/index.md
@@ -2,14 +2,14 @@
 layout: default
 title: "Puppet Development Kit"
 canonical: "/pdk/1.0/pdk.html"
-description: "About the Puppet Development Kit, the shortest path to developing better Puppet code."
+description: "About Puppet Development Kit, the shortest path to developing better Puppet code."
 ---
 
-The Puppet Development Kit (PDK) is a package of development and testing tools to help you create great Puppet modules.
+Puppet Development Kit (PDK) is a package of development and testing tools to help you create great Puppet modules.
 
-The PDK includes key Puppet code development and testing tools for Linux, Windows, and OS X workstations, so you can install one package with the tools you need to create and validate new modules. The PDK includes testing tools, a complete module skeleton, and command line tools to help you create, validate, and run tests on Puppet modules. The PDK also includes all dependencies needed for its use.
+PDK includes key Puppet code development and testing tools for Linux, Windows, and OS X workstations, so you can install one package with the tools you need to create and validate new modules. PDK includes testing tools, a complete module skeleton, and command line tools to help you create, validate, and run tests on Puppet modules. PDK also includes all dependencies needed for its use.
 
-The PDK includes the following tools:
+PDK includes the following tools:
 
 Tool   | Description
 ----------------|-------------------------
@@ -23,7 +23,7 @@ rspec-puppet-facts | Adds support for running rspec-puppet tests against the fac
 
 ## Getting started
 
-To get started, install the PDK, create a module, and then create, validate, and test a class
+To get started, install PDK, create a module, and then create, validate, and test a class.
 
 <!--TK: overview workflow graphic-->
 
@@ -33,4 +33,4 @@ To get started, install the PDK, create a module, and then create, validate, and
 1. Generate a class for your module, using the `pdk new class` command.
 1. Validate and unit test your module.
 
-The PDK can unit test code that it generates, but for any other code you add, you'll need to write unit tests. As you add code to your module, validate and unit test your module before and after adding code. This ensures that you are always developing on a clean, valid codebase.
+PDK can unit test code that it generates, but for any other code you add, you'll need to write unit tests. As you add code to your module, validate and unit test your module before and after adding code. This ensures that you are always developing on a clean, valid codebase.

--- a/source/pdk/1.0/index.md
+++ b/source/pdk/1.0/index.md
@@ -7,14 +7,14 @@ description: "About the Puppet Development Kit, the shortest path to developing 
 
 The Puppet Development Kit (PDK) is a package of development and testing tools to help you create great Puppet modules.
 
-The PDK includes key Puppet code development and testing tools for Linux, Windows, and OS X workstations, so you can install one package with the tools you need to create and validate new modules. PDK includes testing tools, a complete module skeleton, and command line tools to help you create, validate, and run tests on Puppet modules. PDK also includes all dependencies needed for its use.
+The PDK includes key Puppet code development and testing tools for Linux, Windows, and OS X workstations, so you can install one package with the tools you need to create and validate new modules. The PDK includes testing tools, a complete module skeleton, and command line tools to help you create, validate, and run tests on Puppet modules. The PDK also includes all dependencies needed for its use.
 
-PDK includes the following tools:
+The PDK includes the following tools:
 
 Tool   | Description
 ----------------|-------------------------
-metadata-json-lint | Validates and lints `metadata.json` files in modules against  Puppet's module metadatastyle guidelines.
-pdk | Command line tool for generating and testing modules
+metadata-json-lint | Validates and lints `metadata.json` files in modules against Puppet's module metadata style guidelines.
+pdk | Generats and tests modules from the command line.
 puppet-lint | Checks your Puppet code against the recommendations in the Puppet Language style guide.
 puppet-syntax | Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.
 puppetlabs_spec_helper | Provides classes, methods, and Rake tasks to help with spec testing Puppet code.
@@ -28,9 +28,9 @@ To get started, install the PDK, create a module, and then create, validate, and
 <!--TK: overview workflow graphic-->
 
 1. Generate a module using the `pdk new module` command.
-1. Validate your module, to verify that it is well-formed.
-1. Unit test your module, to verify that all dependencies and directories are present.
+1. Validate your module to verify that it is well-formed.
+1. Unit test your module to verify that all dependencies and directories are present.
 1. Generate a class for your module, using the `pdk new class` command.
 1. Validate and unit test your module.
 
-PDK can unit test code that it generates, but for any other code you add, you'll need to write unit tests. As you add code to your module, be sure to validate and unit test your module both before and after adding code. This ensures that you are always developing on a clean, valid codebase.
+The PDK can unit test code that it generates, but for any other code you add, you'll need to write unit tests. As you add code to your module, validate and unit test your module before and after adding code. This ensures that you are always developing on a clean, valid codebase.

--- a/source/pdk/1.0/index.md
+++ b/source/pdk/1.0/index.md
@@ -14,7 +14,7 @@ The PDK includes the following tools:
 Tool   | Description
 ----------------|-------------------------
 metadata-json-lint | Validates and lints `metadata.json` files in modules against Puppet's module metadata style guidelines.
-pdk | Generats and tests modules from the command line.
+pdk | Generates and tests modules from the command line.
 puppet-lint | Checks your Puppet code against the recommendations in the Puppet Language style guide.
 puppet-syntax | Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.
 puppetlabs_spec_helper | Provides classes, methods, and Rake tasks to help with spec testing Puppet code.

--- a/source/pdk/1.0/pdk_generating_modules.md
+++ b/source/pdk/1.0/pdk_generating_modules.md
@@ -31,9 +31,7 @@ When you run the `pdk new module` command, the tool asks the following questions
 
 After you generate a module, validate and test the module _before_ you add classes or write new code in it. This allows you to verify that the module files and directories were correctly created.
 
-After you create the module, create classes by running the `pdk new class` command. It creates a class manifest, with the naming convention `<CLASS_NAME>.pp`. For the module's main class, which has the same name as the module, the class manifest is named `init.pp`.
-
-The new class command also creates a test template file for the class. You can then write tests in this template to validate your class's behavior.
+When you have validated the module, create classes by running the `pdk new class` command. The new class command also creates a test template file for the class. You can then write tests in this template to validate your class's behavior.
 
 Related topics:
 
@@ -99,10 +97,10 @@ Related topics:
 {:.task}
 ## Generate a class with PDK
 
-Use the `pdk new class` command to generate a new class for the module.
+Use the `pdk new class` command to generate a new class for the module. It creates a class manifest file, with the naming convention `class_name.pp`.
 
 > **Note:** To generate the module's main class, which is defined in an `init.pp` file, give the class the same name as the module.
 
 1. From the command line, in your module's directory, run `pdk new class <CLASS_NAME>` 
 
-PDK creates the new class manifest and a test file (`class_name_spec.rb`) in your module's `/spec/classes` directory. This test template checks that your class compiles on all supported operating systems as listed in the `metadata.json`. You can then write additional tests in the provided file to validate your class's behavior.
+PDK creates the new class manifest (`class_name.pp`) and a test file (`class_name_spec.rb`) in your module's `/spec/classes` directory. The test template checks that your class compiles on all supported operating systems as listed in the `metadata.json`. You can then write additional tests in the provided file to validate your class's behavior.

--- a/source/pdk/1.0/pdk_generating_modules.md
+++ b/source/pdk/1.0/pdk_generating_modules.md
@@ -18,10 +18,12 @@ To create module metadata, PDK asks you a series of questions. Each question has
 
 Optionally, you can skip the interview step and use the default answers for all metadata.
 
-* Your Puppet Forge username. If you don't have a Forge account, you can accept the default value for this question. If you create a Forge account later, edit the module metadata manually with the correct value. 
+When you run the `pdk new module` command, the tool asks the following questions:
+
+* Your Puppet Forge user name. If you don't have a Forge account, you can accept the default value for this question. If you create a Forge account later, edit the module metadata manually with the correct value. 
 * Module version. We use and recommend semantic versioning for modules.
-* The module author's name.
-* The license under which your module is made available. This should be an identifier from [SPDX License List](https://spdx.org/licenses/).
+* Your name.
+* The license under which your module is made available, an identifier from [SPDX License List](https://spdx.org/licenses/).
 * A one-sentence summary about your module.
 * The URL to your module's source code repository, so that other users can contribute back to your module.
 * The URL to a web site that offers full information about your module, if you have one.
@@ -29,37 +31,37 @@ Optionally, you can skip the interview step and use the default answers for all 
 
 After you generate a module, validate and test the module _before_ you add classes or write new code in it. This allows you to verify that the module files and directories were correctly created.
 
-PDK does not generate any classes at module creation. You'll create new classes with the `pdk new class` command, which creates a class manifest, with the naming convention. `class_name.pp`. The exception to this is for a module's main class, which you create with the same name as the module, resulting in a manifest named `init.pp`.
+After you create the module, create classes by running the `pdk new class` command. It creates a class manifest, with the naming convention `<CLASS_NAME>.pp`. For the module's main class, which has the same name as the module, the class manifest is named `init.pp`.
 
-PDK also creates a test template file for the class. You can then write tests in this template to validate your class's behavior.
+The new class command also creates a test template file for the class. You can then write tests in this template to validate your class's behavior.
 
 Related topics:
 
 * [Module metadata][metadata]
 
 {:.task}
-### Generate a module with pdk
+### Generate a module with PDK
 
-To generate a module with PDK's default template, use the `pdk new module` command.
+To generate a module with a default template, use the `pdk new module` command.
 
 Before you begin, ensure that you've installed the PDK package. If you are running PDK behind a proxy, be sure you've added the correct environment variables. See [Running PDK behind a proxy](./pdk_install.hmtl#running-pdk-behind-a-proxy) for details.
 
-1. From the command line, run the `pdk new module` command, specifying the name of the module: `pdk new module module_name`
+1. From the command line, run the new module command, specifying the name of the module: `pdk new module <MODULE_NAME>`
    
-   Optionally, to skip the interview questions and generate the module with default values, use the ``skip-interview` flag when you generate the module: `pdk new module module_name --skip-interview`
+   Optionally, to skip the interview questions and generate the module with default values, add the `skip-interview` flag: `pdk new module <MODULE_NAME> --skip-interview`
 
-1. Respond to the PDK dialog questions in the terminal. Each question indicates the default value it will use if you just hit **Enter**.
+1. Respond to the PDK dialog questions. Each question indicates the default value it will use if you just press **Enter**.
 
    1. Forge username: Enter your Forge username, if you have a Forge account.
    2. Version: Enter the semantic version of your module, such as "0.1.0".
-   3. Author: Enter the name of the module author.
+   3. Author: Enter the name of the module author (you or someone else responsible for the module's content).
    4. License: If you want to specify a license other than "Apache-2.0," specify that here, such as "MIT", or "proprietary".
    5. Description: Enter a one-sentence summary that helps other users understand what your module does.
    6. Source code repository: Enter the URL to your module's source code repository.
    7. Where others can learn more: If you have a website where users can learn more about your module, enter the URL.
    8. Where others can report issues: If you have a public bug tracker for your module, enter the URL.
 
-1. If the metadata that PDK displays is correct, confirm to generate the module. If it is incorrect, enter `n` to cancel and start over.
+1. If the metadata that PDK displays is correct, confirm to generate the module. If it is incorrect, cancel and start over.
 
 {:.reference}
 ### Module contents
@@ -78,16 +80,16 @@ Rakefile | File listing tasks and dependencies.
 `appveyor.yml` | File containing configuration for Appveyor CI integration.
 `.gitattributes` | Recommended defaults for using Git.
 `.gitignore` | File listing module files that Git should ignore.
-`/manifests` | Directory containing module manifests, each of which defines one class or defined type. PDK creates manifests only when you generate them with the `pdk new class` command.
+`/manifests` | Directory containing module manifests, each of which defines one class or defined type. PDK creates manifests when you generate them with the `pdk new class` command.
 `metadata.json` | File containing metadata for the module.
-`.pmtignore` | File listing module files that the `puppet module` command should ignore. `.rspec` | File containing the default configuration for RSpec.
+`.pmtignore` | File listing module files that the `puppet module` command should ignore. 
+`.rspec` | File containing the default configuration for RSpec.
 `.rubocop.yml` | File containing recommended settings for Ruby style checking.
 `/spec` | Directory containing files and directories for spec testing.
 `/spec/spec_helper.rb` | File containing containing any ERB or EPP templates.
 `/spec/default_facts.yaml` | File containing default facts.
 `/spec/classes` | Directory containing testing templates for any classes you generate with the `pdk new class` command.
-`/templates` | Directory containing any ERB or EPP templates.
-Required when building a module to upload to the Forge.
+`/templates` | Directory containing ERB or EPP templates. Required when building a module to upload to the Forge.
 `.travis.yml` | File containing configuration for cloud-based testing on Linux and OSX. See [travis-ci](http://travis-ci.org/) for more information.
 
 Related topics:
@@ -95,14 +97,12 @@ Related topics:
 * [Module fundamentals][fundamentals]
 
 {:.task}
-## Generate a class
+## Generate a class with PDK
 
-To generate a class in your module, use the `pdk new class` command, specifying the name of your new class. To generate the main class of the module, which is defined in an `init.pp` file, give the class the same name as the module.
+Use the `pdk new class` command to generate a new class for the module.
 
-1. From the command line, in your module's directory, run `pdk new class class_name`. 
-   
-   ``` bash
-   pdk new class class_name
-   ```
+> **Note:** To generate the module's main class, which is defined in an `init.pp` file, give the class the same name as the module.
 
-PDK creates the new class manifest and a test file (as `class_name_spec.rb`) in your module's `/spec/classes` directory. This test template checks that your class compiles on all supported operating systems as listed in the `metadata.json`. You can then write additional tests in the provided file to validate your class's behavior.
+1. From the command line, in your module's directory, run `pdk new class <CLASS_NAME>` 
+
+PDK creates the new class manifest and a test file (`class_name_spec.rb`) in your module's `/spec/classes` directory. This test template checks that your class compiles on all supported operating systems as listed in the `metadata.json`. You can then write additional tests in the provided file to validate your class's behavior.

--- a/source/pdk/1.0/pdk_generating_modules.md
+++ b/source/pdk/1.0/pdk_generating_modules.md
@@ -18,7 +18,7 @@ To create module metadata, PDK asks you a series of questions. Each question has
 
 Optionally, you can skip the interview step and use the default answers for all metadata.
 
-When you run the `pdk new module` command, the tool asks the following questions:
+When you run the `pdk new module` command, the tool requests the following information:
 
 * Your Puppet Forge user name. If you don't have a Forge account, you can accept the default value for this question. If you create a Forge account later, edit the module metadata manually with the correct value. 
 * Module version. We use and recommend semantic versioning for modules.

--- a/source/pdk/1.0/pdk_install.md
+++ b/source/pdk/1.0/pdk_install.md
@@ -7,19 +7,16 @@ description: "Installing the Puppet Development Kit, the shortest path to develo
 
 [troubleshoot]: ./pdk_troubleshooting.html
 
-Install the Puppet Development Kit (PDK) as your first step in creating and testing Puppet modules.
+Install Puppet Development Kit (PDK) as your first step in creating and testing Puppet modules.
 
-{:.section}
-### Before you begin
+PDK is a stand-alone development kit and does not require a Puppet installation.
 
-PDK is a stand-alone development kit and does not require a pre-existing installation of Puppet.
+If you used an early release version of PDK, uninstall it before installing PDK 1.0. Use your platform's package manager to uninstall any PDK versions earlier than 1.0, and then install the updated 1.0 package.
 
-If you used an early release version of PDK, we recommend you uninstall it before installing PDK 1.0. Use your platform's package manager to uninstall any PDK versions earlier than 1.0, and then install the updated 1.0 package.
+By default, PDK installs to the following location:
 
-By default, PDK installs to:
-
-* Linux and OS X systems: `/opt/puppetlabs/pdk/`
-* Windows systems: `C:\Program Files\Puppet Labs\DevelopmentKit`
+* On Linux and OS X: `/opt/puppetlabs/pdk/`
+* On Windows: `C:\Program Files\Puppet Labs\DevelopmentKit`
 
 {:.reference}
 ### Requirements and limitations
@@ -51,7 +48,7 @@ Download and install the PDK package for Linux-based systems.
 1. Install the `pdk` package using the command appropriate to your system:
    * On RPM-based (Red Hat, SLES) systems, run `sudo rpm -ivh pdk-<version>-<platform>.rpm`
    * On Debian-based (Debian, Ubuntu) systems, run `sudo dpkg -i pdk-<version>-<platform>.rpm`
-1. Open a new terminal to re-source your shell profile and make PDK available to your PATH.
+1. Open a terminal to re-source your shell profile and make PDK available to your PATH.
 
 {:.task}
 ## Install PDK on OS X
@@ -60,7 +57,7 @@ Download and install the PDK package for Mac OS X systems.
 
 1. Download the PDK package from [PDK downloads site](https://puppet.com/download-puppet-development-kit).
 1. Double click on the downloaded package to install.
-2. Open a new terminal to re-source your shell profile and make PDK available to your PATH.
+2. Open a terminal to re-source your shell profile and make PDK available to your PATH.
 
 {:.task}
 ## Install PDK on Windows
@@ -72,7 +69,7 @@ Download and install the PDK package for Windows systems.
 1. Open a new Powershell window to re-source your profile and make PDK available to your PATH. If you are running PowerShell 3.0 or later, PDK loads automatically and the `pdk` command is now available to the prompt.
 1. If you are running PowerShell 2.0, load the module by running `Import-Module -Name PuppetDevelopmentKit` in your PowerShell window.
 
-On some Windows installations, you might get execution policy restriction errors when you try to run `pdk` commands. See the [PDK troubleshooting][troubleshoot] guide for help.
+If you get execution policy restriction errors when you try to run `pdk` commands, see [PDK troubleshooting][troubleshoot] for help.
 
 {:.concept}
 ## Setting up PDK behind a proxy
@@ -81,16 +78,16 @@ If you are using PDK behind a proxy, you must set environment variables before r
 
 You can either set these variables on the command line before each working session or add them to your system configuration, which varies depending on the operating system.
 
-On Windows systems, run:
-
-```
-$env:http_proxy="http://user:password@proxy.domain.com:port"
-$env:https_proxy="http://user:password@proxy.domain.com:port"
-```
-
-On Linux-based or OS X systems, run:
+On Linux-based systems or OS X, run:
 
 ```
 export http_proxy="http://user:password@proxy.domain.com:port"
 export https_proxy="http://user:password@proxy.domain.com:port"
+```
+
+On Windows, run:
+
+```
+$env:http_proxy="http://user:password@proxy.domain.com:port"
+$env:https_proxy="http://user:password@proxy.domain.com:port"
 ```

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -65,23 +65,23 @@ pdk validate [--format=<FORMAT>[:<TARGET_FILE>]] [<VALIDATIONS>] [<TARGETS>*]
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
 `--list` | Displays a list of available validations and their descriptions. Using this option lists the tests without running them. | None.    | No default.
-`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example: `--format=junit:report.xml` | Specifies the output format and an output target file. Valide formats are `junit` (JUnit XML), `text`(plain text). Multiple `--format` options can be specified as long as they all have distinct output targets.  | `text`
+`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example: `--format=junit:report.xml` Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text).  | `text`
 `--parallel` | Runs all validations simultaneously, using multiple threads. | None.    | No default.
 `<VALIDATIONS>` | A comma-separated list of validations to run (or `all`) | See the `--list` output for a list of available validations.    | `all`
-`<TARGETS>` | A list of directories or individual files to validate. Validations which are not applicable to individual files will be skipped for those files. | A space-separated list fof directories or files.    | Validates all available directories and files.
+`<TARGETS>` | A list of directories or individual files to validate. Validations which are not applicable to individual files will be skipped for those files. | A space-separated list of directories or files.    | Validates all available directories and files.
 
 ## `pdk test unit` command
 
-Runs unit tests. Any errors are displayed to the console and reported in the report-file, if requested. The exitcode is non-zero when errors occur.
+Runs unit tests. Errors are displayed to the console and reported in the target file, if specified. The exit code is non-zero when errors occur.
 
 Usage:
 
 ```
-pdk test unit [--list] [--tests=test_list] [--format=format[:target]] [runner_options]
+pdk test unit [--list] [--tests=<TEST_LIST>] [--format=<FORMAT>[:<TARGET_FILE>]] [runner_options]
 ```
 
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
 `--list` | Displays a list of unit tests and their descriptions. Using this option lists the tests without running them. | None.    | No default.
-`--tests=test_list` | A comma-separated list of tests to run. Use this during development to pinpoint a single failing test. | See the `--list` output for allowed values.    | No default.
-`--format=format[:target]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format with the syntax:`--format=junit:report.xml`. Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text).     | `text`
+`--tests=<TEST_LIST>` | A comma-separated list of tests to run. Use this during development to pinpoint a single failing test. | See the `--list` output for allowed values.    | No default.
+`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example:`--format=junit:report.xml`. Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text).     | `text`

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -12,18 +12,18 @@ Generates a new module.
 Usage:
 
 ```
-pdk new module [--template-url=git_url] [--license=spdx_identifier] module_name [target_dir]
+pdk new module [--template-url=<GIT_URL>] [--license=<IDENTIFIER>] <module_name> [<TARGET_DIR>]
 ```
 
-The `pdk new module` command accepts the following arguments and options. Arguments are optional unless otherwise specified.
+The `pdk new module` command accepts the following arguments and options. Arguments are optional unless the Description indicates it is **Required**.
 
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
-`--template-url=git_url` | Overrides the template to use for this module. | A valid Git URL or path to a local template.    | Defaults to the current pdk-module-template.    | No default.
-`--license=spdx_identifier` | Specifies the license this module is written under. | See https://spdx.org/licenses/ for a list of open source licenses, or use `proprietary`.    | Apache-2.0
-`--skip-interview` | Suppress interactive queries for initial values. Metadata will be generated with default values for all questions.| None    | Ask questions.
-`module_name` | **Required**. Specifies the name of the module being created. | A module name beginning with a lowercase letter and including only lowercase letters, digits, and underscores.    | No default.
-`target_dir` | Specifies the directory that the new module will be created in. | A valid directory path.    | Creates a directory with the given `module_name` inside the current directory.
+`--template-url=<GIT_URL>` | Overrides the template to use for this module. | A valid Git URL or path to a local template.    | Defaults to the current pdk-module-template.    | No default.
+`--license=<IDENTIFIER>` | Specifies the license for this module. | See https://spdx.org/licenses/ for a list of open source licenses, or use `proprietary`.    | `Apache-2.0`
+`--skip-interview` | Suppress interactive questions. Default values for all metadata.| None    | Ask questions.
+`<module_name>` | **Required**. Specifies the name of the module being created. | A module name beginning with a lowercase letter and including only lowercase letters, digits, and underscores.    | No default.
+`<TARGET_DIR>` | Specifies the directory that the new module will be created in. | A valid directory path.    | Creates a directory with the given `module_name` inside the current directory.
 
 ## `pdk new class` command
 
@@ -32,7 +32,7 @@ Generates a new class and test templates for it in the current module.
 Usage:
 
 ```
-pdk new class [--template-url=git_url] <class_name>
+pdk new class [--template-url=<GIT_URL>] <class_name> [<parameter_name>[:<PARAMETER_TYPE>]]
 ```
 
 For example:
@@ -44,9 +44,9 @@ pdk new class my_class
 
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
-`--template-url` | Overrides the template to use when generating this class. | A valid Git URL or path to a local template.   | Uses the template used to generate the module. If that template is not available, the default template at [puppetlabs/pdk-module-template](https://github.com/puppetlabs/pdk-module-template) is used.
-`class_name` | **Required**. The name of the class to generate. | A class name beginning with a lowercase letter and including only lowercase letters, digits, and underscores.    | No default.
-`parameter_name[:parameter_type]` | Parameters for the generated class. Specify any number of parameters on the command line. | A valid parameter name, optionally with the parameter's data type.    | No default.
+`--template-url=<GIT_URL>` | Overrides the template to use when generating this class. | A valid Git URL or path to a local template.   | Uses the template used to generate the module. If that template is not available, the default template at [puppetlabs/pdk-module-template](https://github.com/puppetlabs/pdk-module-template) is used.
+`<class_name>` | **Required**. The name of the class to generate. | A class name beginning with a lowercase letter and including only lowercase letters, digits, and underscores.    | No default.
+`<parameter_name>[:<PARAMETER_TYPE>]` | Parameters for the generated class. Specify any number of parameters on the command line. | A valid parameter name, optionally with the parameter's data type.    | No default.
 
 ## `pdk validate` command
 

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -77,7 +77,10 @@ Runs unit tests. Errors are displayed to the console and reported in the target 
 Usage:
 
 ```
-pdk test unit [--list] [--tests=<TEST_LIST>] [--format=<FORMAT>[:<TARGET_FILE>]] [runner_options]
+pdk test unit --list
+```
+or```
+pdk test unit [--tests=<TEST_LIST>] [--format=<FORMAT>[:<TARGET_FILE>]]
 ```
 
 Argument   | Description   | Values      | Default

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Puppet Development Kit command reference"
 canonical: "/pdk/1.0/pdk_reference.html"
-description: "Commands for the Puppet Development Kit, the shortest path to developing better Puppet code."
+description: "Commands for Puppet Development Kit, the shortest path to developing better Puppet code."
 ---
 
 ## `pdk new module` command

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -79,7 +79,8 @@ Usage:
 ```
 pdk test unit --list
 ```
-or```
+or
+```
 pdk test unit [--tests=<TEST_LIST>] [--format=<FORMAT>[:<TARGET_FILE>]]
 ```
 

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -65,10 +65,10 @@ pdk validate [--format=<FORMAT>[:<TARGET_FILE>]] [<VALIDATIONS>] [<TARGETS>*]
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
 `--list` | Displays a list of available validations and their descriptions. Using this option lists the tests without running them. | None.    | No default.
-`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example: `--format=junit:report.xml` | Specifies the output format and an output target file. Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text)    | `text`
+`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example: `--format=junit:report.xml` | Specifies the output format and an output target file. Valide formats are `junit` (JUnit XML), `text`(plain text). Multiple `--format` options can be specified as long as they all have distinct output targets.  | `text`
 `--parallel` | Runs all validations simultaneously, using multiple threads. | None.    | No default.
-`validations` | Specifies a comma-separated list of validations to run (or `all`) | See the `--list` output for a list of available validations.    | `all`
-`targets` | Specifies a list of directories or individual files to validate. Validations which are not applicable to individual files will be skipped for those files. | A space-separated list.    | Validates all available directories and files.
+`<VALIDATIONS>` | A comma-separated list of validations to run (or `all`) | See the `--list` output for a list of available validations.    | `all`
+`<TARGETS>` | A list of directories or individual files to validate. Validations which are not applicable to individual files will be skipped for those files. | A space-separated list fof directories or files.    | Validates all available directories and files.
 
 ## `pdk test unit` command
 

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -57,15 +57,15 @@ Usage:
 ```
 pdk validate --list
 ```
-
+or
 ```
-pdk validate [--format=format[:target]] [validations] [targets*]
+pdk validate [--format=<FORMAT>[:<TARGET_FILE>]] [<VALIDATIONS>] [<TARGETS>*]
 ```
 
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
 `--list` | Displays a list of available validations and their descriptions. Using this option lists the tests without running them. | None.    | No default.
-`--format=format[:target]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format with the syntax: `--format=junit:report.xml` | Specifies the output format and an output target file. Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text)    | `text`
+`--format=<FORMAT>[:<TARGET_FILE>]` | Specifies the format of the output. Optionally, you can specify a target file for the given output format, for example: `--format=junit:report.xml` | Specifies the output format and an output target file. Multiple `--format` options can be specified as long as they all have distinct output targets. | `junit` (JUnit XML), `text`(plain text)    | `text`
 `--parallel` | Runs all validations simultaneously, using multiple threads. | None.    | No default.
 `validations` | Specifies a comma-separated list of validations to run (or `all`) | See the `--list` output for a list of available validations.    | `all`
 `targets` | Specifies a list of directories or individual files to validate. Validations which are not applicable to individual files will be skipped for those files. | A space-separated list.    | Validates all available directories and files.

--- a/source/pdk/1.0/pdk_reference.md
+++ b/source/pdk/1.0/pdk_reference.md
@@ -19,7 +19,7 @@ The `pdk new module` command accepts the following arguments and options. Argume
 
 Argument   | Description   | Values      | Default
 ----------------|:---------------:|:------------------:|-------------------------
-`--template-url=<GIT_URL>` | Overrides the template to use for this module. | A valid Git URL or path to a local template.    | Defaults to the current pdk-module-template.    | No default.
+`--template-url=<GIT_URL>` | Overrides the template to use for this module. | A valid Git URL or path to a local template.    | The current pdk-module-template. 
 `--license=<IDENTIFIER>` | Specifies the license for this module. | See https://spdx.org/licenses/ for a list of open source licenses, or use `proprietary`.    | `Apache-2.0`
 `--skip-interview` | Suppress interactive questions. Default values for all metadata.| None    | Ask questions.
 `<module_name>` | **Required**. Specifies the name of the module being created. | A module name beginning with a lowercase letter and including only lowercase letters, digits, and underscores.    | No default.

--- a/source/pdk/1.0/pdk_testing.md
+++ b/source/pdk/1.0/pdk_testing.md
@@ -65,7 +65,7 @@ PDK includes tools for running unit tests, but it does not write unit tests itse
 
 After you've written your unit tests, run the `pdk test unit` command to run all of the tests you've included in your module.
 
-Test and validate your module anytime you are going to modify or add code, to verify that you are starting out with clean code. Then, as you create classes and write other code in your module, continue to write and run unit tests, and validate.
+Test and validate your module anytime you are going to modify or add code, to verify that you are starting out with clean code. Then, as you create classes and write other code in your module, continue to validate it, and to write and run unit tests.
 
 Related links:
 

--- a/source/pdk/1.0/pdk_testing.md
+++ b/source/pdk/1.0/pdk_testing.md
@@ -2,13 +2,13 @@
 layout: default
 title: "Validating and testing modules with the Puppet Development Kit"
 canonical: "/pdk/1.0/pdk_testing.html"
-description: "Testing modules with the Puppet Development Kit, the shortest path to developing better Puppet code."
+description: "Testing modules with Puppet Development Kit, the shortest path to developing better Puppet code."
 ---
 
 {:.concept}
 ## Validating and testing your module with PDK
 
-The Puppet Development Kit (PDK) provides tools to help you run unit tests on your module and validate your module's metadata, syntax, and style.
+Puppet Development Kit (PDK) provides tools to help you run unit tests on your module and validate your module's metadata, syntax, and style.
 
 By default, the PDK module template includes tools that can:
 
@@ -23,11 +23,11 @@ If you are working behind a proxy, before you begin, ensure that you've added th
 {:.concept}
 ### Validating modules
 
-The validations included in PDK provide a basic check of the well-formedness of the module and syntax and style of the module's files. You do not need to write any tests for this validation.
+The validations included in PDK provide a basic check of the well-formedness of the module, and the syntax and style of the module's files. You do not need to write any tests for this validation.
 
-By default, the `pdk validate` command validates the module's metadata, Puppet code syntax and style, and Ruby code syntax and style. You can also validates specific directories or files in the module, or validate  only certain types of validation, such as metadata or Puppet code.
+By default, the `pdk validate` command validates the module's metadata, Puppet code syntax and style, and Ruby code syntax and style. You can customize it to validate specific directories or files in the module, or validate only certain types of validation, such as metadata or Puppet code.
 
-You can also send module validation output in either JUnit or text format to a file. You can specify multiple output formats and targets in the same command, as long as the targets are each unique.
+You can send module validation output to a file in either JUnit or text format. You can specify multiple output formats and targets in the same command, as long as the targets are each unique.
 
 {:.task}
 ### Validate a module
@@ -36,21 +36,19 @@ To validate that your module is well-formed with correct syntax, run the `pdk va
 
 Optionally, you can validate only certain files or directories, run a specific type of validations, such as metadata or Puppet validation, or run all validations simultaneously. Additionally, you can send your validation output to a file in either JUnit or text format.
 
-1. In your module's directory, from the command line, run `pdk validate`.
+1. In your module's directory, from the command line, run `pdk validate`
 
-   * To run all validations simultaneously, use the `--parallel` flag and run `pdk validate --parallel`.
+   * To run all validations simultaneously, use the `--parallel` flag: `pdk validate --parallel`
 
-   * To run just one type of validation on the module, specify `puppet`, `ruby`, or `metadata`. For example, to validate the module's metadata, run `pdk validate metadata`.
+   * To run just one type of validation on the module, pass in `puppet`, `ruby`, or `metadata`. For example, to validate the module's metadata, run `pdk validate metadata`
    
-   * To run validations on a specific directory or file, pass the name of the file or directory as an argument with `pdk validate`. For example, to run all validations on the `/lib` directory only, run `pdk validate lib/`.
+   * To run validations on a specific directory or file, pass in the name of the file or directory. For example, to run all validations on the `/lib` directory only, run `pdk validate lib/`
 
-   * To send module validation output to a file, use the `pdk validate` command with the option `--format=format[:target]`. This option specifies the output format and an output target file. For example, to create a report file `report.txt`, run `pdk validate --format=txt:report.txt`.
+   * To send module validation output to a file, use the option `--format=format[:target]`, which lets you specify the desired output format and target file. For example, to create a report file `report.txt`, run `pdk validate --format=txt:report.txt`
 
-     You can specify multiple `--format` options, as long as they all have distinct output targets.
+     You can specify multiple `--format` options, provided they all have distinct output targets.
 
-   
-
-See the PDK reference for a complete list of validation options.
+See the PDK reference for a complete list of validation command options.
 
 Related topics:
 
@@ -59,15 +57,15 @@ Related topics:
 {:.concept}
 ### Unit testing modules
 
-PDK can also run your unit tests on a module's Puppet code to verify that it compiles on all supported operating systems, and that the resources declared will be included in the catalog. PDK cannot test changes to the managed system or services.
+PDK can run your unit tests on a module's Puppet code to verify that it compiles on all supported operating systems, and that the resources declared will be included in the catalog. PDK cannot test changes to the managed system or services.
 
 When you generate a class, PDK creates a unit test file. This test file, located in your module's `/spec/classes` folder, includes a basic template for writing your unit tests. To learn more about how to write unit tests, see [rspec-puppet documentation](http://rspec-puppet.com/tutorial/).
 
-PDK includes tools for running unit tests, but it does not write unit tests itself. However, if you are testing an empty PDK-generated module, you can run the unit test command to ensure that all dependencies are present and that the spec directory was created correctly. 
+PDK includes tools for running unit tests, but it does not write unit tests itself. However, if you are testing an empty PDK-generated module, you can run the unit test command to verify that all dependencies are present and that the spec directory was created correctly. 
 
-After you've written your unit tests, you can use the `pdk test unit` command to run all of the tests you've included in your module.
+After you've written your unit tests, run the `pdk test unit` command to run all of the tests you've included in your module.
 
-We suggest testing and validating your module anytime you are going to modify or add code, to verify that you are starting out with clean code. Then, as you create classes and write other code in your module, continue to write unit tests, validate, and unit test your code.
+Test and validate your module anytime you are going to modify or add code, to verify that you are starting out with clean code. Then, as you create classes and write other code in your module, continue to write and run unit tests, and validate.
 
 Related links:
 
@@ -83,13 +81,9 @@ To unit test your module, use the `pdk test unit` command. This command runs all
 
 Before you begin, ensure that you have written unit tests for your module, unless you are unit testing a newly generated module with no classes or code in it.
 
-1. In your module's directory, from the command line, run:
+1. In your module's directory, from the command line, run `pdk test unit`
 
-``` bash
-pdk test unit
-```
-
-If there are no errors, this returns successfully as `exit code 0`, with no warnings.
+If there are no errors, the command returns successfully as `exit code 0`, with no warnings.
 
 See the PDK reference for a complete list of unit test options.
 

--- a/source/pdk/1.0/pdk_troubleshooting.md
+++ b/source/pdk/1.0/pdk_troubleshooting.md
@@ -2,17 +2,17 @@
 layout: default
 title: "Troubleshooting the Puppet Development Kit"
 canonical: "/pdk/1.0/pdk_troubleshooting.html"
-description: "Troubleshooting the Puppet Development Kit, the shortest path to developing better Puppet code."
+description: "Troubleshooting Puppet Development Kit, the shortest path to developing better Puppet code."
 ---
 
 
 {:.concept}
-### Windows: execution policy restrictions
+### Windows: Execution policy restrictions
 
 In some Windows installations, trying to run the `pdk` command causes errors related to execution policy restrictions.
 
-To fix this issue, set your script execution policy to at least [RemoteSigned](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.security/set-executionpolicy) by running `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned`.
+To fix this issue, set your script execution policy to at least [RemoteSigned](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.security/set-executionpolicy) by running `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned`
 
 Alternatively, you can change the `Scope` parameter of the `ExecutionPolicy` to the current session only by running `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
-For more information about PowerShell `ExecutionPolicies` or how to change them, see Microsoft documentation [about_Execution_Policies](http://go.microsoft.com/fwlink/?LinkID=135170).
+For more information about PowerShell execution policies and how to change them, see Microsoft documentation [about_Execution_Policies](http://go.microsoft.com/fwlink/?LinkID=135170).

--- a/source/pdk/1.0/release_notes.md
+++ b/source/pdk/1.0/release_notes.md
@@ -3,7 +3,7 @@ layout: default
 title: "Puppet Development Kit release notes"
 ---
 
-Release notes for the Puppet Development Kit (PDK), a development kit containing key Puppet code development and testing tools.
+Release notes for the Puppet Development Kit (PDK), a development kit containing tools for developing and testing Puppet code.
 
 ## Puppet Development Kit 1.0
 

--- a/source/pdk/1.0/release_notes.md
+++ b/source/pdk/1.0/release_notes.md
@@ -3,13 +3,13 @@ layout: default
 title: "Puppet Development Kit release notes"
 ---
 
-Release notes for the Puppet Development Kit (PDK), a development kit containing tools for developing and testing Puppet code.
+Release notes for Puppet Development Kit (PDK), a development kit containing tools for developing and testing Puppet code.
 
 ## Puppet Development Kit 1.0
 
 Released 15 August 2017.
 
-This is the first major release of the Puppet Development Kit (PDK).
+This is the first major release of Puppet Development Kit (PDK).
 
 ### New features
 


### PR DESCRIPTION
Biggest change is enforcing style for user input on commands, so it's clearer what's part of the command syntax, and what's a variable/name the user supplies. Puppet style is to specify user input <LIKE_THIS> so I changed it to that, except for <module_name> and <class_name> which I did <like_that> to indicate the lowercase requirement for those names. Adjust as you see fit. If this goes against all style you've been using in module developer docs, then just disregard, but I'm curious how readers to distinguish this kind of difference. Maybe examples make it clear enough.