### PR TITLE
Facter 3.9 documentation (HOLD FOR RELEASE)

### DIFF
--- a/source/facter/3.9/_facter_toc.html
+++ b/source/facter/3.9/_facter_toc.html
@@ -1,0 +1,1 @@
+{% partial /puppet/5.1/_puppet_toc.html %}

--- a/source/facter/3.9/_facter_toc.html
+++ b/source/facter/3.9/_facter_toc.html
@@ -1,1 +1,1 @@
-{% partial /puppet/5.1/_puppet_toc.html %}
+{% partial /puppet/5.2/_puppet_toc.html %}

--- a/source/facter/3.9/configuring_facter.md
+++ b/source/facter/3.9/configuring_facter.md
@@ -1,0 +1,109 @@
+---
+layout: default
+toc_levels: 1
+title: "Configuring Facter with facter.conf"
+---
+
+The `facter.conf` file is a configuration file that allows you to cache and block fact groups, and manage how Facter interacts with your system. There are three sections: `facts`, `global` and `cli`. All sections are optional and can be listed in any order within the file.
+
+When you run Facter from the Ruby API, only the `facts` section and limited `global` settings are loaded.
+
+Example facter.conf file:
+
+~~~
+facts : {
+    blocklist : [ "file system", "EC2" ],
+    ttls : [
+        { "timezone" : 30 days },
+    ]
+}
+global : {
+    external-dir     : [ "path1", "path2" ],
+    custom-dir       : [ "custom/path" ],
+    no-exernal-facts : false,
+    no-custom-facts  : false,
+    no-ruby          : false
+}
+
+cli : {
+    debug     : false,
+    trace     : true,
+    verbose   : false,
+    log-level : "warn"
+}
+~~~
+
+### Location
+
+Facter does not create the `facter.conf` file automatically, so you must create it manually, or use a module to manage it. Facter loads the file by default from `/etc/puppetlabs/facter/facter.conf` on *nix systems and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows. Or, you can specify a different default with the `--config` command line option:
+
+`facter --config path/to/my/config/file/facter.conf`
+
+### `facts`
+
+This section of `facter.conf` contains settings that affect fact groups. A fact group is a set of individual facts that are resolved together because they all rely on the same underlying system information. When you add a group name to the config file as a part of either of these `facts` settings, all facts in that group will be affected. Currently only built-in facts can be cached or blocked.
+
+Settings:
+
+* `blocklist` --- Prevents all facts within the listed groups from being resolved when Facter runs.
+  Use the `--list-block-group` command line option to list valid groups.
+
+* `ttls` --- Caches the key-value pairs of groups and their duration to be cached.
+  Use the `--list-cache-group` command line option to list valid groups.
+
+  * Cached facts are stored as JSON in `/opt/puppetlabs/facter/cache/cached_facts` on *nix and `C:\ProgramData\PuppetLabs\facter\cache\cached_facts` on Windows.
+
+#### Example
+
+To see a list of valid group names, from the command line, run `facter --list-block-groups` or `facter --list-cache-groups`. The output shows the fact group at the top level, with all facts in that group nested below.
+
+~~~
+$ facter --list-block-groups
+EC2
+  - ec2_metadata
+  - ec2_userdata
+file system
+  - mountpoints
+  - filesystems
+  - partitions
+~~~
+
+If you want to block any of these groups, add the group name to the `facts` section of `facter.conf`, with the `blocklist` setting. 
+
+
+~~~
+facts : {
+    blocklist : [ "file system" ],
+}
+~~~
+
+Here, the "file system" group has been added, so the `mountpoints`, `filesystems`, and `partitions` facts will all be prevented from loading.
+
+
+### `global`
+
+The `global` section of `facter.conf` contains settings to control how Facter interacts with its external elements on your system. 
+
+Setting        | Effect                                                        | Default
+---------------|---------------------------------------------------------------|--------
+`external-dir` | A list of directories to search for external facts.           |  
+`custom-dir`   | A list of directories to search for custom facts.             |    
+`no-external`* | If true, prevents Facter from searching for external facts.   | `false`
+`no-custom`*   | If true, prevents Facter from searching for custom facts.     | `false`
+`no-ruby`*     | If true, prevents Facter from loading its Ruby functionality. | `false`
+
+\*Not available when you run Facter from the Ruby API.
+
+### `cli` 
+
+The `cli` section of `facter.conf` contains settings that affect Facter’s command line output. All of these settings are ignored when you run Facter from the Ruby API.
+
+
+Setting         | Effect                                           | Default
+----------------|--------------------------------------------------|-------
+`debug`         | If true, Facter outputs debug messages.                                      | `false`
+`trace`         | If true, Facter prints stacktraces from errors arising in your custom facts. | `false`
+`verbose`       | If true, Facter outputs its most detailed messages.                          | `false`
+`log-level`     | Sets the minimum level of message severity that gets logged. Valid options: “none”, “fatal”, “error”, “warn”, “info”, “debug”, “trace”. | “warn”
+
+

