### PR TITLE
Remove erroneous 'inherits ntp' stanzas in beginner's module guide

### DIFF
--- a/source/puppet/4.10/bgtm.md
+++ b/source/puppet/4.10/bgtm.md
@@ -84,7 +84,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -104,7 +104,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -145,7 +145,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -176,7 +176,7 @@ Naming consistency is imperative for community comprehension and assists in trou
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 

--- a/source/puppet/4.9/bgtm.md
+++ b/source/puppet/4.9/bgtm.md
@@ -84,7 +84,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -104,7 +104,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -145,7 +145,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -176,7 +176,7 @@ Naming consistency is imperative for community comprehension and assists in trou
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 

--- a/source/puppet/5.0/bgtm.md
+++ b/source/puppet/5.0/bgtm.md
@@ -91,7 +91,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -112,7 +112,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -154,7 +154,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -191,7 +191,7 @@ Best practices recommend the pattern of `thing_property` for naming parameters.
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -332,7 +332,7 @@ For guidance, see our modules documentation [guide](./modules_documentation.html
 {:.concept}
 ## Releasing your module
 
-We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com). 
+We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com).
 
 Sharing your modules allows other users to write improvements to the modules you make available and contribute them back to you, effectively giving you free improvements to your modules.
 

--- a/source/puppet/5.1/bgtm.md
+++ b/source/puppet/5.1/bgtm.md
@@ -91,7 +91,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -112,7 +112,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -154,7 +154,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -191,7 +191,7 @@ Best practices recommend the pattern of `thing_property` for naming parameters.
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -332,7 +332,7 @@ For guidance, see our modules documentation [guide](./modules_documentation.html
 {:.concept}
 ## Releasing your module
 
-We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com). 
+We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com).
 
 Sharing your modules allows other users to write improvements to the modules you make available and contribute them back to you, effectively giving you free improvements to your modules.
 

--- a/source/puppet/5.2/bgtm.md
+++ b/source/puppet/5.2/bgtm.md
@@ -91,7 +91,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -112,7 +112,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -154,7 +154,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -191,7 +191,7 @@ Best practices recommend the pattern of `thing_property` for naming parameters.
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -332,7 +332,7 @@ For guidance, see our modules documentation [guide](./modules_documentation.html
 {:.concept}
 ## Releasing your module
 
-We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com). 
+We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com).
 
 Sharing your modules allows other users to write improvements to the modules you make available and contribute them back to you, effectively giving you free improvements to your modules.
 

--- a/source/puppet/5.3/bgtm.md
+++ b/source/puppet/5.3/bgtm.md
@@ -91,7 +91,7 @@ The install class must be located in the `install.pp` file. It should contain al
 The install class must be named `module::install`, as in the `ntp` module:
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -112,7 +112,7 @@ The resources related to configuring the installed software should be placed in 
 For example, see the `module::config` class in the `ntp` module:
 
 ``` ruby
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
@@ -154,7 +154,7 @@ The remaining service resources, and anything else related to the running state 
 For example:
 
 ``` ruby
-class ntp::service inherits ntp {
+class ntp::service {
 
   if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
@@ -191,7 +191,7 @@ Best practices recommend the pattern of `thing_property` for naming parameters.
 For example, in the `ntp` module
 
 ``` ruby
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 
@@ -332,7 +332,7 @@ For guidance, see our modules documentation [guide](./modules_documentation.html
 {:.concept}
 ## Releasing your module
 
-We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com). 
+We encourage you to publish your modules on the [Puppet Forge](http://forge.puppet.com).
 
 Sharing your modules allows other users to write improvements to the modules you make available and contribute them back to you, effectively giving you free improvements to your modules.
 


### PR DESCRIPTION
Since the ntp class contains the other ntp classes ntp::install,
ntp::config, ntp::service it is neither necessary nor useful for these
classes to inherit from the "main" ntp class.

Class inheritance is also never touched upon in the beginner's module
guide so it seems dangerous to use inheritance in an unnecessary way
and without any explanation.

The reason inheritance even made it into the guide is probably that the
puppetlabs-ntp module made that change years ago and it was never
cleaned up.