### PR TITLE
(PA-1510) Release notes for Puppet 4.10.8 and Agent 1.10.8.

### DIFF
--- a/source/puppet/4.10/release_notes.markdown
+++ b/source/puppet/4.10/release_notes.markdown
@@ -18,6 +18,20 @@ Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), because the
 
 Also of interest: the [Puppet 4.9 release notes](/puppet/4.9/release_notes.html) and [Puppet 4.8 release notes](/puppet/4.8/release_notes.html).
 
+## Puppet 4.10.8
+
+Released September 14, 2017.
+
+This is a small bug-fix release in the Puppet 4.10 series.
+
+* [All issues fixed in Puppet 4.10.8](https://tickets.puppetlabs.com/issues/?jql=fixVersion+%3D+%27PUP+4.10.8%27)
+
+### Bug fixes
+
+If illegal variables (with many or long name segments) had a segment with an initial uppercase letter in previous versions of Puppet 4, the parser could take an extremely long time to match the input. This caused very long compilation times and excessive CPU load. Puppet 4.10.8 resolves this issue by changing the relevant regular expression to avoid excessive backtracking to match the regular expression for variables.
+
+* [PUP-7848](https://tickets.puppetlabs.com/browse/PUP-7848)
+
 ## Puppet 4.10.7
 
 Released September 6, 2017.

--- a/source/puppet/4.10/release_notes_agent.md
+++ b/source/puppet/4.10/release_notes_agent.md
@@ -9,6 +9,7 @@ title: "Puppet agent release notes"
 [Puppet 4.10.5]: /puppet/4.10/release_notes.html#puppet-4105
 [Puppet 4.10.6]: /puppet/4.10/release_notes.html#puppet-4106
 [Puppet 4.10.7]: /puppet/4.10/release_notes.html#puppet-4107
+[Puppet 4.10.8]: /puppet/4.10/release_notes.html#puppet-4108
 
 [Facter 3.6.3]: /facter/3.6/release_notes.html#facter-363
 [Facter 3.6.4]: /facter/3.6/release_notes.html#facter-364
@@ -38,6 +39,20 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html), and the [Puppet 4.10 release notes](./release_notes.html).
+
+## Puppet agent 1.10.8
+
+Released September 14, 2017.
+
+### Component updates
+
+This release contains a bug fix in [Puppet 4.10.8][] and a versioning fix in the Windows package. No other components are updated.
+
+### Bug fix: Change NSSM version increment to avoid upgrade issues
+
+Previous versions of Puppet agent did not increment the version of NSSM in a manner expected by Microsoft Installer (MSI), leading to MSI unintentionally removing it upon upgrade. Puppet agent 1.10.8 resolves this issue by changing the versioning scheme for NSSM.
+
+* [PA-1504](https://tickets.puppetlabs.com/browse/PA-1504)
 
 ## Puppet agent 1.10.7
 


### PR DESCRIPTION
Just in case. Feel free to close this PR if someone else will handle release on Sept. 14.