--- a/source/facter/3.9/core_facts.md
+++ b/source/facter/3.9/core_facts.md
@@ -1,0 +1,3036 @@
+---
+layout: default
+built_from_commit: 6d2e4df0c56141b265775d1de528aa7e15bf92cd
+title: 'Facter: Core Facts'
+toc: columns
+canonical: "/facter/latest/core_facts.html"
+---
+
+This is a list of all of the built-in facts that ship with Facter, which includes both legacy facts and newer structured facts.
+
+Not all of them apply to every system, and your site might also use [custom facts](./custom_facts.html) delivered via Puppet modules. To see the full list of structured facts and values on a given system (including plugin facts), run `puppet facts` at the command line. If you are using Puppet Enterprise, you can view all of the facts for any node on the node's page in the console.
+
+You can access facts in your Puppet manifests as `$fact_name` or `$facts[fact_name]`. For more information, see [the Puppet docs on facts and built-in variables.]({{puppet}}/lang_facts_and_builtin_vars.html)
+
+> **Legacy Facts Note:** As of Facter 3, legacy facts such as `architecture` are hidden by default to reduce noise in Facter's default command-line output. These older facts are now part of more useful structured facts; for example, `architecture` is now part of the `os` fact and accessible as `os.architecture`. You can still use these legacy facts in Puppet manifests (`$architecture`), request them on the command line (`facter architecture`), and view them alongside structured facts (`facter --show-legacy`).
+
+* * *
+
+## Modern Facts
+
+### `aio_agent_version`
+
+**Type:** string
+
+**Purpose:**
+
+Return the version of the puppet-agent package that installed facter.
+
+
+**Resolution:**
+
+* All platforms: use the compile-time enabled version definition.
+
+
+([↑ Back to top](#page-nav))
+
+### `augeas`
+
+**Type:** map
+
+**Purpose:**
+
+Return information about augeas.
+
+**Elements:**
+
+* `version` (string) --- The version of augparse.
+
+
+**Resolution:**
+
+* All platforms: query augparse for augeas metadata.
+
+
+([↑ Back to top](#page-nav))
+
+### `cloud`
+
+**Type:** map
+
+**Purpose:**
+
+Information about the cloud instance of the node. This is currently only populated on Linux nodes running in Microsoft Azure.
+
+**Elements:**
+
+* `provider` (string) --- The cloud provider for the node.
+
+
+
+
+([↑ Back to top](#page-nav))
+
+### `disks`
+
+**Type:** map
+
+**Purpose:**
+
+Return the disk (block) devices attached to the system.
+
+**Elements:**
+
+* `<devicename>` (map) --- Represents a disk or block device.
+    * `model` (string) --- The model of the disk or block device.
+    * `product` (string) --- The product name of the disk or block device.
+    * `size` (string) --- The display size of the disk or block device (e.g. "1 GiB").
+    * `size_bytes` (integer) --- The size of the disk or block device, in bytes.
+    * `vendor` (string) --- The vendor of the disk or block device.
+
+
+**Resolution:**
+
+* AIX: query the ODM for all disk devices
+* Linux: parse the contents of `/sys/block/<device>/`.
+* Solaris: use the `kstat` function to query disk information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `dmi`
+
+**Type:** map
+
+**Purpose:**
+
+Return the system management information.
+
+**Elements:**
+
+* `bios` (map) --- The system BIOS information.
+    * `release_date` (string) --- The release date of the system BIOS.
+    * `vendor` (string) --- The vendor of the system BIOS.
+    * `version` (string) --- The version of the system BIOS.
+* `board` (map) --- The system board information.
+    * `asset_tag` (string) --- The asset tag of the system board.
+    * `manufacturer` (string) --- The manufacturer of the system board.
+    * `product` (string) --- The product name of the system board.
+    * `serial_number` (string) --- The serial number of the system board.
+* `chassis` (map) --- The system chassis information.
+    * `asset_tag` (string) --- The asset tag of the system chassis.
+    * `type` (string) --- The type of the system chassis.
+* `manufacturer` (string) --- The system manufacturer.
+* `product` (map) --- The system product information.
+    * `name` (string) --- The product name of the system.
+    * `serial_number` (string) --- The product serial number of the system.
+    * `uuid` (string) --- The product unique identifier of the system.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/` to retrieve system management information.
+* Mac OSX: use the `sysctl` function to retrieve system management information.
+* Solaris: use the `smbios`, `prtconf`, and `uname` utilities to retrieve system management information.
+* Windows: use WMI to retrieve system management information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `ec2_metadata`
+
+**Type:** map
+
+**Purpose:**
+
+Return the Amazon Elastic Compute Cloud (EC2) instance metadata.
+Please see the [EC2 instance metadata documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the contents of this fact.
+
+
+
+**Resolution:**
+
+* EC2: query the EC2 metadata endpoint and parse the response.
+
+**Caveats:**
+
+* All platforms: `libfacter` must be built with `libcurl` support.
+
+([↑ Back to top](#page-nav))
+
+### `ec2_userdata`
+
+**Type:** string
+
+**Purpose:**
+
+Return the Amazon Elastic Compute Cloud (EC2) instance user data.
+Please see the [EC2 instance user data documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the contents of this fact.
+
+
+
+**Resolution:**
+
+* EC2: query the EC2 user data endpoint and parse the response.
+
+**Caveats:**
+
+* All platforms: `libfacter` must be built with `libcurl` support.
+
+([↑ Back to top](#page-nav))
+
+### `env_windows_installdir`
+
+**Type:** string
+
+**Purpose:**
+
+Return the path of the directory in which Puppet was installed.
+
+
+**Resolution:**
+
+* Windows: This fact is specific to the Windows MSI generated environment, and is
+*   set using the `environment.bat` script that configures the runtime environment
+*   for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
+
+**Caveats:**
+
+* This fact is specific to Windows, and will not resolve on any other platform.
+
+([↑ Back to top](#page-nav))
+
+### `facterversion`
+
+**Type:** string
+
+**Purpose:**
+
+Return the version of facter.
+
+
+**Resolution:**
+
+* All platforms: use the built-in version of libfacter.
+
+
+([↑ Back to top](#page-nav))
+
+### `filesystems`
+
+**Type:** string
+
+**Purpose:**
+
+Return the usable file systems for block or disk devices.
+
+
+**Resolution:**
+
+* AIX: parse the contents of `/etc/vfs` to retrieve the usable file systems.
+* Linux: parse the contents of `/proc/filesystems` to retrieve the usable file systems.
+* Mac OSX: use the `getfsstat` function to retrieve the usable file systems.
+* Solaris: use the `sysdef` utility to retrieve the usable file systems.
+
+**Caveats:**
+
+* Linux: The proc file system must be mounted.
+* Mac OSX: The usable file systems is limited to the file system of mounted devices.
+
+([↑ Back to top](#page-nav))
+
+### `gce`
+
+**Type:** map
+
+**Purpose:**
+
+Return the Google Compute Engine (GCE) metadata.
+Please see the [GCE metadata documentation](https://cloud.google.com/compute/docs/metadata) for the contents of this fact.
+
+
+
+**Resolution:**
+
+* GCE: query the GCE metadata endpoint and parse the response.
+
+**Caveats:**
+
+* All platforms: `libfacter` must be built with `libcurl` support.
+
+([↑ Back to top](#page-nav))
+
+### `identity`
+
+**Type:** map
+
+**Purpose:**
+
+Return the identity information of the user running facter.
+
+**Elements:**
+
+* `gid` (integer) --- The group identifier of the user running facter.
+* `group` (string) --- The group name of the user running facter.
+* `uid` (integer) --- The user identifier of the user running facter.
+* `user` (string) --- The user name of the user running facter.
+* `privileged` (boolean) --- True if facter is running as a privileged process or false if not.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information; use the result of the `geteuid() == 0` test as the value of the privileged element
+* Windows: use the `GetUserNameExW` function to retrieve the identity information; use the `GetTokenInformation` to get the current process token elevation status and use it as the value of the privileged element on versions of Windows supporting the token elevation, on older versions of Windows use the `CheckTokenMembership` to test whether the well known local Administrators group SID is enabled in the current thread impersonation token and use the test result as the value of the privileged element
+
+
+([↑ Back to top](#page-nav))
+
+### `is_virtual`
+
+**Type:** boolean
+
+**Purpose:**
+
+Return whether or not the host is a virtual machine.
+
+
+**Resolution:**
+
+* Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine status.
+* Mac OSX: use the system profiler to retrieve virtual machine status.
+* Solaris: use the `zonename` utility to retrieve virtual machine status.
+* Windows: use WMI to retrieve virtual machine status.
+
+
+([↑ Back to top](#page-nav))
+
+### `kernel`
+
+**Type:** string
+
+**Purpose:**
+
+Return the kernel's name.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the kernel name.
+* Windows: use the value of `windows` for all Windows versions.
+
+
+([↑ Back to top](#page-nav))
+
+### `kernelmajversion`
+
+**Type:** string
+
+**Purpose:**
+
+Return the kernel's major version.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the kernel's major version.
+* Windows: use the file version of `kernel32.dll` to retrieve the kernel's major version.
+
+
+([↑ Back to top](#page-nav))
+
+### `kernelrelease`
+
+**Type:** string
+
+**Purpose:**
+
+Return the kernel's release.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the kernel's release.
+* Windows: use the file version of `kernel32.dll` to retrieve the kernel's release.
+
+
+([↑ Back to top](#page-nav))
+
+### `kernelversion`
+
+**Type:** string
+
+**Purpose:**
+
+Return the kernel's version.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the kernel's version.
+* Windows: use the file version of `kernel32.dll` to retrieve the kernel's version.
+
+
+([↑ Back to top](#page-nav))
+
+### `ldom`
+
+**Type:** map
+
+**Purpose:**
+
+Return Solaris LDom information from the `virtinfo` utility.
+
+
+**Resolution:**
+
+* Solaris: use the `virtinfo` utility to retrieve LDom information.
+
+
+([↑ Back to top](#page-nav))
+
+### `load_averages`
+
+**Type:** map
+
+**Purpose:**
+
+Return the load average over the last 1, 5 and 15 minutes.
+
+**Elements:**
+
+* `1m` (double) --- The system load average over the last minute.
+* `5m` (double) --- The system load average over the last 5 minutes.
+* `15m` (double) --- The system load average over the last 15 minutes.
+
+
+**Resolution:**
+
+* POSIX platforms: use `getloadavg` function to retrieve the system load averages.
+
+
+([↑ Back to top](#page-nav))
+
+### `memory`
+
+**Type:** map
+
+**Purpose:**
+
+Return the system memory information.
+
+**Elements:**
+
+* `swap` (map) --- Represents information about swap memory.
+    * `available` (string) --- The display size of the available amount of swap memory (e.g. "1 GiB").
+    * `available_bytes` (integer) --- The size of the available amount of swap memory, in bytes.
+    * `capacity` (string) --- The capacity percentage (0% is empty, 100% is full).
+    * `encrypted` (boolean) --- True if the swap is encrypted or false if not.
+    * `total` (string) --- The display size of the total amount of swap memory (e.g. "1 GiB").
+    * `total_bytes` (integer) --- The size of the total amount of swap memory, in bytes.
+    * `used` (string) --- The display size of the used amount of swap memory (e.g. "1 GiB").
+    * `used_bytes` (integer) --- The size of the used amount of swap memory, in bytes.
+* `system` (map) --- Represents information about system memory.
+    * `available` (string) --- The display size of the available amount of system memory (e.g. "1 GiB").
+    * `available_bytes` (integer) --- The size of the available amount of system memory, in bytes.
+    * `capacity` (string) --- The capacity percentage (0% is empty, 100% is full).
+    * `total` (string) --- The display size of the total amount of system memory (e.g. "1 GiB").
+    * `total_bytes` (integer) --- The size of the total amount of system memory, in bytes.
+    * `used` (string) --- The display size of the used amount of system memory (e.g. "1 GiB").
+    * `used_bytes` (integer) --- The size of the used amount of system memory, in bytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the system memory information.
+* Mac OSX: use the `sysctl` function to retrieve the system memory information.
+* Solaris: use the `kstat` function to retrieve the system memory information.
+* Windows: use the `GetPerformanceInfo` function to retrieve the system memory information.
+
+
+([↑ Back to top](#page-nav))
+
+### `mountpoints`
+
+**Type:** map
+
+**Purpose:**
+
+Return the current mount points of the system.
+
+**Elements:**
+
+* `<mountpoint>` (map) --- Represents a mount point.
+    * `available` (string) --- The display size of the available space (e.g. "1 GiB").
+    * `available_bytes` (integer) --- The size of the available space, in bytes.
+    * `capacity` (string) --- The capacity percentage (0% is empty, 100% is full).
+    * `device` (string) --- The name of the mounted device.
+    * `filesystem` (string) --- The file system of the mounted device.
+    * `options` (array) --- The mount options.
+    * `size` (string) --- The display size of the total space (e.g. "1 GiB").
+    * `size_bytes` (integer) --- The size of the total space, in bytes.
+    * `used` (string) --- The display size of the used space (e.g. "1 GiB").
+    * `used_bytes` (integer) --- The size of the used space, in bytes.
+
+
+**Resolution:**
+
+* AIX: use the `mntctl` function to retrieve the mount points.
+* Linux: use the `setmntent` function to retrieve the mount points.
+* Mac OSX: use the `getfsstat` function to retrieve the mount points.
+* Solaris: parse the contents of `/etc/mnttab` to retrieve the mount points.
+
+
+([↑ Back to top](#page-nav))
+
+### `networking`
+
+**Type:** map
+
+**Purpose:**
+
+Return the networking information for the system.
+
+**Elements:**
+
+* `dhcp` (ip) --- The address of the DHCP server for the default interface.
+* `domain` (string) --- The domain name of the system.
+* `fqdn` (string) --- The fully-qualified domain name of the system.
+* `hostname` (string) --- The host name of the system.
+* `interfaces` (map) --- The network interfaces of the system.
+    * `<interface>` (map) --- Represents a network interface.
+        * `bindings` (array) --- The array of IPv4 address bindings for the interface.
+        * `bindings6` (array) --- The array of IPv6 address bindings for the interface.
+        * `dhcp` (ip) --- The DHCP server for the network interface.
+        * `ip` (ip) --- The IPv4 address for the network interface.
+        * `ip6` (ip6) --- The IPv6 address for the network interface.
+        * `mac` (mac) --- The MAC address for the network interface.
+        * `mtu` (integer) --- The Maximum Transmission Unit (MTU) for the network interface.
+        * `netmask` (ip) --- The IPv4 netmask for the network interface.
+        * `netmask6` (ip6) --- The IPv6 netmask for the network interface.
+        * `network` (ip) --- The IPv4 network for the network interface.
+        * `network6` (ip6) --- The IPv6 network for the network interface.
+* `ip` (ip) --- The IPv4 address of the default network interface.
+* `ip6` (ip6) --- The IPv6 address of the default network interface.
+* `mac` (mac) --- The MAC address of the default network interface.
+* `mtu` (integer) --- The Maximum Transmission Unit (MTU) of the default network interface.
+* `netmask` (ip) --- The IPv4 netmask of the default network interface.
+* `netmask6` (ip6) --- The IPv6 netmask of the default network interface.
+* `network` (ip) --- The IPv4 network of the default network interface.
+* `network6` (ip6) --- The IPv6 network of the default network interface.
+* `primary` (string) --- The name of the primary interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interfaces.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interfaces.
+* Solaris: use the `ioctl` function to retrieve the network interfaces.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interfaces.
+
+**Caveats:**
+
+* Windows Server 2003: the `GetAdaptersInfo` function is used for DHCP and netmask lookup. This function does not support IPv6 netmasks.
+
+([↑ Back to top](#page-nav))
+
+### `os`
+
+**Type:** map
+
+**Purpose:**
+
+Return information about the host operating system.
+
+**Elements:**
+
+* `architecture` (string) --- The operating system's hardware architecture.
+* `distro` (map) --- Represents information about a Linux distribution.
+    * `codename` (string) --- The code name of the Linux distribution.
+    * `description` (string) --- The description of the Linux distribution.
+    * `id` (string) --- The identifier of the Linux distribution.
+    * `release` (map) --- Represents information about a Linux distribution release.
+        * `full` (string) --- The full release of the Linux distribution.
+        * `major` (string) --- The major release of the Linux distribution.
+        * `minor` (string) --- The minor release of the Linux distribution.
+    * `specification` (string) --- The Linux Standard Base (LSB) release specification.
+* `family` (string) --- The operating system family.
+* `hardware` (string) --- The operating system's hardware model.
+* `macosx` (map) --- Represents information about Mac OSX.
+    * `build` (string) --- The Mac OSX build version.
+    * `product` (string) --- The Mac OSX product name.
+    * `version` (map) --- Represents information about the Mac OSX version.
+        * `full` (string) --- The full Mac OSX version number.
+        * `major` (string) --- The major Mac OSX version number.
+        * `minor` (string) --- The minor Mac OSX version number.
+* `name` (string) --- The operating system's name.
+* `release` (map) --- Represents the operating system's release.
+    * `full` (string) --- The full operating system release.
+    * `major` (string) --- The major release of the operating system.
+    * `minor` (string) --- The minor release of the operating system.
+* `selinux` (map) --- Represents information about Security-Enhanced Linux (SELinux).
+    * `config_mode` (string) --- The configured SELinux mode.
+    * `config_policy` (string) --- The configured SELinux policy.
+    * `current_mode` (string) --- The current SELinux mode.
+    * `enabled` (boolean) --- True if SELinux is enabled or false if not.
+    * `enforced` (boolean) --- True if SELinux policy is enforced or false if not.
+    * `policy_version` (string) --- The version of the SELinux policy.
+* `windows` (map) --- Represents information about Windows.
+    * `system32` (string) --- The path to the System32 directory.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility and parse the contents of release files in `/etc` to retrieve the OS information.
+* OSX: use the `sw_vers` utility to retrieve the OS information.
+* Solaris: parse the contents of `/etc/release` to retrieve the OS information.
+* Windows: use WMI to retrieve the OS information.
+
+
+([↑ Back to top](#page-nav))
+
+### `partitions`
+
+**Type:** map
+
+**Purpose:**
+
+Return the disk partitions of the system.
+
+**Elements:**
+
+* `<partition>` (map) --- Represents a disk partition.
+    * `filesystem` (string) --- The file system of the partition.
+    * `label` (string) --- The label of the partition.
+    * `mount` (string) --- The mount point of the partition (if mounted).
+    * `partlabel` (string) --- The label of a GPT partition.
+    * `partuuid` (string) --- The unique identifier of a GPT partition.
+    * `size` (string) --- The display size of the partition (e.g. "1 GiB").
+    * `size_bytes` (integer) --- The size of the partition, in bytes.
+    * `uuid` (string) --- The unique identifier of a partition.
+    * `backing_file` (string) --- The path to the file backing the partition.
+
+
+**Resolution:**
+
+* AIX: use the ODM to retrieve list of logical volumes; use `lvm_querylv` function to get details
+* Linux: use `libblkid` to retrieve the disk partitions.
+
+**Caveats:**
+
+* Linux: `libfacter` must be built with `libblkid` support.
+
+([↑ Back to top](#page-nav))
+
+### `path`
+
+**Type:** string
+
+**Purpose:**
+
+Return the PATH environment variable.
+
+
+**Resolution:**
+
+* All platforms: retrieve the value of the PATH environment variable.
+
+
+([↑ Back to top](#page-nav))
+
+### `processors`
+
+**Type:** map
+
+**Purpose:**
+
+Return information about the system's processors.
+
+**Elements:**
+
+* `count` (integer) --- The count of logical processors.
+* `isa` (string) --- The processor instruction set architecture.
+* `models` (array) --- The processor model strings (one for each logical processor).
+* `physicalcount` (integer) --- The count of physical processors.
+* `speed` (string) --- The speed of the processors (e.g. "2.0 GHz").
+
+
+**Resolution:**
+
+* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the processor information.
+* Mac OSX: use the `sysctl` function to retrieve the processor information.
+* Solaris: use the `kstat` function to retrieve the processor information.
+* Windows: use WMI to retrieve the processor information.
+
+
+([↑ Back to top](#page-nav))
+
+### `ruby`
+
+**Type:** map
+
+**Purpose:**
+
+Return information about the Ruby loaded by facter.
+
+**Elements:**
+
+* `platform` (string) --- The platform Ruby was built for.
+* `sitedir` (string) --- The path to Ruby's site library directory.
+* `version` (string) --- The version of Ruby.
+
+
+**Resolution:**
+
+* All platforms: Use `RbConfig`, `RUBY_PLATFORM`, and `RUBY_VERSION` to retrieve information about Ruby.
+
+**Caveats:**
+
+* All platforms: facter must be able to locate `libruby`.
+
+([↑ Back to top](#page-nav))
+
+### `solaris_zones`
+
+**Type:** map
+
+**Purpose:**
+
+Return information about Solaris zones.
+
+**Elements:**
+
+* `current` (string) --- The name of the current Solaris zone.
+* `zones` (map) --- Represents the Solaris zones.
+    * `<zonename>` (map) --- Represents a Solaris zone.
+        * `brand` (string) --- The brand of the Solaris zone.
+        * `id` (string) --- The id of the Solaris zone.
+        * `ip_type` (string) --- The IP type of the Solaris zone.
+        * `path` (string) --- The path of the Solaris zone.
+        * `status` (string) --- The status of the Solaris zone.
+        * `uuid` (string) --- The unique identifier of the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` and `zonename` utilities to retrieve information about the Solaris zones.
+
+
+([↑ Back to top](#page-nav))
+
+### `ssh`
+
+**Type:** map
+
+**Purpose:**
+
+Return SSH public keys and fingerprints.
+
+**Elements:**
+
+* `dsa` (map) --- Represents the public key and fingerprints for the DSA algorithm.
+    * `fingerprints` (map) --- Represents fingerprint information.
+        * `sha1` (string) --- The SHA1 fingerprint of the public key.
+        * `sha256` (string) --- The SHA256 fingerprint of the public key.
+    * `key` (string) --- The DSA public key.
+* `ecdsa` (map) --- Represents the public key and fingerprints for the ECDSA algorithm.
+    * `fingerprints` (map) --- Represents fingerprint information.
+        * `sha1` (string) --- The SHA1 fingerprint of the public key.
+        * `sha256` (string) --- The SHA256 fingerprint of the public key.
+    * `key` (string) --- The ECDSA public key.
+* `ed25519` (map) --- Represents the public key and fingerprints for the Ed25519 algorithm.
+    * `fingerprints` (map) --- Represents fingerprint information.
+        * `sha1` (string) --- The SHA1 fingerprint of the public key.
+        * `sha256` (string) --- The SHA256 fingerprint of the public key.
+    * `key` (string) --- The Ed25519 public key.
+* `rsa` (map) --- Represents the public key and fingerprints for the RSA algorithm.
+    * `fingerprints` (map) --- Represents fingerprint information.
+        * `sha1` (string) --- The SHA1 fingerprint of the public key.
+        * `sha256` (string) --- The SHA256 fingerprint of the public key.
+    * `key` (string) --- The RSA public key.
+
+
+**Resolution:**
+
+* POSIX platforms: parse SSH public key files and derive fingerprints.
+
+**Caveats:**
+
+* POSIX platforms: facter must be built with OpenSSL support.
+
+([↑ Back to top](#page-nav))
+
+### `system_profiler`
+
+**Type:** map
+
+**Purpose:**
+
+Return information from the Mac OSX system profiler.
+
+**Elements:**
+
+* `boot_mode` (string) --- The boot mode.
+* `boot_rom_version` (string) --- The boot ROM version.
+* `boot_volume` (string) --- The boot volume.
+* `computer_name` (string) --- The name of the computer.
+* `cores` (string) --- The total number of processor cores.
+* `hardware_uuid` (string) --- The hardware unique identifier.
+* `kernel_version` (string) --- The version of the kernel.
+* `l2_cache_per_core` (string) --- The size of the processor per-core L2 cache.
+* `l3_cache` (string) --- The size of the processor L3 cache.
+* `memory` (string) --- The size of the system memory.
+* `model_identifier` (string) --- The identifier of the computer model.
+* `model_name` (string) --- The name of the computer model.
+* `processor_name` (string) --- The model name of the processor.
+* `processor_speed` (string) --- The speed of the processor.
+* `processors` (string) --- The total number of processors.
+* `secure_virtual_memory` (string) --- Whether or not secure virtual memory is enabled.
+* `serial_number` (string) --- The serial number of the computer.
+* `smc_version` (string) --- The System Management Controller (SMC) version.
+* `system_version` (string) --- The operating system version.
+* `uptime` (string) --- The uptime of the system.
+* `username` (string) --- The name of the user running facter.
+
+
+**Resolution:**
+
+* Mac OSX: use the `system_profiler` utility to retrieve system profiler information.
+
+
+([↑ Back to top](#page-nav))
+
+### `system_uptime`
+
+**Type:** map
+
+**Purpose:**
+
+Return the system uptime information.
+
+**Elements:**
+
+* `days` (integer) --- The number of complete days the system has been up.
+* `hours` (integer) --- The number of complete hours the system has been up.
+* `seconds` (integer) --- The number of total seconds the system has been up.
+* `uptime` (string) --- The full uptime string.
+
+
+**Resolution:**
+
+* Linux: use the `sysinfo` function to retrieve the system uptime.
+* POSIX platforms: use the `uptime` utility to retrieve the system uptime.
+* Solaris: use the `kstat` function to retrieve the system uptime.
+* Windows: use WMI to retrieve the system uptime.
+
+
+([↑ Back to top](#page-nav))
+
+### `timezone`
+
+**Type:** string
+
+**Purpose:**
+
+Return the system timezone.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `localtime_r` function to retrieve the system timezone.
+* Windows: use the `localtime_s` function to retrieve the system timezone.
+
+
+([↑ Back to top](#page-nav))
+
+### `virtual`
+
+**Type:** string
+
+**Purpose:**
+
+Return the hypervisor name for virtual machines or "physical" for physical machines.
+
+
+**Resolution:**
+
+* Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine name.
+* Mac OSX: use the system profiler to retrieve virtual machine name.
+* Solaris: use the `zonename` utility to retrieve virtual machine name.
+* Windows: use WMI to retrieve virtual machine name.
+
+
+([↑ Back to top](#page-nav))
+
+### `xen`
+
+**Type:** map
+
+**Purpose:**
+
+Return metadata for the Xen hypervisor.
+
+**Elements:**
+
+* `domains` (array) --- list of strings identifying active Xen domains.
+
+
+**Resolution:**
+
+* POSIX platforms: use `/usr/lib/xen-common/bin/xen-toolstack` to locate xen admin commands if available, otherwise fallback to `/usr/sbin/xl` or `/usr/sbin/xm`. Use the found command to execute the `list` query.
+
+**Caveats:**
+
+* POSIX platforms: confined to Xen privileged virtual machines.
+
+([↑ Back to top](#page-nav))
+
+### `zfs_featurenumbers`
+
+**Type:** string
+
+**Purpose:**
+
+Return the comma-delimited feature numbers for ZFS.
+
+
+**Resolution:**
+
+* Solaris: use the `zfs` utility to retrieve the feature numbers for ZFS
+
+**Caveats:**
+
+* Solaris: the `zfs` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zfs_version`
+
+**Type:** string
+
+**Purpose:**
+
+Return the version for ZFS.
+
+
+**Resolution:**
+
+* Solaris: use the `zfs` utility to retrieve the version for ZFS
+
+**Caveats:**
+
+* Solaris: the `zfs` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zpool_featureflags`
+
+**Type:** string
+
+**Purpose:**
+
+Return the comma-delimited feature flags for ZFS storage pools.
+
+
+**Resolution:**
+
+* Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools
+
+**Caveats:**
+
+* Solaris: the `zpool` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zpool_featurenumbers`
+
+**Type:** string
+
+**Purpose:**
+
+Return the comma-delimited feature numbers for ZFS storage pools.
+
+
+**Resolution:**
+
+* Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools
+
+**Caveats:**
+
+* Solaris: the `zpool` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zpool_version`
+
+**Type:** string
+
+**Purpose:**
+
+Return the version for ZFS storage pools.
+
+
+**Resolution:**
+
+* Solaris: use the `zpool` utility to retrieve the version for ZFS storage pools
+
+**Caveats:**
+
+* Solaris: the `zpool` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+## Legacy Facts
+
+### `architecture`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the operating system's hardware architecture.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the OS hardware architecture.
+* Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware architecture.
+
+**Caveats:**
+
+* Linux: Debian, Gentoo, kFreeBSD, and Ubuntu use "amd64" for "x86_64" and Gentoo uses "x86" for "i386".
+
+([↑ Back to top](#page-nav))
+
+### `augeasversion`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the version of augeas.
+
+
+**Resolution:**
+
+* All platforms: query augparse for the augeas version.
+
+
+([↑ Back to top](#page-nav))
+
+### `blockdevices`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return a comma-separated list of block devices.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/block/<device>/`.
+* Solaris: use the `kstat` function to query disk information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `blockdevice_<devicename>_model`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the model name of block devices attached to the system.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/block/<device>/device/model` to retrieve the model name/number for a device.
+* Solaris: use the `kstat` function to query disk information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `blockdevice_<devicename>_size`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the size of a block device in bytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes).
+* Solaris: use the `kstat` function to query disk information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `blockdevice_<devicename>_vendor`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the vendor name of block devices attached to the system.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/block/<device>/device/vendor` to retrieve the vendor for a device.
+* Solaris: use the `kstat` function to query disk information.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `bios_release_date`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the release date of the system BIOS.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/bios_date` to retrieve the system BIOS release date.
+* Solaris: use the `smbios` utility to retrieve the system BIOS release date.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `bios_vendor`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the vendor of the system BIOS.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/bios_vendor` to retrieve the system BIOS vendor.
+* Solaris: use the `smbios` utility to retrieve the system BIOS vendor.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `bios_version`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the version of the system BIOS.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/bios_version` to retrieve the system BIOS version.
+* Solaris: use the `smbios` utility to retrieve the system BIOS version.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `boardassettag`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system board asset tag.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/board_asset_tag` to retrieve the system board asset tag.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `boardmanufacturer`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system board manufacturer.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/board_vendor` to retrieve the system board manufacturer.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `boardproductname`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system board product name.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/board_name` to retrieve the system board product name.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `boardserialnumber`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system board serial number.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/board_serial` to retrieve the system board serial number.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `chassisassettag`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system chassis asset tag.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/chassis_asset_tag` to retrieve the system chassis asset tag.
+* Solaris: use the `smbios` utility to retrieve the system chassis asset tag.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `chassistype`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system chassis type.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/chassis_type` to retrieve the system chassis type.
+* Solaris: use the `smbios` utility to retrieve the system chassis type.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `dhcp_servers`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** map
+
+**Purpose:**
+
+Return the DHCP servers for the system.
+
+**Elements:**
+
+* `<interface>` (ip) --- The DHCP server for the interface.
+* `system` (ip) --- The DHCP server for the default interface.
+
+
+**Resolution:**
+
+* Linux: parse `dhclient` lease files or use the `dhcpcd` utility to retrieve the DHCP servers.
+* Mac OSX: use the `ipconfig` utility to retrieve the DHCP servers.
+* Solaris: use the `dhcpinfo` utility to retrieve the DHCP servers.
+* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the DHCP servers.
+
+
+([↑ Back to top](#page-nav))
+
+### `domain`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the network domain of the system.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `getaddrinfo` function to retrieve the network domain.
+* Windows: query the registry to retrieve the network domain; falls back to the primary interface's domain if not set in the registry.
+
+
+([↑ Back to top](#page-nav))
+
+### `fqdn`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the fully qualified domain name (FQDN) of the system.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `getaddrinfo` function to retrieve the FQDN or use host and domain names.
+* Windows: use the host and domain names to build the FQDN.
+
+
+([↑ Back to top](#page-nav))
+
+### `gid`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the group identifier (GID) of the user running facter.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `getegid` fuction to retrieve the group identifier.
+
+
+([↑ Back to top](#page-nav))
+
+### `hardwareisa`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the hardware instruction set architecture (ISA).
+
+
+**Resolution:**
+
+* POSIX platforms: use `uname` to retrieve the hardware ISA.
+* Windows: use WMI to retrieve the hardware ISA.
+
+
+([↑ Back to top](#page-nav))
+
+### `hardwaremodel`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the operating system's hardware model.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `uname` function to retrieve the OS hardware model.
+* Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware model.
+
+
+([↑ Back to top](#page-nav))
+
+### `hostname`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the host name of the system.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `gethostname` function to retrieve the host name
+* Windows: use the `GetComputerNameExW` function to retrieve the host name.
+
+
+([↑ Back to top](#page-nav))
+
+### `id`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the user identifier (UID) of the user running facter.
+
+
+**Resolution:**
+
+* POSIX platforms: use the `geteuid` fuction to retrieve the user identifier.
+
+
+([↑ Back to top](#page-nav))
+
+### `interfaces`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the comma-separated list of network interface names.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface names.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface names.
+* Solaris: use the `ioctl` function to retrieve the network interface names.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface names.
+
+
+([↑ Back to top](#page-nav))
+
+### `ipaddress`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 address for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `ipaddress6`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 address for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `ipaddress6_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 address for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `ipaddress_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 address for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `ldom_<name>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return Solaris LDom information.
+
+
+**Resolution:**
+
+* Solaris: use the `virtinfo` utility to retrieve LDom information.
+
+
+([↑ Back to top](#page-nav))
+
+### `lsbdistcodename`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) distribution code name.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB distribution code name.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbdistdescription`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) distribution description.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB distribution description.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbdistid`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) distribution identifier.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB distribution identifier.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbdistrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) distribution release.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB distribution release.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbmajdistrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) major distribution release.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB major distribution release.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbminordistrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) minor distribution release.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB minor distribution release.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `lsbrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Linux Standard Base (LSB) release.
+
+
+**Resolution:**
+
+* Linux: use the `lsb_release` utility to retrieve the LSB release.
+
+**Caveats:**
+
+* Linux: Requires that the `lsb_release` utility be installed.
+
+([↑ Back to top](#page-nav))
+
+### `macaddress`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** mac
+
+**Purpose:**
+
+Return the MAC address for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `macaddress_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** mac
+
+**Purpose:**
+
+Return the MAC address for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface address.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
+* Solaris: use the `ioctl` function to retrieve the network interface address.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
+
+
+([↑ Back to top](#page-nav))
+
+### `macosx_buildversion`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Mac OSX build version.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX build version.
+
+
+([↑ Back to top](#page-nav))
+
+### `macosx_productname`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Mac OSX product name.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product name.
+
+
+([↑ Back to top](#page-nav))
+
+### `macosx_productversion`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Mac OSX product version.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product version.
+
+
+([↑ Back to top](#page-nav))
+
+### `macosx_productversion_major`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Mac OSX product major version.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product major version.
+
+
+([↑ Back to top](#page-nav))
+
+### `macosx_productversion_minor`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Mac OSX product minor version.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product minor version.
+
+
+([↑ Back to top](#page-nav))
+
+### `manufacturer`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system manufacturer.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/sys_vendor` to retrieve the system manufacturer.
+* Solaris: use the `prtconf` utility to retrieve the system manufacturer.
+* Windows: use WMI to retrieve the system manufacturer.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `memoryfree`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the display size of the free system memory (e.g. "1 GiB").
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory.
+* Mac OSX: use the `sysctl` function to retrieve the free system memory.
+* Solaris: use the `kstat` function to retrieve the free system memory.
+* Windows: use the `GetPerformanceInfo` function to retrieve the free system memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `memoryfree_mb`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** double
+
+**Purpose:**
+
+Return the size of the free system memory, in mebibytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory.
+* Mac OSX: use the `sysctl` function to retrieve the free system memory.
+* Solaris: use the `kstat` function to retrieve the free system memory.
+* Windows: use the `GetPerformanceInfo` function to retrieve the free system memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `memorysize`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the display size of the total system memory (e.g. "1 GiB").
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory.
+* Mac OSX: use the `sysctl` function to retrieve the total system memory.
+* Solaris: use the `kstat` function to retrieve the total system memory.
+* Windows: use the `GetPerformanceInfo` function to retrieve the total system memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `memorysize_mb`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** double
+
+**Purpose:**
+
+Return the size of the total system memory, in mebibytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory.
+* Mac OSX: use the `sysctl` function to retrieve the total system memory.
+* Solaris: use the `kstat` function to retrieve the total system memory.
+* Windows: use the `GetPerformanceInfo` function to retrieve the total system memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `mtu_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the Maximum Transmission Unit (MTU) for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `ioctl` function to retrieve the network interface MTU.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface MTU.
+* Solaris: use the `ioctl` function to retrieve the network interface MTU.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface MTU.
+
+
+([↑ Back to top](#page-nav))
+
+### `netmask`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 netmask for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
+* Solaris: use the `ioctl` function to retrieve the network interface netmask.
+* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask.
+
+
+([↑ Back to top](#page-nav))
+
+### `netmask6`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 netmask for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
+* Solaris: use the `ioctl` function to retrieve the network interface netmask.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask.
+
+**Caveats:**
+
+* Windows Server 2003: IPv6 netmasks are not supported.
+
+([↑ Back to top](#page-nav))
+
+### `netmask6_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 netmask for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
+* Solaris: use the `ioctl` function to retrieve the network interface netmask.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask.
+
+**Caveats:**
+
+* Windows Server 2003: IPv6 netmasks are not supported.
+
+([↑ Back to top](#page-nav))
+
+### `netmask_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 netmask for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
+* Solaris: use the `ioctl` function to retrieve the network interface netmask.
+* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask.
+
+
+([↑ Back to top](#page-nav))
+
+### `network`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 network for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface network.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
+* Solaris: use the `ioctl` function to retrieve the network interface network.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
+
+
+([↑ Back to top](#page-nav))
+
+### `network6`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 network for the default network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface network.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
+* Solaris: use the `ioctl` function to retrieve the network interface network.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
+
+
+([↑ Back to top](#page-nav))
+
+### `network6_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip6
+
+**Purpose:**
+
+Return the IPv6 network for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface network.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
+* Solaris: use the `ioctl` function to retrieve the network interface network.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
+
+
+([↑ Back to top](#page-nav))
+
+### `network_<interface>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** ip
+
+**Purpose:**
+
+Return the IPv4 network for a network interface.
+
+
+**Resolution:**
+
+* Linux: use the `getifaddrs` function to retrieve the network interface network.
+* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
+* Solaris: use the `ioctl` function to retrieve the network interface network.
+* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
+
+
+([↑ Back to top](#page-nav))
+
+### `operatingsystem`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the name of the operating system.
+
+
+**Resolution:**
+
+* All platforms: default to the kernel name.
+* Linux: use various release files in `/etc` to retrieve the OS name.
+
+
+([↑ Back to top](#page-nav))
+
+### `operatingsystemmajrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the major release of the operating system.
+
+
+**Resolution:**
+
+* All platforms: default to the major version of the kernel release.
+* Linux: parse the contents of release files in `/etc` to retrieve the OS major release.
+* Solaris: parse the contents of `/etc/release` to retrieve the OS major release.
+* Windows: use WMI to retrieve the OS major release.
+
+**Caveats:**
+
+* Linux: for Ubuntu, the major release is X.Y (e.g. "10.4").
+
+([↑ Back to top](#page-nav))
+
+### `operatingsystemrelease`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the release of the operating system.
+
+
+**Resolution:**
+
+* All platforms: default to the kernel release.
+* Linux: parse the contents of release files in `/etc` to retrieve the OS release.
+* Solaris: parse the contents of `/etc/release` to retrieve the OS release.
+* Windows: use WMI to retrieve the OS release.
+
+
+([↑ Back to top](#page-nav))
+
+### `osfamily`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the family of the operating system.
+
+
+**Resolution:**
+
+* All platforms: default to the kernel name.
+* Linux: map various Linux distributions to their base distribution (e.g. Ubuntu is a "Debian" distro).
+* Solaris: map various Solaris-based operating systems to the "Solaris" family.
+* Windows: use "windows" as the family name.
+
+
+([↑ Back to top](#page-nav))
+
+### `physicalprocessorcount`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the count of physical processors.
+
+
+**Resolution:**
+
+* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of physical processors.
+* Mac OSX: use the `sysctl` function to retrieve the count of physical processors.
+* Solaris: use the `kstat` function to retrieve the count of physical processors.
+* Windows: use WMI to retrieve the count of physical processors.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `processor<N>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the model string of processor N.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/cpuinfo` to retrieve the processor model string.
+* Mac OSX: use the `sysctl` function to retrieve the processor model string.
+* Solaris: use the `kstat` function to retrieve the processor model string.
+* Windows: use WMI to retrieve the processor model string.
+
+
+([↑ Back to top](#page-nav))
+
+### `processorcount`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the count of logical processors.
+
+
+**Resolution:**
+
+* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of logical processors.
+* Mac OSX: use the `sysctl` function to retrieve the count of logical processors.
+* Solaris: use the `kstat` function to retrieve the count of logical processors.
+* Windows: use WMI to retrieve the count of logical processors.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `productname`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system product name.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product name.
+* Mac OSX: use the `sysctl` function to retrieve the system product name.
+* Solaris: use the `smbios` utility to retrieve the system product name.
+* Windows: use WMI to retrieve the system product name.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `rubyplatform`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the platform Ruby was built for.
+
+
+**Resolution:**
+
+* All platforms: use `RUBY_PLATFORM` from the Ruby loaded by facter.
+
+**Caveats:**
+
+* All platforms: facter must be able to locate `libruby`.
+
+([↑ Back to top](#page-nav))
+
+### `rubysitedir`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the path to Ruby's site library directory.
+
+
+**Resolution:**
+
+* All platforms: use `RbConfig` from the Ruby loaded by facter.
+
+**Caveats:**
+
+* All platforms: facter must be able to locate `libruby`.
+
+([↑ Back to top](#page-nav))
+
+### `rubyversion`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the version of Ruby.
+
+
+**Resolution:**
+
+* All platforms: use `RUBY_VERSION` from the Ruby loaded by facter.
+
+**Caveats:**
+
+* All platforms: facter must be able to locate `libruby`.
+
+([↑ Back to top](#page-nav))
+
+### `selinux`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** boolean
+
+**Purpose:**
+
+Return whether Security-Enhanced Linux (SELinux) is enabled.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/self/mounts` to determine if SELinux is enabled.
+
+
+([↑ Back to top](#page-nav))
+
+### `selinux_config_mode`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the configured Security-Enhanced Linux (SELinux) mode.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux mode.
+
+
+([↑ Back to top](#page-nav))
+
+### `selinux_config_policy`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the configured Security-Enhanced Linux (SELinux) policy.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux policy.
+
+
+([↑ Back to top](#page-nav))
+
+### `selinux_current_mode`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the current Security-Enhanced Linux (SELinux) mode.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode.
+
+
+([↑ Back to top](#page-nav))
+
+### `selinux_enforced`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** boolean
+
+**Purpose:**
+
+Return whether Security-Enhanced Linux (SELinux) is enforced.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode.
+
+
+([↑ Back to top](#page-nav))
+
+### `selinux_policyversion`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the Security-Enhanced Linux (SELinux) policy version.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `<mountpoint>/policyvers` to retrieve the SELinux policy version.
+
+
+([↑ Back to top](#page-nav))
+
+### `serialnumber`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system product serial number.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product serial number.
+* Solaris: use the `smbios` utility to retrieve the system product serial number.
+* Windows: use WMI to retrieve the system product serial number.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `sp_<name>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return Mac OSX system profiler information.
+
+
+**Resolution:**
+
+* Mac OSX: use the `system_profiler` utility to retrieve system profiler information.
+
+
+([↑ Back to top](#page-nav))
+
+### `ssh<algorithm>key`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the SSH public key for the algorithm.
+
+
+**Resolution:**
+
+* POSIX platforms: parse SSH public key files.
+
+**Caveats:**
+
+* POSIX platforms: facter must be built with OpenSSL support.
+
+([↑ Back to top](#page-nav))
+
+### `sshfp_<algorithm>`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the SSH fingerprints for the algorithm's public key.
+
+
+**Resolution:**
+
+* POSIX platforms: derive the SHA1 and SHA256 fingerprints; delimit with a new line character.
+
+**Caveats:**
+
+* POSIX platforms: facter must be built with OpenSSL support.
+
+([↑ Back to top](#page-nav))
+
+### `swapencrypted`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** boolean
+
+**Purpose:**
+
+Return whether or not the swap is encrypted.
+
+
+**Resolution:**
+
+* Mac OSX: use the `sysctl` function to retrieve swap encryption status.
+
+
+([↑ Back to top](#page-nav))
+
+### `swapfree`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the display size of the free swap memory (e.g. "1 GiB").
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory.
+* Mac OSX: use the `sysctl` function to retrieve the free swap memory.
+* Solaris: use the `swapctl` function to retrieve the free swap memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `swapfree_mb`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** double
+
+**Purpose:**
+
+Return the size of the free swap memory, in mebibytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory.
+* Mac OSX: use the `sysctl` function to retrieve the free swap memory.
+* Solaris: use the `swapctl` function to retrieve the free swap memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `swapsize`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the display size of the total swap memory (e.g. "1 GiB").
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
+* Mac OSX: use the `sysctl` function to retrieve the total swap memory.
+* Solaris: use the `swapctl` function to retrieve the total swap memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `swapsize_mb`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** double
+
+**Purpose:**
+
+Return the size of the total swap memory, in mebibytes.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
+* Mac OSX: use the `sysctl` function to retrieve the total swap memory.
+* Solaris: use the `swapctl` function to retrieve the total swap memory.
+
+
+([↑ Back to top](#page-nav))
+
+### `system32`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the path to the System32 directory on Windows.
+
+
+**Resolution:**
+
+* Windows: use the `SHGetFolderPath` function to retrieve the path to the System32 directory.
+
+
+([↑ Back to top](#page-nav))
+
+### `uptime`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system uptime.
+
+
+**Resolution:**
+
+* Linux: use the `sysinfo` function to retrieve the system uptime.
+* POSIX platforms: use the `uptime` utility to retrieve the system uptime.
+* Solaris: use the `kstat` function to retrieve the system uptime.
+* Windows: use WMI to retrieve the system uptime.
+
+
+([↑ Back to top](#page-nav))
+
+### `uptime_days`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the system uptime days.
+
+
+**Resolution:**
+
+* Linux: use the `sysinfo` function to retrieve the system uptime days.
+* POSIX platforms: use the `uptime` utility to retrieve the system uptime days.
+* Solaris: use the `kstat` function to retrieve the system uptime days.
+* Windows: use WMI to retrieve the system uptime days.
+
+
+([↑ Back to top](#page-nav))
+
+### `uptime_hours`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the system uptime hours.
+
+
+**Resolution:**
+
+* Linux: use the `sysinfo` function to retrieve the system uptime hours.
+* POSIX platforms: use the `uptime` utility to retrieve the system uptime hours.
+* Solaris: use the `kstat` function to retrieve the system uptime hours.
+* Windows: use WMI to retrieve the system uptime hours.
+
+
+([↑ Back to top](#page-nav))
+
+### `uptime_seconds`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the system uptime seconds.
+
+
+**Resolution:**
+
+* Linux: use the `sysinfo` function to retrieve the system uptime seconds.
+* POSIX platforms: use the `uptime` utility to retrieve the system uptime seconds.
+* Solaris: use the `kstat` function to retrieve the system uptime seconds.
+* Windows: use WMI to retrieve the system uptime seconds.
+
+
+([↑ Back to top](#page-nav))
+
+### `uuid`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the system product unique identifier.
+
+
+**Resolution:**
+
+* Linux: parse the contents of `/sys/class/dmi/id/product_uuid` to retrieve the system product unique identifier.
+* Solaris: use the `smbios` utility to retrieve the system product unique identifier.
+
+**Caveats:**
+
+* Linux: kernel 2.6+ is required due to the reliance on sysfs.
+
+([↑ Back to top](#page-nav))
+
+### `xendomains`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return a list of comma-separated active Xen domain names.
+
+
+**Resolution:**
+
+* POSIX platforms: see the `xen` structured fact.
+
+**Caveats:**
+
+* POSIX platforms: confined to Xen privileged virtual machines.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_brand`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the brand for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the brand for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_iptype`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the IP type for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the IP type for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_name`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the name for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the name for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_uuid`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the unique identifier for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the unique identifier for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_id`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the zone identifier for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the zone identifier for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_path`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the zone path for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the zone path for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zone_<name>_status`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the zone state for the Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the zone state for the Solaris zone.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zonename`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** string
+
+**Purpose:**
+
+Return the name of the current Solaris zone.
+
+
+**Resolution:**
+
+* Solaris: use the `zonename` utility to retrieve the current zone name.
+
+**Caveats:**
+
+* Solaris: the `zonename` utility must be present.
+
+([↑ Back to top](#page-nav))
+
+### `zones`
+
+This legacy fact is hidden by default in Facter's command-line output.
+
+**Type:** integer
+
+**Purpose:**
+
+Return the count of Solaris zones.
+
+
+**Resolution:**
+
+* Solaris: use the `zoneadm` utility to retrieve the count of Solaris zones.
+
+**Caveats:**
+
+* Solaris: the `zoneadm` utility must be present.
+
+([↑ Back to top](#page-nav))
+

--- a/source/facter/3.9/core_facts.md
+++ b/source/facter/3.9/core_facts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-built_from_commit: 6d2e4df0c56141b265775d1de528aa7e15bf92cd
+built_from_commit: 1650f446b4b6076ab0e5937ef9e47a4523fc385b
 title: 'Facter: Core Facts'
 toc: columns
 canonical: "/facter/latest/core_facts.html"
@@ -263,6 +263,23 @@ Please see the [GCE metadata documentation](https://cloud.google.com/compute/doc
 **Caveats:**
 
 * All platforms: `libfacter` must be built with `libcurl` support.
+
+([↑ Back to top](#page-nav))
+
+### `hypervisors`
+
+**Type:** map
+
+**Purpose:**
+
+Experimental fact: Return the names of any detected hypervisors and any collected metadata about them.
+
+
+
+**Resolution:**
+
+* All platforms: Use the external `whereami` library to gather hypervisor data, if available.
+
 
 ([↑ Back to top](#page-nav))
 

--- a/source/facter/3.9/custom_facts.md
+++ b/source/facter/3.9/custom_facts.md
@@ -1,0 +1,489 @@
+---
+layout: default
+title: "Custom facts walkthrough"
+---
+
+[Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
+[Plugins in Modules]: /guides/plugins_in_modules.html
+
+
+You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
+
+## Adding custom facts to Facter
+
+Sometimes you need to be able to write conditional expressions based on site-specific data that just isn't available via Facter, or perhaps you'd like to include it in a template.
+
+Because you can't include arbitrary Ruby code in your manifests, the best solution is to add a new fact to Facter. These additional facts can then be distributed to Puppet clients and are available for use in manifests and templates, just like any other fact is.
+
+> **Note:** Facter 3.0 removed the Ruby implementations of some features and replaced them with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` fails with an error. For more information, see the [Facter 3.0 release notes](../3.0/release_notes.html).
+
+## Loading custom facts
+
+Facter offers multiple methods of loading facts:
+
+* `$LOAD\_PATH`, or the Ruby library load path
+* The `--custom-dir` command line option
+* The environment variable 'FACTERLIB'
+
+You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
+
+### Using the Ruby load path
+
+Facter searches all directories in the Ruby `$LOAD_PATH` variable for
+subdirectories named `facter`, and loads all Ruby files in those directories.
+If you had a directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
+this:
+
+    #~/lib/ruby
+    └── facter
+        ├── rackspace.rb
+        ├── system_load.rb
+        └── users.rb
+
+Facter loads `facter/system\_load.rb`, `facter/users.rb`, and
+`facter/rackspace.rb`.
+
+### Using the `--custom-dir` command line option
+
+Facter can take multiple `--custom-dir` options on the command line that specifies a single directory
+to search for custom facts. Facter attempts to load all Ruby files in the specified directories.
+This allows you to do something like this:
+
+    $ ls my_facts
+    system_load.rb
+    $ ls my_other_facts
+    users.rb
+    $ facter --custom-dir=./my_facts --custom-dir=./my_other_facts system_load users
+    system_load => 0.25
+    users => thomas,pat
+
+### Using the `FACTERLIB` environment variable
+
+Facter also checks the environment variable `FACTERLIB` for a delimited (semicolon for Windows and colon for all
+other platforms) set of directories, and tries to load all Ruby files in those directories.
+This allows you to do something like this:
+
+    $ ls my_facts
+    system_load.rb
+    $ ls my_other_facts
+    users.rb
+    $ export FACTERLIB="./my_facts:./my_other_facts"
+    $ facter system_load users
+    system_load => 0.25
+    users => thomas,pat
+
+> ### Note: Changes in built-in pluginsync support in Facter 3
+>
+> Facter 2.4 **deprecated** Facter's support for loading facts via Puppet's pluginsync
+> (the `-p` option), and Facter 3.0.0 **removed** the `-p` option. However, we reversed
+> this decision in Facter 3.0.2 and re-enabled the `-p` option. For details about current
+> and future support for this option, see the [Facter 3.0.2 release notes][].
+
+## Two parts of every fact
+
+Most facts have at least two elements:
+
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+
+Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
+
+## Executing shell commands in facts
+
+Puppet gets information about a system from Facter, and the most common way for Facter to
+get that information is by executing shell commands. You can then parse and manipulate the
+output from those commands using standard Ruby code. The Facter API gives you a few ways to
+execute shell commands:
+
+* To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
+* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+* Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
+
+>**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
+
+### Example
+
+To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
+
+1. Start by giving the fact a name, in this case, `hardware_platform`.
+2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+
+    ``` ruby
+    # hardware_platform.rb
+
+    Facter.add('hardware_platform') do
+      setcode do
+        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+      end
+    end
+    ```
+
+3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
+
+## Using other facts
+
+You can write a fact that uses other facts by accessing `Facter.value(:somefact)`.
+If the fact fails to resolve or is not present, Facter returns `nil`.
+
+For example:
+
+``` ruby
+Facter.add(:osfamily) do
+  setcode do
+    distid = Facter.value(:lsbdistid)
+    case distid
+    when /RedHatEnterprise|CentOS|Fedora/
+      'redhat'
+    when 'ubuntu'
+      'debian'
+    else
+      distid
+    end
+  end
+end
+```
+
+## Configuring facts
+
+Facts have a few properties that you can use to customize how they are evaluated.
+
+### Confining facts
+
+One of the more commonly used properties is the `confine` statement, which
+restricts the fact to only run on systems that matches another given fact.
+
+An example of the confine statement would be something like the following:
+
+``` ruby
+Facter.add(:powerstates) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution.exec('cat /sys/power/states')
+  end
+end
+```
+
+This fact uses sysfs on linux to get a list of the power states that are
+available on the given system. Since this is only available on Linux systems,
+we use the confine statement to ensure that this fact isn't needlessly run on
+systems that don't support this type of enumeration.
+
+### Fact precedence
+
+A single fact can have multiple **resolutions**, each of which is a different way
+of ascertaining what the value of the fact should be. It's very common to have
+different resolutions for different operating systems, for example. It's easy to
+confuse facts and resolutions because they are superficially identical --- to add
+a new resolution to a fact, you simply add the fact again, only with a different
+`setcode` statement.
+
+When a fact has more than one resolution, the first resolution that returns a value other
+than `nil` sets the fact's value. The way that Facter decides the issue of resolution precedence is the
+weight property. Once Facter rules out any resolutions that are excluded because of `confine` statements,
+the resolution with the highest weight is evaluated first. If that resolution returns `nil`,
+Facter moves on to the next resolution (by descending weight) until it gets a value for the fact.
+
+By default, the weight of a fact is the number of confines for that resolution, so
+that more specific resolutions take priority over less specific resolutions.
+
+``` ruby
+# Check to see if this server has been marked as a postgres server
+Facter.add(:role) do
+  has_weight 100
+  setcode do
+    if File.exist? '/etc/postgres_server'
+      'postgres_server'
+    end
+  end
+end
+
+# Guess if this is a server by the presence of the pg_create binary
+Facter.add(:role) do
+  has_weight 50
+  setcode do
+    if File.exist? '/usr/sbin/pg_create'
+      'postgres_server'
+    end
+  end
+end
+
+# If this server doesn't look like a server, it must be a desktop
+Facter.add(:role) do
+  setcode do
+    'desktop'
+  end
+end
+```
+
+### Execution timeouts
+
+Although this version of Facter does not support overall timeouts on resolutions, you can pass a timeout
+to `Facter::Core::Execution#execute`:
+
+``` ruby
+Facter.add(:sleep) do
+  setcode do
+    begin
+      Facter::Core::Execution.execute('sleep 10', options = {:timeout => 5})
+      'did not timeout!'
+    rescue Facter::Core::Execution::ExecutionFailure
+      'timeout!'
+    end
+  end
+end
+```
+
+## Structured facts
+
+Structured facts take the form of either a hash or an array. To create a structured fact, return a hash or an array from the `setcode` statement.
+
+You can see some relevant examples in the [writing structured facts](fact_overview.html#writing-structured-facts) section of the [Fact Overview](fact_overview.html).
+
+## Aggregate resolutions
+
+If your fact combines the output of multiple commands, it may make sense to use aggregate resolutions. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks have been resolved separately, they're combined into a single flat or structured fact and returned.
+
+Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, add the `:type => :aggregate` parameter:
+
+``` ruby
+Facter.add(:fact_name, :type => :aggregate) do
+    #chunks go here
+    #aggregate block goes here
+end
+```
+
+Each step in the resolution then gets its own named `chunk` statement:
+
+``` ruby
+chunk(:one) do
+    'Chunk one returns this. '
+end
+
+chunk(:two) do
+    'Chunk two returns this.'
+end
+```
+
+Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns is the fact's value. Here's an example that just combines the strings from the two chunks above:
+
+``` ruby
+aggregate do |chunks|
+  result = ''
+
+  chunks.each_value do |str|
+    result += str
+  end
+
+  # Result: "Chunk one returns this. Chunk two returns this."
+  result
+end
+```
+
+If the `chunk` blocks all return arrays or hashes, you can omit the `aggregate` block. If you do, Facter automatically merges all of your data into one array or hash and uses that as the fact's value.
+
+For more examples of aggregate resolutions, see the [aggregate resolutions](fact_overview.html#writing-facts-with-aggregate-resolutions) section of the [Fact Overview](fact_overview.html) page.
+
+## Viewing fact values
+
+[puppetdb]: /puppetdb/latest
+
+If your Puppet masters are configured to use [PuppetDB][puppetdb], you can view and search all of the facts for any node, including custom facts. See [the PuppetDB docs][puppetdb] for more info.
+
+## External facts
+
+### What are external facts?
+
+External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
+
+### Fact locations
+
+The best way to distribute external facts is with pluginsync, which added support for them in [Puppet 3.4](/puppet/3/reference/release_notes.html#preparations-for-syncing-external-facts)/[Facter 2.0.1](../2.0/release_notes.html#pluginsync-for-external-facts). To add external facts to your Puppet modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
+
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system, whether your deployment uses Puppet Enterprise or open source releases, and whether you are running as root/Administrator. When calling facter from the command line, you can specify the external facts directory with the `--external-dir` option.
+
+> **Note:** These directories don't necessarily exist by default; you may need to create them. If you create the directory, make sure to restrict access so that only Administrators can write to the directory.
+
+In a module (recommended):
+
+    <MODULEPATH>/<MODULE>/facts.d/
+
+On Unix/Linux/OS X, there are three directories:
+
+    /opt/puppetlabs/facter/facts.d/
+    /etc/puppetlabs/facter/facts.d/
+    /etc/facter/facts.d/
+
+On Windows:
+
+    C:\ProgramData\PuppetLabs\facter\facts.d\
+
+When running as a non-root / non-Administrator user:
+
+    <HOME DIRECTORY>/.facter/facts.d/
+
+> **Note:** You can only use custom facts as a non-root user if you have first [configured non-root user access]({{pe}}/deploy_nonroot-agent.html) and previously run Puppet agent as that same user.
+
+### Executable facts --- Unix
+
+Executable facts on Unix work by dropping an executable file into the standard
+external fact path. A shebang (`#!`) is always required for executable facts on Unix. If the shebang is missing, the execution of the fact fails.
+
+An example external fact written in Python:
+
+``` python
+#!/usr/bin/env python
+data = {"key1" : "value1", "key2" : "value2" }
+
+for k in data:
+    print "%s=%s" % (k,data[k])
+```
+
+You must ensure that the script has its execute bit set:
+
+    chmod +x /etc/facter/facts.d/my_fact_script.py
+
+For Facter to parse the output, the script must return key/value pairs on
+STDOUT in the format:
+
+    key1=value1
+    key2=value2
+    key3=value3
+
+Using this format, a single script can return multiple facts.
+
+### Executable facts --- Windows
+
+Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
+
+- `.com` and `.exe`: binary executables
+- `.bat` and `.cmd`: batch scripts
+- `.ps1`: PowerShell scripts
+
+As with Unix facts, each script must return key/value pairs on STDOUT in the format:
+
+    key1=value1
+    key2=value2
+    key3=value3
+
+Using this format, a single script can return multiple facts in one return.
+
+#### Batch scripts
+
+The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (Byte Order Mark), otherwise you may get strange output.
+
+Here is a sample batch script which outputs facts using the required format:
+
+    @echo off
+    echo key1=val1
+    echo key2=val2
+    echo key3=val3
+    REM Invalid - echo 'key4=val4'
+    REM Invalid - echo "key5=val5"
+
+#### PowerShell scripts
+
+The encoding that should be used with `.ps1` files is pretty open. PowerShell determines the encoding of the file at run time.
+
+Here is a sample PowerShell script which outputs facts using the required format:
+
+    Write-Host "key1=val1"
+    Write-Host 'key2=val2'
+    Write-Host key3=val3
+
+You should be able to save and execute this PowerShell script on the command line.
+
+### Structured data facts
+
+Facter can parse structured data files stored in the external facts directory and set facts based on their contents.
+
+Structured data files must use one of the supported data types and must have the correct file extension. Facter supports the following extensions and data types:
+
+`.yaml`: YAML data, in the following format:
+
+``` yaml
+---
+key1: val1
+key2: val2
+key3: val3
+```
+
+`.json`: JSON data, in the following format:
+
+``` javascript
+{
+    "key1": "val1",
+    "key2": "val2",
+    "key3": "val3"
+}
+```
+
+`.txt`: Key value pairs, in the following format:
+
+```
+key1=value1
+key2=value2
+key3=value3
+```
+
+As with executable facts, structured data files can set multiple facts at once.
+
+``` javascript
+{
+  "datacenter":
+  {
+    "location": "bfs",
+    "workload": "Web Development Pipeline",
+    "contact": "Blackbird"
+  },
+  "provision":
+  {
+    "birth": "2017-01-01 14:23:34",
+    "user": "alex"
+  }
+}
+```
+
+#### Structured data facts on Windows
+
+All of the above types are supported on Windows with the following caveats:
+
+* The line endings can be either `LF` or `CRLF`.
+* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+
+### Troubleshooting
+
+If your external fact is not appearing in Facter's output, running
+Facter in debug mode should give you a meaningful reason and tell you which file is causing the problem:
+
+    # puppet facts --debug
+
+One example of when this can happen is in cases where a fact returns invalid characters.
+For example if you used a hyphen instead of an equals sign in your script `test.sh`:
+
+    #!/bin/bash
+
+    echo "key1-value1"
+
+Running `puppet facts --debug` yields a useful message:
+
+    ...
+    Debug: Facter: resolving facts from executable file "/tmp/test.sh".
+    Debug: Facter: executing command: /tmp/test.sh
+    Debug: Facter: key1-value1
+    Debug: Facter: ignoring line in output: key1-value1
+    Debug: Facter: process exited with status code 0.
+    Debug: Facter: completed resolving facts from executable file "/tmp/test.sh".
+    ...
+
+#### External facts and `stdlib`
+
+If you find that an external fact does not match what you have configured in your `facts.d`
+directory, make sure you have not defined the same fact using the external facts capabilities
+found in the `stdlib` module.
+
+### Drawbacks
+
+While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
+
+* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+* External executable facts are forked instead of executed within the same process.

--- a/source/facter/3.9/fact_overview.md
+++ b/source/facter/3.9/fact_overview.md
@@ -1,0 +1,230 @@
+---
+layout: default
+title: "Overview of custom facts with examples"
+---
+
+
+A typical fact in Facter is a fairly simple assemblage of just a few different elements.
+This page is an example-driven tour of those elements, and is intended as a quick primer or reference
+for authors of custom facts. You need some familiarity with Ruby to understand most of these examples.
+For a gentler introduction, check out the [Custom Facts Walkthrough](custom_facts.html).
+
+It's important to distinguish between **facts** and **resolutions**. A fact is a piece of information about a given node,
+while a resolution is a way of obtaining that information from the system. That means every fact needs to have **at least one**
+resolution, and facts that can run on different operating systems may need to have different resolutions for each one.
+
+Even though facts and resolutions are conceptually very different, the line can get a bit blurry at times. That's because declaring a second
+(or more) resolution for a fact looks just like declaring a completely new fact, only with the same name as an existing fact.
+
+## Writing facts with simple resolutions
+
+Most facts are resolved all at once, without any need to merge data from different sources. In that case, the resolution is simple.
+Both flat and structured facts can have simple resolutions.
+
+### Example: Minimal fact that relies on a single shell command
+
+``` ruby
+Facter.add(:rubypath) do
+  setcode 'which ruby'
+end
+```
+
+### Example: Different resolutions for different operating systems
+
+``` ruby
+Facter.add(:rubypath) do
+  setcode 'which ruby'
+end
+
+Facter.add(:rubypath) do
+  confine :osfamily => "Windows"
+  # Windows uses 'where' instead of 'which'
+  setcode 'where ruby'
+end
+```
+
+### Example: Slightly more complex fact, confined to Linux with a block
+
+``` ruby
+Facter.add(:jruby_installed) do
+  confine :kernel do |value|
+    value == "Linux"
+  end
+
+  setcode do
+    # If jruby is present, return true. Otherwise, return false.
+    Facter::Core::Execution.which('jruby') != nil
+  end
+end
+```
+
+### Main components of simple resolutions
+
+Simple facts are typically made up of the following parts:
+
+1. A call to `Facter.add(:fact_name)`:
+    * This introduces a new fact *or* a new resolution for an existing fact with the same name.
+    * The name can be either a symbol or a string.
+    * The rest of the fact is wrapped in the `add` call's `do ... end` block.
+2. Zero or more `confine` statements:
+    * Determine whether the resolution is suitable (and therefore is evaluated).
+    * Can either match against the value of another fact or evaluate a Ruby block.
+    * If given a symbol or string representing a fact name, a block is required and the block receives the fact's value as an argument.
+    * If given a hash, the keys are expected to be fact names. The values of the hash are either the expected fact values or an array of values to compare against.
+    * If given a block, the confine is suitable if the block returns a value other than `nil` or `false`.
+3. An optional `has_weight` statement:
+    * When multiple resolutions are available for a fact, resolutions are evaluated from highest weight value to lowest.
+    * Must be an integer greater than 0.
+    * Defaults to the number of `confine` statements for the resolution.
+4. A `setcode` statement that determines the value of the fact:
+    * Can take either a string or a block.
+    * If given a string, Facter executes it as a shell command. If the command succeeds, the output of the command is the value of the fact. If the command fails, the next suitable resolution is evaluated.
+    * If given a block, the block's return value is the value of the fact unless the block returns `nil`. If `nil` is returned, the next suitable resolution is evalutated.
+    * Can execute shell commands within a `setcode` block, using the `Facter::Core::Execution.exec` function.
+    * If multiple `setcode` statements are evaluated for a single resolution, only the last `setcode` block is used.
+
+## Writing structured facts
+
+Structured facts can take the form of hashes or arrays. You don't have to do anything special to mark the fact as structured --- if your fact returns a hash or array, Facter recognizes it as a structured fact. Structured facts can have [simple](#main-components-of-simple-resolutions) or [aggregate resolutions](#main-components-of-aggregate-resolutions).
+
+### Example: Returning an array of network interfaces
+
+``` ruby
+Facter.add(:interfaces_array) do
+  setcode do
+   interfaces = Facter.value(:interfaces)
+   # the 'interfaces' fact returns a single comma-delimited string, e.g., "lo0,eth0,eth1"
+   # this splits the value into an array of interface names
+   interfaces.split(',')
+  end
+end
+```
+
+### Example: Returning a hash of network interfaces to IP addresses
+
+``` ruby
+Facter.add(:interfaces_hash) do
+  setcode do
+    interfaces_hash = {}
+
+    Facter.value(:interfaces_array).each do |interface|
+      ipaddress = Facter.value("ipaddress_#{interface}")
+      if ipaddress
+        interfaces_hash[interface] = ipaddress
+      end
+    end
+
+    interfaces_hash
+  end
+end
+```
+
+## Writing facts with aggregate resolutions
+
+Aggregate resolutions allow you to split up the resolution of a fact into separate chunks. By default, Facter merges hashes with hashes or arrays with arrays, resulting in a [structured fact](#writing-structured-facts), but you can also aggregate the chunks into a flat fact using concatenation, addition, or any other function that you can express in Ruby code.
+
+### Main components of aggregate resolutions
+
+Aggregate resolutions have two key differences compared to simple resolutions: the presence of `chunk` statements and the lack of a `setcode` statement. The `aggregate` block is optional, and without it Facter merges hashes with hashes or arrays with arrays.
+
+1. A call to `Facter.add(:fact_name, :type => :aggregate)`:
+    * Introduces a new fact *or* a new resolution for an existing fact with the same name.
+    * The name can be either a symbol or a string.
+    * The `:type => :aggregate` parameter is required for aggregate resolutions.
+    * The rest of the fact is wrapped in the `add` call's `do ... end` block.
+2. Zero or more `confine` statements:
+    * Determine whether the resolution is suitable and (therefore is evaluated).
+    * They can either match against the value of another fact or evaluate a Ruby block.
+    * If given a symbol or string representing a fact name, a block is required and the block receives the fact's value as an argument.
+    * If given a hash, the keys are expected to be fact names. The values of the hash are either the expected fact values or an array of values to compare against.
+    * If given a block, the confine is suitable if the block returns a value other than `nil` or `false`.
+3. An optional `has_weight` statement:
+    * Evaluates multiple resolutions for a fact from highest weight value to lowest.
+    * Must be an integer greater than 0.
+    * Defaults to the number of `confine` statements for the resolution.
+4. One or more calls to `chunk`, each containing:
+    * A name (as the argument to `chunk`).
+    * A block of code, which is responsible for resolving the chunk to a value. The block's return value is the value of the chunk; it can be any type, but is typically a hash or array.
+5. An optional `aggregate` block:
+    * If absent, Facter automatically merges hashes with hashes or arrays with arrays.
+    * To merge the chunks in any other way, you need to make a call to `aggregate`, which takes a block of code.
+    * The block is passed one argument (`chunks`, in the example), which is a hash of chunk name to chunk value for all the chunks in the resolution.
+
+### Example: Building a structured fact progressively
+
+This example builds a new fact, `networking_primary_sha`, by progressively merging two chunks. One chunk encodes each networking interface's MAC address as an encoded base64 value, and the other determines if each interface is the system's primary interface.
+
+``` ruby
+require 'digest'
+require 'base64'
+
+Facter.add(:networking_primary_sha, :type => :aggregate) do
+
+  chunk(:sha256) do
+    interfaces = {}
+
+    Facter.value(:networking)['interfaces'].each do |interface, values|
+      if values['mac']
+        hash = Digest::SHA256.digest(values['mac'])
+        encoded = Base64.encode64(hash)
+        interfaces[interface] = {:mac_sha256 => encoded.strip}
+      end
+    end
+
+    interfaces
+  end
+
+  chunk(:primary?) do
+    interfaces = {}
+
+    Facter.value(:networking)['interfaces'].each do |interface, values|
+      interfaces[interface] = {:primary? => (interface == Facter.value(:networking)['primary'])}
+    end
+
+    interfaces
+  end
+  # Facter merges the return values for the two chunks
+  # automatically, so there's no aggregate statement.
+end
+```
+
+The fact's output is organized by network interface into hashes, each containing the two chunks:
+
+``` ruby
+{
+  bridge0 => {
+    mac_sha256 => "bfgEFV7m1V04HYU6UqzoNoVmnPIEKWRSUOU650j0Wkk=",
+    primary?   => false
+  },
+  en0 => {
+    mac_sha256 => "6Fd3Ws2z+aIl8vNmClCbzxiO2TddyFBChMlIU+QB28c=",
+    primary?   => true
+  },
+  ...
+}
+```
+
+### Example: Building a flat fact progressively with addition
+
+``` ruby
+Facter.add(:total_free_memory_mb, :type => :aggregate) do
+  chunk(:physical_memory) do
+    Facter.value(:memoryfree_mb)
+  end
+
+  chunk(:virtual_memory) do
+    Facter.value(:swapfree_mb)
+  end
+
+  aggregate do |chunks|
+    # The return value for this block determines the value of the fact.
+    sum = 0
+    chunks.each_value do |i|
+      sum += i
+    end
+
+    sum
+  end
+end
+```
+

--- a/source/facter/3.9/index.md
+++ b/source/facter/3.9/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: "Documentation index"
+---
+
+Facter is Puppet's cross-platform system profiling library. It discovers and reports per-node facts, which are available in your Puppet manifests as variables.
+
+* [The list of core facts](./core_facts.html) lists and describes every built-in fact that ships with Facter.
+* [The custom fact reference](./fact_overview.html) serves as an example-driven primer and quick reference for fact authors.
+* [The custom facts walkthrough](./custom_facts.html) explains in detail how to write and distribute your own custom or external facts.
+* [The Facter release notes](./release_notes.html) document Facter's history.

--- a/source/facter/3.9/release_notes.md
+++ b/source/facter/3.9/release_notes.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: "Facter Release notes"
+---
+
+This page documents the history of the Facter 3.8 series.
+
+## Facter 3.8.0
+
+Released August 17, 2017.
+
+This is a feature and improvement release of Facter that includes several bug fixes.
+
+* [All issues resolved in Facter 3.8.0](https://tickets.puppetlabs.com/issues/?jql=fixVersion%20%3D%20%27FACT%203.8.0%27)
+
+### New Features
+
+* New facts, ZFS and ZPool have been aded to Facter's FreeBSD resolvers. Previously, these were only reported on Solaris.
+
+* Added Go bindings. This release includes a function to gather default facts for Linux machines only. 
+
+
+### Improvements
+
+* BSDs now report hardware architecture.
+
+* Virtualization detection for FreeBSD Jails has been added.
+
+* Backward support added for zpool feature flags prior to verion 28.
+
+
+### Bug fixes
+
+These bugs have been fixed in this release:
+
+* Free BSD OS release and Kernel release are now reported independently
+
+* Memory reporting on FreeBSD now reports accurately.
+
+* Facter is now compatible with OpenSSL 1.1.0
+
+* Integers from feature descriptions are no longer reported as zpool feature numbers.
+
+

--- a/source/facter/3.9/release_notes.md
+++ b/source/facter/3.9/release_notes.md
@@ -1,44 +1,27 @@
 ---
 layout: default
-title: "Facter Release notes"
+title: "Facter release notes"
 ---
 
-This page documents the history of the Facter 3.8 series.
+This page documents the history of the Facter 3.9 series.
 
-## Facter 3.8.0
+## Facter 3.9.0
 
 Released August 17, 2017.
 
-This is a feature and improvement release of Facter that includes several bug fixes.
+This is a feature and bug-fix release of Facter.
 
-* [All issues resolved in Facter 3.8.0](https://tickets.puppetlabs.com/issues/?jql=fixVersion%20%3D%20%27FACT%203.8.0%27)
+-   [All issues resolved in Facter 3.9.0](https://tickets.puppetlabs.com/issues/?jql=fixVersion%20%3D%20%27FACT%203.9.0%27)
 
 ### New Features
 
-* New facts, ZFS and ZPool have been aded to Facter's FreeBSD resolvers. Previously, these were only reported on Solaris.
+-   [FACT-1742](https://tickets.puppetlabs.com/browse/FACT-1742): Facter 3.9.0 adds a new `hypervisors` fact for virtualization providers that uses [libwhereami](https://github.com/puppetlabs/libwhereami/), an optional new dependency enabled by default in Puppet Platform 5.2 builds of Facter.
 
-* Added Go bindings. This release includes a function to gather default facts for Linux machines only. 
+    The new fact recognizes multiple hypervisors in nested virtualization environments, and includes metadata about each hypervisor where available. The `hypervisor` fact and libwhereami are the first steps toward improved virtualzation support in future releases of Facter. They also reduce its dependence on the external tool `virt-what`, which has a few detection bugs and requires root to run.
 
-
-### Improvements
-
-* BSDs now report hardware architecture.
-
-* Virtualization detection for FreeBSD Jails has been added.
-
-* Backward support added for zpool feature flags prior to verion 28.
-
+    This new feature should therefore also remediate discrepancies in Facter's output when run as root and as a non-root user under virtualized environments.
 
 ### Bug fixes
 
-These bugs have been fixed in this release:
-
-* Free BSD OS release and Kernel release are now reported independently
-
-* Memory reporting on FreeBSD now reports accurately.
-
-* Facter is now compatible with OpenSSL 1.1.0
-
-* Integers from feature descriptions are no longer reported as zpool feature numbers.
-
-
+-   [FACT-1728](https://tickets.puppetlabs.com/browse/FACT-1728): Facter 3.9.0 provides an improved error message when `facter -p` is specified but Puppet cannot be loaded.
+-   [FACT-1731](https://tickets.puppetlabs.com/browse/FACT-1731): Facter 3.9.0 correctly reports `virtual` and `is_virtual` facts when using FreeBSD's bhyve hypervisor.

--- a/source/facter/3.9/release_notes.md
+++ b/source/facter/3.9/release_notes.md
@@ -7,7 +7,7 @@ This page documents the history of the Facter 3.9 series.
 
 ## Facter 3.9.0
 
-Released August 17, 2017.
+Released September 13, 2017.
 
 This is a feature and bug-fix release of Facter.
 

--- a/source/facter/3.9/release_notes.md
+++ b/source/facter/3.9/release_notes.md
@@ -15,9 +15,9 @@ This is a feature and bug-fix release of Facter.
 
 ### New Features
 
--   [FACT-1742](https://tickets.puppetlabs.com/browse/FACT-1742): Facter 3.9.0 adds a new `hypervisors` fact for virtualization providers that uses [libwhereami](https://github.com/puppetlabs/libwhereami/), an optional new dependency enabled by default in Puppet Platform 5.2 builds of Facter.
+-   [FACT-1742](https://tickets.puppetlabs.com/browse/FACT-1742): Facter 3.9.0 adds a new [`hypervisors` fact](./core_facts.html#hypervisors) for virtualization providers that uses [libwhereami](https://github.com/puppetlabs/libwhereami/), an optional new dependency enabled by default in Puppet Platform 5.2 builds of Facter.
 
-    The new fact recognizes multiple hypervisors in nested virtualization environments, and includes metadata about each hypervisor where available. The `hypervisor` fact and libwhereami are the first steps toward improved virtualzation support in future releases of Facter. They also reduce its dependence on the external tool `virt-what`, which has a few detection bugs and requires root to run.
+    The new fact recognizes multiple hypervisors in nested virtualization environments, and includes metadata about each hypervisor where available. The `hypervisors` fact and libwhereami are the first steps toward improved virtualzation support in future releases of Facter. They also reduce its dependence on the external tool `virt-what`, which has a few detection bugs and requires root to run.
 
     This new feature should therefore also remediate discrepancies in Facter's output when run as root and as a non-root user under virtualized environments.
 


### PR DESCRIPTION
-   Add Facter 3.9 release notes.
-   Update core facts list.

Relevant files to review:

See commit 379735845c33549e1e2adefcd07e75fe0968d8b7.

-   core_facts.md
-   release_notes.md

Changes still pending for this PR:

None. References have already been generated from facter commit [`1650f44`](https://github.com/puppetlabs/facter/commit/1650f446b4b6076ab0e5937ef9e47a4523fc385b), which includes the new `hypervisor` fact.

Changes to be made in other PRs:

-   Puppet 5.2 release notes and docs (PR #785)
-   Puppet Server 5.1 release notes and docs (puppet-server [PR #1506](https://github.com/puppetlabs/puppetserver/pull/1506))
-   Hiera release notes (if any)
-   `_config.yml` updates to publish the docs (PR #787)