### PR TITLE
(PDK-463) Improve PowerShell 2 and 3 documentation

### DIFF
--- a/source/pdk/1.0/pdk_install.md
+++ b/source/pdk/1.0/pdk_install.md
@@ -35,7 +35,7 @@ PDK supports the following operating systems.
 | Windows Server (Server OS) | 2008r2, 2012, 2012r2, 2012r2 Core, and 2016 | x86_64 | MSI |
 | Mac OS X | 10.11, 10.12 | x86_64 | N/A |
 
-On Windows, PowerShell 2.0 or greater is supported.
+On Windows, PowerShell 4.0 or greater is recommended, 2.0 or greater is supported.
 
 PDK functions, such as creating classes, testing, and validation, are supported only on modules created with PDK.
 
@@ -68,8 +68,26 @@ Download and install the PDK package for Windows systems.
 
 1. Download the PDK package from [PDK downloads site](https://puppet.com/download-puppet-development-kit).
 1. Double click on the downloaded package to install.
-1. Open a Powershell window to re-source your profile and make PDK available to your PATH. If you are running PowerShell 3.0 or later, PDK loads automatically and the `pdk` command is now available to the prompt.
-1. If you are running PowerShell 2.0, load the module by running `Import-Module -Name PuppetDevelopmentKit` in your PowerShell window.
+1. Open a Powershell window to re-source your profile and make PDK available to your PATH. On PowerShell 4.0 or later, PDK loads automatically and the `pdk` command is available to the prompt. On PowerShell 2.0 or 3.0, see below.
+
+PowerShell 2.0 and 3.0 Instructions
+
+While PowerShell 4.0 and greater automatically discover and load the PDK PowerSHell Module, PowerShell v2 and 3 do not have autoloading capabilities. You will have to load the module yourself using the full path to the PDK module. You can do this by adding the following line to you PowerShell profile:
+
+```
+`Import-Module -Name "$($env:ProgramFiles)\WindowsPowerShell\Modules\PuppetDevelopmentKit"`
+```
+
+You can alternatly add the `$env:ProgramFiles\WindowsPowerShell\Modules` path to the `$env:PSModulePath` environment variable instead. You can do this by adding the following line to you PowerShell profile:
+
+```
+$env:PSModulePath = $env:PSModulePath + ";$($env:ProgramFiles)\WindowsPowerShell\Modules"
+Import-Module -Name PuppetDevelopmentKit
+```
+
+Once that is done, either close and reopen PowerShell, or dot source your PowerShell profile by running: `. $profile`, and the PDK will automatically load every time you open PowerShell. 
+
+PoweShell Execution Policy
 
 If you get execution policy restriction errors when you try to run `pdk` commands, see [PDK troubleshooting][troubleshoot] for help.
 


### PR DESCRIPTION
This updates the explanation for how to install the PDK on systems with PowerShell v2 or v3. It corrects the assumption that you can load the PowerShell by name and replaces it with the full path. It also adds steps to load the module on v2 and v3 in your PowerShell profile so it can be done automatically like v4 and v5 can.