### PR TITLE
Rewrite /puppet/(version)/reference links.

### DIFF
--- a/source/puppet/4.0/architecture.markdown
+++ b/source/puppet/4.0/architecture.markdown
@@ -9,7 +9,7 @@ title: "Overview of Puppet's Architecture"
 [master_http]: ./http_api/http_api_index.html
 [auth.conf]: ./conf_file_auth.html
 [catalog_compilation]: ./subsystem_catalog_compilation.html
-[report handlers]: /puppet/3.7/reference/report.html
+[report handlers]: /puppet/3.7/report.html
 [lang_basics]: ./lang_summary.html
 [apply]: ./services_apply.html
 [puppetdb]: /puppetdb/latest

--- a/source/puppet/4.0/configuration.md
+++ b/source/puppet/4.0/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -138,7 +138,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -278,15 +278,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](http://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](http://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](http://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](http://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -389,7 +389,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### configprint
@@ -636,7 +636,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/environments
 
@@ -1031,7 +1031,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: 
 
@@ -1127,7 +1127,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### name

--- a/source/puppet/4.0/function.md
+++ b/source/puppet/4.0/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 

--- a/source/puppet/4.0/index.markdown
+++ b/source/puppet/4.0/index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.0 Reference Manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 
@@ -33,7 +33,7 @@ In order to get this release into the world as quickly as possible we had to mak
 
 ## Previous Versions
 
-- [Puppet 3.7](/puppet/3.7/reference)
-- [Puppet 3.6](/puppet/3.6/reference)
-- [Puppet 3.5](/puppet/3.5/reference)
+- [Puppet 3.7](/puppet/3.7)
+- [Puppet 3.6](/puppet/3.6)
+- [Puppet 3.5](/puppet/3.5)
 - [Puppet 3.0 through 3.4](/puppet/3/reference)

--- a/source/puppet/4.0/indirection.md
+++ b/source/puppet/4.0/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.0/install_linux.markdown
+++ b/source/puppet/4.0/install_linux.markdown
@@ -3,15 +3,15 @@ layout: default
 title: "Installing Puppet: Linux"
 ---
 
-[master_settings]: /puppet/latest/reference/config_important_settings.html#settings-for-puppet-master-servers
-[agent_settings]: /puppet/latest/reference/config_important_settings.html#settings-for-agents-all-nodes
+[master_settings]: /puppet/latest/config_important_settings.html#settings-for-puppet-master-servers
+[agent_settings]: /puppet/latest/config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: /puppetserver/latest/install_from_packages.html#memory-allocation
 [puppetserver_confd]: /puppetserver/latest/configuration.html
-[modules]: /puppet/latest/reference/modules_fundamentals.html
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
-[environments]: /puppet/latest/reference/environments.html
+[modules]: /puppet/latest/modules_fundamentals.html
+[main manifest]: /puppet/latest/dirs_manifest.html
+[environments]: /puppet/latest/environments.html
 
 
 ## Read the Pre-Install Tasks

--- a/source/puppet/4.0/install_pre.markdown
+++ b/source/puppet/4.0/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-Install Tasks"
 [peinstall]: /pe/latest/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 
 > **Note:** This document covers open source releases of Puppet. [See here for instructions on installing Puppet Enterprise.][peinstall]
 

--- a/source/puppet/4.0/install_windows.markdown
+++ b/source/puppet/4.0/install_windows.markdown
@@ -7,10 +7,10 @@ title: "Installing Puppet: Microsoft Windows"
 [peinstall]: /pe/latest/install_windows.html
 [pre_install]: ./install_pre.html
 [where]: ./whered_it_go.html
-[puppet.conf]: /puppet/latest/reference/config_file_main.html
-[environment]: /puppet/latest/reference/environments.html
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[vardir]: /puppet/latest/reference/dirs_vardir.html
+[puppet.conf]: /puppet/latest/config_file_main.html
+[environment]: /puppet/latest/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[vardir]: /puppet/latest/dirs_vardir.html
 
 ## Review the Pre-Install Tasks
 
@@ -93,10 +93,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 

--- a/source/puppet/4.0/metaparameter.md
+++ b/source/puppet/4.0/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### loglevel
 
@@ -144,7 +144,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -157,12 +157,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -171,7 +171,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -223,7 +223,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -236,7 +236,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 

--- a/source/puppet/4.0/release_notes.markdown
+++ b/source/puppet/4.0/release_notes.markdown
@@ -78,7 +78,7 @@ The rewritten parser includes new capabilities like iteration and type-checking 
 
 ## BREAK: Directory Environments Replace Config File Environments
 
-Starting with Puppet 3.6, Directory Environments started taking over from Dynamic Environments as Puppet's mechanism for serving different versions of modules and code. In Puppet 4, they're the default and other environment support is gone. Read more about directory environments in the [environments section of the docs](/puppet/latest/reference/environments.html).
+Starting with Puppet 3.6, Directory Environments started taking over from Dynamic Environments as Puppet's mechanism for serving different versions of modules and code. In Puppet 4, they're the default and other environment support is gone. Read more about directory environments in the [environments section of the docs](/puppet/latest/environments.html).
 
 * [PUP-3268: Remove non-directory environment support](https://tickets.puppetlabs.com/browse/PUP-3268)
 * [PUP-3567: Remove current_environment check in Puppet::Indirector::Request#environment=](https://tickets.puppetlabs.com/browse/PUP-3567)

--- a/source/puppet/4.0/report.md
+++ b/source/puppet/4.0/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 

--- a/source/puppet/4.0/system_requirements.markdown
+++ b/source/puppet/4.0/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.0 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet 4.0, first [view pre-install tasks](/pre_install.html).

--- a/source/puppet/4.0/type.md
+++ b/source/puppet/4.0/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 08cb8b2d315a296fa404a4871f94b3703a819461
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc: columns
 ---
 
@@ -22,7 +22,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.

--- a/source/puppet/4.0/upgrade_agent.markdown
+++ b/source/puppet/4.0/upgrade_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/latest/reference/upgrade_agent.html"
+canonical: "/puppet/latest/upgrade_agent.html"
 ---
 
 This guide will help you update your Puppet 3.x agents to Puppet 4.0.

--- a/source/puppet/4.0/upgrade_server.markdown
+++ b/source/puppet/4.0/upgrade_server.markdown
@@ -44,7 +44,7 @@ from agents. Once the puppet-agent package is installed and the CA files are in 
 
 One of the big changes in Puppet 4 is its standardization on Directory Environments. There's an in-depth document
 on [configuration settings for directory 
-environments](/puppet/latest/reference/environments_configuring.html#global-settings-for-configuring-environments) but 
+environments](/puppet/latest/environments_configuring.html#global-settings-for-configuring-environments) but 
 the defaults have been adjusted for Puppet 4 so very little configuration should be necessary for most people. Out of 
 the box, the puppet-agent's directory structure will look like this:
 
@@ -64,7 +64,7 @@ If you're not using r10k, or not using environments at all, you can simply put y
 
 ## Transfer custom settings
 
-The default settings written into the newer, slimmer puppet.conf should work pretty well for most people. If your old puppet.conf had settings related to environments (especially static "config file environments" that use the `[environmentname]` stanzas in puppet.conf, these will either become global (such as adjusting `basemodulepath` [as described here](/puppet/latest/reference/environments_configuring.html#basemodulepath]) or move into an environment-specific config file, [documented in the environment.conf section](/puppet/3.7/reference/environments_creating.html#the-environmentconf-file). 
+The default settings written into the newer, slimmer puppet.conf should work pretty well for most people. If your old puppet.conf had settings related to environments (especially static "config file environments" that use the `[environmentname]` stanzas in puppet.conf, these will either become global (such as adjusting `basemodulepath` [as described here](/puppet/latest/environments_configuring.html#basemodulepath]) or move into an environment-specific config file, [documented in the environment.conf section](/puppet/3.7/environments_creating.html#the-environmentconf-file). 
 
 Read through the [Puppet 4 Release Notes](release_notes.html) for more detail on other settings which were removed or whose defaults may have changed.
 

--- a/source/puppet/4.0/whered_it_go.markdown
+++ b/source/puppet/4.0/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Puppet 4.0 Preview: Where Did Everything Go?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.1/config_about_settings.markdown
+++ b/source/puppet/4.1/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is Configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.1/config_file_auth.markdown
+++ b/source/puppet/4.1/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: auth.conf"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.1/config_file_autosign.markdown
+++ b/source/puppet/4.1/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.1/config_file_csr_attributes.markdown
+++ b/source/puppet/4.1/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config Files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.1/config_file_device.markdown
+++ b/source/puppet/4.1/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.1/config_file_environment.markdown
+++ b/source/puppet/4.1/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config Files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.1/config_file_fileserver.markdown
+++ b/source/puppet/4.1/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.1/config_file_hiera.markdown
+++ b/source/puppet/4.1/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: /hiera/latest/

--- a/source/puppet/4.1/config_file_main.markdown
+++ b/source/puppet/4.1/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: The Main Config File (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.1/config_file_oid_map.md
+++ b/source/puppet/4.1/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.1/config_file_puppetdb.markdown
+++ b/source/puppet/4.1/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html

--- a/source/puppet/4.1/config_file_routes.markdown
+++ b/source/puppet/4.1/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.1/config_important_settings.markdown
+++ b/source/puppet/4.1/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short List of Important Settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.1/config_print.markdown
+++ b/source/puppet/4.1/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking Values of Settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.1/config_set.markdown
+++ b/source/puppet/4.1/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing Settings on the Command Line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.1/configuration.md
+++ b/source/puppet/4.1/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -138,7 +138,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -278,15 +278,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](http://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](http://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](http://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](http://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -389,7 +389,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### configprint
@@ -636,7 +636,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/environments
 
@@ -1031,7 +1031,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: 
 
@@ -1127,7 +1127,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### name

--- a/source/puppet/4.1/dirs_codedir.markdown
+++ b/source/puppet/4.1/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and Data Directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 Puppet's `codedir` is the main directory for Puppet code and data. It contains environments (which contain your manifests and modules), a global modules directory for all environments, and your Hiera data.

--- a/source/puppet/4.1/dirs_confdir.markdown
+++ b/source/puppet/4.1/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config Directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [listen]: ./configuration.html#listen

--- a/source/puppet/4.1/dirs_manifest.markdown
+++ b/source/puppet/4.1/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Main Manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.1/dirs_modulepath.markdown
+++ b/source/puppet/4.1/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.1/dirs_ssldir.markdown
+++ b/source/puppet/4.1/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.1/dirs_vardir.markdown
+++ b/source/puppet/4.1/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Cache Directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.1/environments.markdown
+++ b/source/puppet/4.1/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.1/environments_https.markdown
+++ b/source/puppet/4.1/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS Interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.1/environments_limitations.markdown
+++ b/source/puppet/4.1/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of Environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.1/environments_suggestions.markdown
+++ b/source/puppet/4.1/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.1/experiments_cfacter.markdown
+++ b/source/puppet/4.1/experiments_cfacter.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Native Facter"
-canonical: "/puppet/latest/reference/experiments_cfacter.html"
+canonical: "/puppet/latest/experiments_cfacter.html"
 ---
 
 [users_group]: https://groups.google.com/forum/#!forum/puppet-users

--- a/source/puppet/4.1/experiments_msgpack.markdown
+++ b/source/puppet/4.1/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Msgpack Support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 Background on Msgpack

--- a/source/puppet/4.1/experiments_overview.markdown
+++ b/source/puppet/4.1/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.1/format_report.markdown
+++ b/source/puppet/4.1/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.1/function.md
+++ b/source/puppet/4.1/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 

--- a/source/puppet/4.1/index.md
+++ b/source/puppet/4.1/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.1 Reference Manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 
@@ -34,7 +34,7 @@ This manual is split into several sections, which can be reached from the left s
 
 * The [Release Notes](./release_notes.html) have information about what's new and different in Puppet 4.1, and track changes from patch releases.
 * If you're an experienced Puppet user, you'll want to take a look at the [Where Did Everything Go?](./whered_it_go.html) page.
-* The [Resource Type Reference](/puppet/3.8/reference/type.html) is the page where experienced Puppet users spend most of their time.
+* The [Resource Type Reference](/puppet/3.8/type.html) is the page where experienced Puppet users spend most of their time.
 * Puppet uses its own configuration language, which is documented in the language section of this reference. Two good starting points are:
     * The [Language Summary](./lang_summary.html), which gives an overview and some context.
     * The [Visual Index](./lang_visual_index.html), which can help you find docs for syntax when you know what it looks like but don't know what it's called.

--- a/source/puppet/4.1/indirection.md
+++ b/source/puppet/4.1/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.1/install_linux.markdown
+++ b/source/puppet/4.1/install_linux.markdown
@@ -3,15 +3,15 @@ layout: default
 title: "Installing Puppet: Linux"
 ---
 
-[master_settings]: /puppet/latest/reference/config_important_settings.html#settings-for-puppet-master-servers
-[agent_settings]: /puppet/latest/reference/config_important_settings.html#settings-for-agents-all-nodes
+[master_settings]: /puppet/latest/config_important_settings.html#settings-for-puppet-master-servers
+[agent_settings]: /puppet/latest/config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: /puppetserver/latest/install_from_packages.html#memory-allocation
 [puppetserver_confd]: /puppetserver/latest/configuration.html
-[modules]: /puppet/latest/reference/modules_fundamentals.html
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
-[environments]: /puppet/latest/reference/environments.html
+[modules]: /puppet/latest/modules_fundamentals.html
+[main manifest]: /puppet/latest/dirs_manifest.html
+[environments]: /puppet/latest/environments.html
 
 ## Read the Pre-Install Tasks
 

--- a/source/puppet/4.1/install_pre.markdown
+++ b/source/puppet/4.1/install_pre.markdown
@@ -4,9 +4,9 @@ title: "Installing Puppet: Pre-Install Tasks"
 ---
 
 [peinstall]: /pe/latest/install_basic.html
-[sysreqs]: /puppet/4.1/reference/system_requirements.html
-[ruby]: /puppet/4.1/reference/system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[sysreqs]: /puppet/4.1/system_requirements.html
+[ruby]: /puppet/4.1/system_requirements.html#basic-requirements
+[architecture]: /puppet/latest/architecture.html
 
 > **Note:** This document covers open source releases of Puppet. [See here for instructions on installing Puppet Enterprise.][peinstall]
 

--- a/source/puppet/4.1/install_windows.markdown
+++ b/source/puppet/4.1/install_windows.markdown
@@ -94,10 +94,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 

--- a/source/puppet/4.1/lang_classes.markdown
+++ b/source/puppet/4.1/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.1/lang_collectors.markdown
+++ b/source/puppet/4.1/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.1/lang_comments.markdown
+++ b/source/puppet/4.1/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.1/lang_conditional.markdown
+++ b/source/puppet/4.1/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional Statements and Expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.1/lang_containment.markdown
+++ b/source/puppet/4.1/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of Resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.1/lang_data.md
+++ b/source/puppet/4.1/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About Values and Data Types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.1/lang_data_abstract.md
+++ b/source/puppet/4.1/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Abstract Data Types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.1/lang_data_array.md
+++ b/source/puppet/4.1/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.1/lang_data_boolean.md
+++ b/source/puppet/4.1/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.1/lang_data_default.md
+++ b/source/puppet/4.1/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.1/lang_data_hash.md
+++ b/source/puppet/4.1/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.1/lang_data_number.md
+++ b/source/puppet/4.1/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.1/lang_data_regexp.md
+++ b/source/puppet/4.1/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Regular Expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.1/lang_data_resource_reference.md
+++ b/source/puppet/4.1/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource and Class References"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.1/lang_data_resource_type.md
+++ b/source/puppet/4.1/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource Types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.1/lang_data_string.md
+++ b/source/puppet/4.1/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.1/lang_data_type.md
+++ b/source/puppet/4.1/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Data Type Syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.1/lang_data_undef.md
+++ b/source/puppet/4.1/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.1/lang_defaults.markdown
+++ b/source/puppet/4.1/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Default Statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.1/lang_defined_types.markdown
+++ b/source/puppet/4.1/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined Resource Types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.1/lang_exported.markdown
+++ b/source/puppet/4.1/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported Resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.1/lang_expressions.markdown
+++ b/source/puppet/4.1/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and Operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html
@@ -469,7 +469,7 @@ Assignment Operators
 
 ### `=` (assignment)
 
-The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/reference/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
+The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
 
 Note that variables can only be set once, after which any attempt to set the variable to a new value will cause an error.
 

--- a/source/puppet/4.1/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.1/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and Built-in Variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.1/lang_functions.markdown
+++ b/source/puppet/4.1/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.1/lang_iteration.md
+++ b/source/puppet/4.1/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and Loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.1/lang_lambdas.md
+++ b/source/puppet/4.1/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (Code Blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.1/lang_namespaces.markdown
+++ b/source/puppet/4.1/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and Autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.1/lang_node_definitions.markdown
+++ b/source/puppet/4.1/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node Definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: /hiera/latest

--- a/source/puppet/4.1/lang_relationships.markdown
+++ b/source/puppet/4.1/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and Ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.1/lang_reserved.markdown
+++ b/source/puppet/4.1/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved Words and Acceptable Names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.1/lang_resources.markdown
+++ b/source/puppet/4.1/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.1/lang_resources_advanced.md
+++ b/source/puppet/4.1/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (Advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.1/lang_run_stages.markdown
+++ b/source/puppet/4.1/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run Stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.1/lang_scope.markdown
+++ b/source/puppet/4.1/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.1/lang_summary.markdown
+++ b/source/puppet/4.1/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.1/lang_tags.markdown
+++ b/source/puppet/4.1/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.1/lang_updating_manifests.markdown
+++ b/source/puppet/4.1/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-Check to Make Sure It's Safe Before Purging `cron` Resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.1/lang_variables.markdown
+++ b/source/puppet/4.1/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.1/lang_virtual.markdown
+++ b/source/puppet/4.1/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual Resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.1/lang_visual_index.markdown
+++ b/source/puppet/4.1/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual Index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.1/lang_windows_file_paths.markdown
+++ b/source/puppet/4.1/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling File Paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: /guides/templating.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using Backslashes in Double-Quoted Strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.1/metaparameter.md
+++ b/source/puppet/4.1/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### loglevel
 
@@ -144,7 +144,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -157,12 +157,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -171,7 +171,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -223,7 +223,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#resource-references).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_datatypes.html#resource-references).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -236,7 +236,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 

--- a/source/puppet/4.1/modules_documentation.markdown
+++ b/source/puppet/4.1/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting Modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.1/modules_fundamentals.markdown
+++ b/source/puppet/4.1/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.1/modules_installing.markdown
+++ b/source/puppet/4.1/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppetlabs.com
@@ -221,7 +221,7 @@ By default, the tool won't uninstall a module that other modules depend on, or w
 
 #### Upgrade/Uninstall
 
-The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
 You might see an error similar to the following when upgrading or uninstalling:
 

--- a/source/puppet/4.1/modules_publishing.markdown
+++ b/source/puppet/4.1/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing Modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 
@@ -78,7 +78,7 @@ If you already have a Puppet module with the [correct directory layout][fundamen
 
 Alternately, you can use the `puppet module generate` action to generate a template layout. Generating a module will provide you with a sample README and a copy of the `spec_helper` tool for writing [rspec-puppet][rspec] tests. It will also launch a series of questions that will create your metadata.json file.
 
-Follow the directions to [generate a new module](https://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#writing-modules)
+Follow the directions to [generate a new module](https://docs.puppetlabs.com/puppet/latest/modules_fundamentals.html#writing-modules)
 
 ### Set files to be ignored
 

--- a/source/puppet/4.1/puppet_collections.md
+++ b/source/puppet/4.1/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and Packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.1/report.md
+++ b/source/puppet/4.1/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 

--- a/source/puppet/4.1/resources_file_windows.markdown
+++ b/source/puppet/4.1/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource Tips and Examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.1/resources_service.markdown
+++ b/source/puppet/4.1/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource Tips and Examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.1/resources_user_group_windows.markdown
+++ b/source/puppet/4.1/resources_user_group_windows.markdown
@@ -5,10 +5,10 @@ title: "Resource Tips and Examples: User and Group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
 [relationships]: /puppet/4.1.latest/reference/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.

--- a/source/puppet/4.1/services_agent_unix.markdown
+++ b/source/puppet/4.1/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on *nix Systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.1/services_agent_windows.markdown
+++ b/source/puppet/4.1/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on Windows Systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.1/services_apply.markdown
+++ b/source/puppet/4.1/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.1/services_master_rack.markdown
+++ b/source/puppet/4.1/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The Rack Puppet Master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.1/services_master_webrick.markdown
+++ b/source/puppet/4.1/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The WEBrick Puppet Master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.1/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.1/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: CSR Attributes and Certificate Extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.1/ssl_autosign.markdown
+++ b/source/puppet/4.1/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: Autosigning Certificate Requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.1/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.1/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating All Certificates in a Puppet Deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.1/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.1/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/Master HTTPS Communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.1/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.1/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog Compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.1/system_requirements.markdown
+++ b/source/puppet/4.1/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.1 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet 4.1, first [view pre-install tasks](/pre_install.html).

--- a/source/puppet/4.1/type.md
+++ b/source/puppet/4.1/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: c4a6a76fd219bffd689476413985ed13f40ef1dd
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc: columns
 ---
 
@@ -22,7 +22,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.

--- a/source/puppet/4.1/upgrade_agent.markdown
+++ b/source/puppet/4.1/upgrade_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/latest/reference/upgrade_agent.html"
+canonical: "/puppet/latest/upgrade_agent.html"
 ---
 
 This guide will help you update your Puppet 3.x agents to Puppet 4.x.
@@ -14,7 +14,7 @@ If you have currently running Puppet agents that you want to update to Puppet 4,
 * Note the current `ssldir` location by running (as root) `puppet agent --configprint ssldir`; you'll need this information to avoid re-issuing certificates.
 * Disable the previous Puppet Labs `products` and `devel` repositories.
 * Using your package manager, install the `puppet-agent` package for your operating system.
-* Modify the new, Puppet 4-compatible `/etc/puppetlabs/puppet/puppet.conf` file to include any local customizations from the old `/etc/puppet/puppet.conf` configuration file. You will need to set the `server` setting (and `ca_server`, if you've set up a separate Puppet 4 CA) to point at the hostname of your new Puppet 4 master. Be sure to check the Puppet 4.0 release notes for [deprecated and changed settings](/puppet/4.0/reference/release_notes.html#break-changed-defaults-for-settings) that should not be copied over. Notably, if you previously set `stringify_facts=false`, this is no longer necessary.  
+* Modify the new, Puppet 4-compatible `/etc/puppetlabs/puppet/puppet.conf` file to include any local customizations from the old `/etc/puppet/puppet.conf` configuration file. You will need to set the `server` setting (and `ca_server`, if you've set up a separate Puppet 4 CA) to point at the hostname of your new Puppet 4 master. Be sure to check the Puppet 4.0 release notes for [deprecated and changed settings](/puppet/4.0/release_notes.html#break-changed-defaults-for-settings) that should not be copied over. Notably, if you previously set `stringify_facts=false`, this is no longer necessary.  
 * Copy your SSL certificate tree from its previous location (from `puppet agent --configprint ssldir` above) to its new path (`/etc/puppetlabs/puppet/ssl`), making sure to preserve permissions and ownership. For example:
 
     `cp -rp /var/lib/puppet/ssl /etc/puppetlabs/puppet/ssl`
@@ -29,4 +29,4 @@ If you have currently running Puppet agents that you want to update to Puppet 4,
 
 ## Windows Hosts
 
-The filesystem paths for configuration and certificates did not change from Puppet 3.x. Windows upgraders need to check individual settings that [may be deprecated or whose defaults have changed](/puppet/4.0/reference/release_notes.html#break-changed-defaults-for-settings).
+The filesystem paths for configuration and certificates did not change from Puppet 3.x. Windows upgraders need to check individual settings that [may be deprecated or whose defaults have changed](/puppet/4.0/release_notes.html#break-changed-defaults-for-settings).

--- a/source/puppet/4.1/upgrade_server.markdown
+++ b/source/puppet/4.1/upgrade_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Server Upgrades"
-canonical: "/puppet/latest/reference/upgrade_server.html"
+canonical: "/puppet/latest/upgrade_server.html"
 ---
 
 This guide is for sites that have all master-related functions (Puppet master, certificate authority, file server) on one system.
@@ -62,7 +62,7 @@ If you're not using r10k, or not using environments at all, put your `site.pp` a
 
 The default settings written into this version of puppet.conf should work for most people. If your old puppet.conf had settings related to environments (especially static "config file environments" that use the `[environmentname]` stanzas in puppet.conf, these will either become global (such as adjusting `basemodulepath` [as described here](./environments_configuring.html#basemodulepath]) or move into an environment-specific config file, [documented in the environment.conf section](./environments_creating.html#the-environmentconf-file).
 
-Read through the [Puppet 4 Release Notes](/puppet/4.0/reference/release_notes.html) for more detail on other settings that were removed or whose defaults may have changed.
+Read through the [Puppet 4 Release Notes](/puppet/4.0/release_notes.html) for more detail on other settings that were removed or whose defaults may have changed.
 
 ## Start Running the Puppet Server
 

--- a/source/puppet/4.1/whered_it_go.markdown
+++ b/source/puppet/4.1/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Puppet 4.0 Preview: Where Did Everything Go?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.10/about_agent.md
+++ b/source/puppet/4.10/about_agent.md
@@ -33,7 +33,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages.
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent).
 
 ### How version numbers work
 

--- a/source/puppet/4.10/config_file_csr_attributes.markdown
+++ b/source/puppet/4.10/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.10/config_file_environment.markdown
+++ b/source/puppet/4.10/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.10/configuration.md
+++ b/source/puppet/4.10/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -608,7 +608,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -688,7 +688,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1096,7 +1096,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1192,7 +1192,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1283,7 +1283,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1464,7 +1464,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.10/deprecated_language.markdown
+++ b/source/puppet/4.10/deprecated_language.markdown
@@ -39,7 +39,7 @@ To update, enable `strict_variables` on your Puppet master, run as normal for a 
 
 ## Automatic symbolic links for `ensure` values in `file` resources
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.10/function.md
+++ b/source/puppet/4.10/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -366,7 +366,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -457,7 +457,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -480,12 +480,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -538,7 +538,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -721,7 +721,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -741,7 +741,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/4.10/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/4.10/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -805,7 +805,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -824,7 +824,7 @@ $allusers = hiera_array('users') | $key | { "Key '${key}' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/4.10/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/4.10/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -897,7 +897,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -917,7 +917,7 @@ $allusers = hiera_hash('users') | $key | { "Key '${key}' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/4.10/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/4.10/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -994,7 +994,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1011,7 +1011,7 @@ hiera_include('classes') | $key | {"Key '${key}' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/4.10/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/4.10/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1079,12 +1079,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1102,7 +1102,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1118,14 +1118,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1133,7 +1133,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1209,7 +1209,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1308,7 +1308,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2411,7 +2411,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2650,7 +2650,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2842,7 +2842,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3136,7 +3136,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3285,9 +3285,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.10/function_strings_prefer_v3.md
+++ b/source/puppet/4.10/function_strings_prefer_v3.md
@@ -40,9 +40,9 @@ Log a message on the server at level alert.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -87,7 +87,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -384,7 +384,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each()`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -475,7 +475,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -501,12 +501,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -573,7 +573,7 @@ found, skipping any files that don't exist.
 * `filter()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -760,7 +760,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -845,7 +845,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -938,7 +938,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -1036,7 +1036,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1143,12 +1143,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1166,7 +1166,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1182,7 +1182,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 ## `inline_template`
 
@@ -1190,7 +1190,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1208,7 +1208,7 @@ how to use this function.
 * `lest()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1285,7 +1285,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1385,7 +1385,7 @@ remove values by prefixing them with `--`:
 * `map()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2495,7 +2495,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2737,7 +2737,7 @@ Note that the returned value is ignored if used in a class or user defined type.
     * Return type(s): `Any`. 
 
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2938,7 +2938,7 @@ The first parameter is format string describing how the rest of the parameters s
     * Return type(s): `Any`. 
 
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3236,7 +3236,7 @@ return their outputs concatenated into a single string.
 * `then()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3418,9 +3418,9 @@ Log a message on the server at level notice.
 * `with()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.10/function_strings_prefer_v4.md
+++ b/source/puppet/4.10/function_strings_prefer_v4.md
@@ -42,9 +42,9 @@ Log a message on the server at level alert.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -85,7 +85,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 ## `binary_file`
 
@@ -301,7 +301,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -382,7 +382,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `emerg`
@@ -406,12 +406,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -482,7 +482,7 @@ found, skipping any files that don't exist.
 * `filter(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -645,7 +645,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -716,7 +716,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -796,7 +796,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -885,7 +885,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -951,12 +951,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -974,7 +974,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -995,7 +995,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1059,7 +1059,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1144,7 +1144,7 @@ but can adjust the merge with additional options. The available options are:
 * `map(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1284,7 +1284,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce(Iterable $enumerable, Any $memo, Callable[2,2] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1662,9 +1662,9 @@ Log a message on the server at level notice.
 * `with(Any *$arg, Callable &$block)`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.10/hiera_use_hiera_functions.md
+++ b/source/puppet/4.10/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/4.10/install_linux.markdown
+++ b/source/puppet/4.10/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.10/install_pre.markdown
+++ b/source/puppet/4.10/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.10/install_windows.markdown
+++ b/source/puppet/4.10/install_windows.markdown
@@ -99,10 +99,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 * `INSTALLDIR`
 

--- a/source/puppet/4.10/lang_resources.markdown
+++ b/source/puppet/4.10/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.10/lang_template_epp.md
+++ b/source/puppet/4.10/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.10/lang_updating_manifests.markdown
+++ b/source/puppet/4.10/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.10/lang_windows_file_paths.markdown
+++ b/source/puppet/4.10/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.10/metaparameter.md
+++ b/source/puppet/4.10/metaparameter.md
@@ -90,7 +90,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -99,7 +99,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -182,7 +182,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -193,7 +193,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -206,12 +206,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -220,7 +220,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -228,7 +228,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -254,7 +254,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -272,7 +272,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -285,7 +285,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -304,7 +304,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.10/passenger.markdown
+++ b/source/puppet/4.10/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.10/release_notes_agent.md
+++ b/source/puppet/4.10/release_notes_agent.md
@@ -36,7 +36,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html), and the [Puppet 4.10 release notes](./release_notes.html).
 

--- a/source/puppet/4.10/report.md
+++ b/source/puppet/4.10/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.10/reporting_about.md
+++ b/source/puppet/4.10/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.10/resources_file_windows.markdown
+++ b/source/puppet/4.10/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.10/resources_service.markdown
+++ b/source/puppet/4.10/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.10/resources_user_group_windows.markdown
+++ b/source/puppet/4.10/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.10/style_guide.markdown
+++ b/source/puppet/4.10/style_guide.markdown
@@ -243,7 +243,7 @@ Every module must have metadata defined in the metadata.json file.  Your metadat
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 ### 8.1 Dependencies
 
@@ -814,7 +814,7 @@ You should help indicate to the user which classes are which by making sure all 
 
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -945,7 +945,7 @@ class my_module (
 
 Exported resources should be opt-in rather than opt-out. Your module should not be written to use exported resources to function by default unless it is expressly required. When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/4.10/type.md
+++ b/source/puppet/4.10/type.md
@@ -1206,7 +1206,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1300,8 +1300,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1863,7 +1863,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8490,7 +8490,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10073,7 +10073,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.10/type_strings.md
+++ b/source/puppet/4.10/type_strings.md
@@ -1360,7 +1360,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -4382,7 +4382,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -5955,7 +5955,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.10/upgrade_major_agent.markdown
+++ b/source/puppet/4.10/upgrade_major_agent.markdown
@@ -78,7 +78,7 @@ Find your operating system in the sidebar navigation to the left and follow the 
    Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
    * It includes any necessary modifications.
-   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
    * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 4. Start service or update cron job.

--- a/source/puppet/4.10/upgrade_major_post.md
+++ b/source/puppet/4.10/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.10/upgrade_major_pre.md
+++ b/source/puppet/4.10/upgrade_major_pre.md
@@ -13,7 +13,7 @@ Upgrading from Puppet 3 to Puppet 4 is a major upgrade with lots of configuratio
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 1. If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-2. If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+2. If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
 
   **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
 
@@ -26,7 +26,7 @@ Upgrading from Puppet 3 to Puppet 4 is a major upgrade with lots of configuratio
 
 ## Checking for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 deprecated several features which are either removed from Puppet 4 or require major workflow changes.
 
@@ -37,7 +37,7 @@ Puppet 3.8 deprecated several features which are either removed from Puppet 4 or
 
 Puppet 4 always uses proper data types for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the next section. Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the next section. Otherwise:
 
 1. Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -50,7 +50,7 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 Puppet 4 organizes all code into directory environments, which are the only way to organize code now that config file environments are removed.
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 1. If you're using config file environments, [switch to directory environments.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enabling the future parser and fixing broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -84,7 +84,7 @@ Run Puppet for several runs with the future parser enabled to ensure your change
 ## Finishing upgrade prep
 
 1. Read the release notes for each Puppet 4 feature release version and prepare accordingly.
-   Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). 
+   Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). 
 
 ## You're ready!
 

--- a/source/puppet/4.10/upgrade_major_server.markdown
+++ b/source/puppet/4.10/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -66,7 +66,7 @@ Repeat these steps for each Puppet Server until you're running a pure Puppet 4 a
 
    The [`puppet.conf`][puppet.conf] file moved to `/etc/puppetlabs/puppet/puppet.conf`, a lot of defaults were changed, and many settings have been removed. Compare the new `puppet.conf` to the old one, which by default lives at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-   If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+   If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 4. Reconcile `auth.conf`
 
@@ -167,13 +167,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Moving code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, because [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, because [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or another code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.10/whered_it_go.markdown
+++ b/source/puppet/4.10/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.2/about_agent.md
+++ b/source/puppet/4.2/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What Is It, and What's In It?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: /facter/latest/
@@ -25,7 +25,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's Up With the Version Numbers?
 

--- a/source/puppet/4.2/config_about_settings.markdown
+++ b/source/puppet/4.2/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is Configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.2/config_file_auth.markdown
+++ b/source/puppet/4.2/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: auth.conf"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.2/config_file_autosign.markdown
+++ b/source/puppet/4.2/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.2/config_file_csr_attributes.markdown
+++ b/source/puppet/4.2/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config Files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.2/config_file_device.markdown
+++ b/source/puppet/4.2/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.2/config_file_environment.markdown
+++ b/source/puppet/4.2/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config Files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.2/config_file_fileserver.markdown
+++ b/source/puppet/4.2/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.2/config_file_hiera.markdown
+++ b/source/puppet/4.2/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: /hiera/latest/

--- a/source/puppet/4.2/config_file_main.markdown
+++ b/source/puppet/4.2/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: The Main Config File (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.2/config_file_oid_map.md
+++ b/source/puppet/4.2/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.2/config_file_puppetdb.markdown
+++ b/source/puppet/4.2/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html

--- a/source/puppet/4.2/config_file_routes.markdown
+++ b/source/puppet/4.2/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.2/config_important_settings.markdown
+++ b/source/puppet/4.2/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short List of Important Settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.2/config_print.markdown
+++ b/source/puppet/4.2/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking Values of Settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.2/config_set.markdown
+++ b/source/puppet/4.2/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing Settings on the Command Line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.2/configuration.md
+++ b/source/puppet/4.2/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -138,7 +138,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -278,15 +278,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](http://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](http://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](http://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](http://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -390,7 +390,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### configprint
@@ -637,7 +637,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/environments
 
@@ -1032,7 +1032,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: 
 
@@ -1128,7 +1128,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### name

--- a/source/puppet/4.2/dirs_codedir.markdown
+++ b/source/puppet/4.2/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and Data Directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.2/dirs_confdir.markdown
+++ b/source/puppet/4.2/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config Directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: /puppetserver/2.1/configuration.html#puppetserverconf

--- a/source/puppet/4.2/dirs_manifest.markdown
+++ b/source/puppet/4.2/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Main Manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.2/dirs_modulepath.markdown
+++ b/source/puppet/4.2/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.2/dirs_ssldir.markdown
+++ b/source/puppet/4.2/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.2/dirs_vardir.markdown
+++ b/source/puppet/4.2/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Cache Directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.2/environments.markdown
+++ b/source/puppet/4.2/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.2/environments_https.markdown
+++ b/source/puppet/4.2/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS Interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.2/environments_limitations.markdown
+++ b/source/puppet/4.2/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of Environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.2/environments_suggestions.markdown
+++ b/source/puppet/4.2/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.2/experiments_cfacter.markdown
+++ b/source/puppet/4.2/experiments_cfacter.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Native Facter"
-canonical: "/puppet/latest/reference/experiments_cfacter.html"
+canonical: "/puppet/latest/experiments_cfacter.html"
 ---
 
 

--- a/source/puppet/4.2/experiments_msgpack.markdown
+++ b/source/puppet/4.2/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Msgpack Support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 Background on Msgpack

--- a/source/puppet/4.2/experiments_overview.markdown
+++ b/source/puppet/4.2/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.2/format_report.markdown
+++ b/source/puppet/4.2/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.2/function.md
+++ b/source/puppet/4.2/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -272,12 +272,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -586,12 +586,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -625,14 +625,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](http://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](http://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 

--- a/source/puppet/4.2/index.md
+++ b/source/puppet/4.2/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.2 Reference Manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.2/indirection.md
+++ b/source/puppet/4.2/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.2/install_linux.markdown
+++ b/source/puppet/4.2/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: /puppetserver/2.1/install_from_packages.html#memory-allocation
 [puppetserver_confd]: /puppetserver/2.1/configuration.html
 [server_install]: /puppetserver/2.1/install_from_packages.html

--- a/source/puppet/4.2/install_osx.md
+++ b/source/puppet/4.2/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Mac OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: /puppetserver/2.1/install_from_packages.html

--- a/source/puppet/4.2/install_pre.markdown
+++ b/source/puppet/4.2/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-Install Tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: /pe/latest/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: /puppetdb/latest
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.2/install_windows.markdown
+++ b/source/puppet/4.2/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: http://downloads.puppetlabs.com/windows
@@ -92,10 +92,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 

--- a/source/puppet/4.2/lang_classes.markdown
+++ b/source/puppet/4.2/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.2/lang_collectors.markdown
+++ b/source/puppet/4.2/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.2/lang_comments.markdown
+++ b/source/puppet/4.2/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.2/lang_conditional.markdown
+++ b/source/puppet/4.2/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional Statements and Expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.2/lang_containment.markdown
+++ b/source/puppet/4.2/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of Resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.2/lang_data.md
+++ b/source/puppet/4.2/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About Values and Data Types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.2/lang_data_abstract.md
+++ b/source/puppet/4.2/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Abstract Data Types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.2/lang_data_array.md
+++ b/source/puppet/4.2/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.2/lang_data_boolean.md
+++ b/source/puppet/4.2/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.2/lang_data_default.md
+++ b/source/puppet/4.2/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.2/lang_data_hash.md
+++ b/source/puppet/4.2/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.2/lang_data_number.md
+++ b/source/puppet/4.2/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.2/lang_data_regexp.md
+++ b/source/puppet/4.2/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Regular Expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.2/lang_data_resource_reference.md
+++ b/source/puppet/4.2/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource and Class References"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.2/lang_data_resource_type.md
+++ b/source/puppet/4.2/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource Types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.2/lang_data_string.md
+++ b/source/puppet/4.2/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.2/lang_data_type.md
+++ b/source/puppet/4.2/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Data Type Syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.2/lang_data_undef.md
+++ b/source/puppet/4.2/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.2/lang_defaults.markdown
+++ b/source/puppet/4.2/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Default Statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.2/lang_defined_types.markdown
+++ b/source/puppet/4.2/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined Resource Types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.2/lang_exported.markdown
+++ b/source/puppet/4.2/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported Resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.2/lang_expressions.markdown
+++ b/source/puppet/4.2/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and Operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html
@@ -481,7 +481,7 @@ Assignment Operators
 
 ### `=` (assignment)
 
-The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/reference/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
+The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
 
 Note that variables can only be set once, after which any attempt to set the variable to a new value will cause an error.
 

--- a/source/puppet/4.2/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.2/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and Built-in Variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.2/lang_functions.markdown
+++ b/source/puppet/4.2/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Function Calls"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.2/lang_iteration.md
+++ b/source/puppet/4.2/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and Loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.2/lang_lambdas.md
+++ b/source/puppet/4.2/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (Code Blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.2/lang_namespaces.markdown
+++ b/source/puppet/4.2/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and Autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.2/lang_node_definitions.markdown
+++ b/source/puppet/4.2/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node Definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: /hiera/latest

--- a/source/puppet/4.2/lang_relationships.markdown
+++ b/source/puppet/4.2/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and Ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.2/lang_reserved.markdown
+++ b/source/puppet/4.2/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved Words and Acceptable Names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.2/lang_resources.markdown
+++ b/source/puppet/4.2/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.2/lang_resources_advanced.md
+++ b/source/puppet/4.2/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (Advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.2/lang_run_stages.markdown
+++ b/source/puppet/4.2/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run Stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.2/lang_scope.markdown
+++ b/source/puppet/4.2/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.2/lang_summary.markdown
+++ b/source/puppet/4.2/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.2/lang_tags.markdown
+++ b/source/puppet/4.2/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.2/lang_template.md
+++ b/source/puppet/4.2/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using Templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.2/lang_template_epp.md
+++ b/source/puppet/4.2/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html

--- a/source/puppet/4.2/lang_template_erb.md
+++ b/source/puppet/4.2/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.2/lang_updating_manifests.markdown
+++ b/source/puppet/4.2/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-Check to Make Sure It's Safe Before Purging `cron` Resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.2/lang_variables.markdown
+++ b/source/puppet/4.2/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.2/lang_virtual.markdown
+++ b/source/puppet/4.2/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual Resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.2/lang_visual_index.markdown
+++ b/source/puppet/4.2/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual Index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.2/lang_windows_file_paths.markdown
+++ b/source/puppet/4.2/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling File Paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: /guides/templating.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using Backslashes in Double-Quoted Strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.2/metaparameter.md
+++ b/source/puppet/4.2/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### loglevel
 
@@ -144,7 +144,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -157,12 +157,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -171,7 +171,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -223,7 +223,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -236,7 +236,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 

--- a/source/puppet/4.2/modules_documentation.markdown
+++ b/source/puppet/4.2/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting Modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.2/modules_fundamentals.markdown
+++ b/source/puppet/4.2/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.2/modules_installing.markdown
+++ b/source/puppet/4.2/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppetlabs.com
@@ -221,7 +221,7 @@ By default, the tool won't uninstall a module that other modules depend on, or w
 
 #### Upgrade/Uninstall
 
-The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
 You might see an error similar to the following when upgrading or uninstalling:
 

--- a/source/puppet/4.2/modules_publishing.markdown
+++ b/source/puppet/4.2/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing Modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 
@@ -78,7 +78,7 @@ If you already have a Puppet module with the [correct directory layout][fundamen
 
 Alternately, you can use the `puppet module generate` action to generate a template layout. Generating a module will provide you with a sample README and a copy of the `spec_helper` tool for writing [rspec-puppet][rspec] tests. It will also launch a series of questions that will create your metadata.json file.
 
-Follow the directions to [generate a new module](https://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#writing-modules)
+Follow the directions to [generate a new module](https://docs.puppetlabs.com/puppet/latest/modules_fundamentals.html#writing-modules)
 
 ### Set files to be ignored
 

--- a/source/puppet/4.2/puppet_collections.md
+++ b/source/puppet/4.2/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and Packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.2/quick_start.markdown
+++ b/source/puppet/4.2/quick_start.markdown
@@ -29,7 +29,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, World!
- Modules contain [classes](./puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](./puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a Module
  Next, learn how to install a Puppet Labs module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html). 

--- a/source/puppet/4.2/quick_start_adding_classes_nix.markdown
+++ b/source/puppet/4.2/quick_start_adding_classes_nix.markdown
@@ -41,7 +41,7 @@ Every module contains one or more **classes**. [Classes](../lang_classes.html) a
    
 ## Editing Class Parameters in the Main Manifest
 
-You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#defining-classes) of a class in `site.pp` as well. Parameters allow a class to request external data. If a class needs to configure itself with data other than [Puppet facts](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html), provide that data to the class via a parameter.
+You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/lang_classes.html#defining-classes) of a class in `site.pp` as well. Parameters allow a class to request external data. If a class needs to configure itself with data other than [Puppet facts](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html), provide that data to the class via a parameter.
 
 
 **To edit the parameters of the** `apache` **class**:
@@ -54,7 +54,7 @@ You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/referenc
     	  docroot => '/var/www'
 		}
 		
-	>**Note**: You must remove `include apache` because Puppet will only allow you to [declare a class once](https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#declaring-classes).
+	>**Note**: You must remove `include apache` because Puppet will only allow you to [declare a class once](https://docs.puppetlabs.com/puppet/latest/lang_classes.html#declaring-classes).
 
 > That's it! You have set the Apache web server's root directory to `/var/www` instead of its default `/var/www/html`. If you refresh `http://myagentnodeIP:80/` in your web browser, it shows the list of files in `/var/www`. If you click `html`, the browser will again show the contents of `/var/www/html/index.html`.
 >

--- a/source/puppet/4.2/quick_start_firewall.markdown
+++ b/source/puppet/4.2/quick_start_firewall.markdown
@@ -135,7 +135,7 @@ Modules are directory trees. For this task, you'll create the following files:
 		    purge => true,
 		  }
   
-4. Add the following Puppet code to your `site.pp` file. These defaults will ensure that the `pre` and `post` classes are [run in the correct order](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html) to avoid locking you out of your box during the first Puppet run, and declaring `my_fw::pre` and `my_fw::post` satisfies the specified dependencies.
+4. Add the following Puppet code to your `site.pp` file. These defaults will ensure that the `pre` and `post` classes are [run in the correct order](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html) to avoid locking you out of your box during the first Puppet run, and declaring `my_fw::pre` and `my_fw::post` satisfies the specified dependencies.
 
 		  Firewall {
 		    before  => Class['my_fw::post'],

--- a/source/puppet/4.2/quick_start_helloworld.markdown
+++ b/source/puppet/4.2/quick_start_helloworld.markdown
@@ -32,7 +32,7 @@ Modules are directory trees. For this task, you'll create the following structur
 
 Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](./lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `helloworld`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>`, or in this case, `helloworld::motd`.
 
-* For more on how modules work, see [Module Fundamentals](/puppet/3.8/reference/modules_fundamentals.html) in the Puppet documentation.
+* For more on how modules work, see [Module Fundamentals](/puppet/3.8/modules_fundamentals.html) in the Puppet documentation.
 * For more on best practices, methods, and approaches to writing modules, see the [Beginners Guide to Modules](/guides/module_guides/bgtm.html).
 * For a more detailed guided tour, also see [the module chapters of Learning Puppet](/learning/modules1.html).
 

--- a/source/puppet/4.2/quick_start_user_group.markdown
+++ b/source/puppet/4.2/quick_start_user_group.markdown
@@ -91,7 +91,7 @@ Puppet uses some defaults for unspecified user and group attributes, so all you'
 13. From the command line on your Puppet agent, use `puppet agent -t` to trigger a Puppet run.
 
 > Success! You have created a user, `jargyle`, and added jargyle to the group with `groups => web`. 
-> For more information on users and groups, check out the documentation for Puppet resource types regarding [users](https://docs.puppetlabs.com/puppet/latest/reference/type.html#user) and [groups](https://docs.puppetlabs.com/puppet/latest/reference/type.html#group).
+> For more information on users and groups, check out the documentation for Puppet resource types regarding [users](https://docs.puppetlabs.com/puppet/latest/type.html#user) and [groups](https://docs.puppetlabs.com/puppet/latest/type.html#group).
 > With users and groups, you can assign different permissions for managing Puppet. 
 
 ---------

--- a/source/puppet/4.2/release_notes.markdown
+++ b/source/puppet/4.2/release_notes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Puppet 4.2 Release Notes"
 ---
 
-[puppet-agent]: /puppet/latest/reference/about_agent.html
+[puppet-agent]: /puppet/latest/about_agent.html
 
 This page lists the changes in Puppet 4.2 and its patch releases.
 
@@ -15,9 +15,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If You're Upgrading from Puppet 3.x
 
-Make sure you also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+Make sure you also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.1 release notes](/puppet/4.1/reference/release_notes.html).
+Also of interest: the [Puppet 4.1 release notes](/puppet/4.1/release_notes.html).
 
 ## Puppet 4.2.3
 

--- a/source/puppet/4.2/release_notes_agent.md
+++ b/source/puppet/4.2/release_notes_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Agent 1.2.x Release Notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
 [Puppet 4.2.0]: ./release_notes.html#puppet-420
@@ -30,7 +30,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If You're Upgrading from Puppet 3.x
 
-The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.2 release notes](./release_notes.html).
 

--- a/source/puppet/4.2/report.md
+++ b/source/puppet/4.2/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 

--- a/source/puppet/4.2/reporting_about.md
+++ b/source/puppet/4.2/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About Reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools](/pe/latest/CM_reports.html) in the console. [PuppetDB](/puppetdb/latest/), with [its report processor enabled](/puppetdb/latest/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.2/reporting_write_processors.md
+++ b/source/puppet/4.2/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing Custom Report Processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.2/resources_file_windows.markdown
+++ b/source/puppet/4.2/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource Tips and Examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 
@@ -45,7 +45,7 @@ Windows NTFS filesystems are case-insensitive (albeit case-preserving); Puppet i
 
 To manage files properly, Puppet needs the "Create symbolic links" (Vista/2008 and up), "Back up files and directories," and "Restore files and directories" privileges. The easiest way to handle this is:
 
-* When Puppet runs as a service, make sure its user account is a member of the local `Administrators` group.  When you use the [`PUPPET_AGENT_ACCOUNT_USER` parameter](./puppet/latest/reference/install_windows.html#puppetagentaccountuser) with the MSI installer, the user will automatically be added to the administrators group.
+* When Puppet runs as a service, make sure its user account is a member of the local `Administrators` group.  When you use the [`PUPPET_AGENT_ACCOUNT_USER` parameter](./puppet/latest/install_windows.html#puppetagentaccountuser) with the MSI installer, the user will automatically be added to the administrators group.
 * Before running Puppet interactively (on Vista/2008 and up), be sure to start the command prompt window with elevated privileges by right-clicking on the start menu and choosing "Run as Administrator."
 
 ## Managing File Permissions

--- a/source/puppet/4.2/resources_service.markdown
+++ b/source/puppet/4.2/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource Tips and Examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.2/resources_user_group_windows.markdown
+++ b/source/puppet/4.2/resources_user_group_windows.markdown
@@ -5,10 +5,10 @@ title: "Resource Tips and Examples: User and Group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
 [relationships]: /puppet/4.2.latest/reference/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.

--- a/source/puppet/4.2/services_agent_unix.markdown
+++ b/source/puppet/4.2/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on *nix Systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.2/services_agent_windows.markdown
+++ b/source/puppet/4.2/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on Windows Systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html
@@ -12,7 +12,7 @@ canonical: "/puppet/latest/reference/services_master_windows.html"
 [runinterval]: ./configuration.html#runinterval
 [short_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [page on triggering puppet runs]: /pe/latest/orchestration_puppet.html
-[msiproperties]: /puppet/latest/reference/install_windows.html#automated-installation
+[msiproperties]: /puppet/latest/install_windows.html#automated-installation
 [uac]: ./images/uac.png
 [rightclick]: ./images/run_as_admin.png
 [report]: /guides/reporting.html

--- a/source/puppet/4.2/services_apply.markdown
+++ b/source/puppet/4.2/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.2/services_master_rack.markdown
+++ b/source/puppet/4.2/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The Rack Puppet Master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.2/services_master_webrick.markdown
+++ b/source/puppet/4.2/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The WEBrick Puppet Master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.2/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.2/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: CSR Attributes and Certificate Extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.2/ssl_autosign.markdown
+++ b/source/puppet/4.2/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: Autosigning Certificate Requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.2/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.2/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating All Certificates in a Puppet Deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.2/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.2/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/Master HTTPS Communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.2/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.2/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog Compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.2/system_requirements.markdown
+++ b/source/puppet/4.2/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.2 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view pre-install tasks](/pre_install.html).

--- a/source/puppet/4.2/type.md
+++ b/source/puppet/4.2/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: e49293167c2a4753e3db51df5585478e3d8c8877
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc: columns
 ---
 
@@ -22,7 +22,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.

--- a/source/puppet/4.2/upgrade_major_agent.markdown
+++ b/source/puppet/4.2/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -82,7 +82,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start Service or Update Cron Job

--- a/source/puppet/4.2/upgrade_major_post.md
+++ b/source/puppet/4.2/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-Upgrade Clean-Up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the Per-Environment `parser` Setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` Class from Nodes
 

--- a/source/puppet/4.2/upgrade_major_pre.md
+++ b/source/puppet/4.2/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get Upgrade-Ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/latest/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for Deprecated Features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable Directory Environments and Move Code into Them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the Future Parser and Fix Broken Code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x Release Notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), and [4.2](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), and [4.2](./release_notes.html) and prepare accordingly.
 
 ## You're Ready!
 

--- a/source/puppet/4.2/upgrade_major_server.markdown
+++ b/source/puppet/4.2/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: /puppetserver/2.1/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: /hiera/latest/configuring.html
 [Hiera]: /hiera/
 [r10k]: /pe/latest/r10k.html
@@ -66,7 +66,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser](/puppet/latest/reference/experiments_future.html).
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser](/puppet/latest/experiments_future.html).
 
 ### Reconcile `auth.conf`
 
@@ -129,13 +129,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move Code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser](/puppet/latest/reference/experiments_future.html) in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser](/puppet/latest/experiments_future.html) in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.2/upgrade_minor.md
+++ b/source/puppet/4.2/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor Upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.2/whered_it_go.markdown
+++ b/source/puppet/4.2/whered_it_go.markdown
@@ -3,10 +3,10 @@ layout: default
 title: "Where Did Everything Go in Puppet 4.x?"
 ---
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.3/about_agent.md
+++ b/source/puppet/4.3/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What Is It, and What's In It?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: /facter/latest/
@@ -25,7 +25,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's Up With the Version Numbers?
 

--- a/source/puppet/4.3/config_about_settings.markdown
+++ b/source/puppet/4.3/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is Configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.3/config_file_auth.markdown
+++ b/source/puppet/4.3/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: auth.conf"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.3/config_file_autosign.markdown
+++ b/source/puppet/4.3/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.3/config_file_csr_attributes.markdown
+++ b/source/puppet/4.3/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config Files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.3/config_file_device.markdown
+++ b/source/puppet/4.3/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.3/config_file_environment.markdown
+++ b/source/puppet/4.3/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config Files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.3/config_file_fileserver.markdown
+++ b/source/puppet/4.3/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.3/config_file_hiera.markdown
+++ b/source/puppet/4.3/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: /hiera/latest/

--- a/source/puppet/4.3/config_file_main.markdown
+++ b/source/puppet/4.3/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: The Main Config File (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.3/config_file_oid_map.md
+++ b/source/puppet/4.3/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.3/config_file_puppetdb.markdown
+++ b/source/puppet/4.3/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: /puppetdb/latest/puppetdb_connection.html

--- a/source/puppet/4.3/config_file_routes.markdown
+++ b/source/puppet/4.3/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.3/config_important_settings.markdown
+++ b/source/puppet/4.3/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short List of Important Settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.3/config_print.markdown
+++ b/source/puppet/4.3/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking Values of Settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.3/config_set.markdown
+++ b/source/puppet/4.3/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing Settings on the Command Line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.3/configuration.md
+++ b/source/puppet/4.3/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -144,7 +144,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -284,15 +284,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](http://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](http://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](http://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](http://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](http://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -397,7 +397,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### configprint
@@ -645,7 +645,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/environments
 
@@ -1040,7 +1040,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: 
 
@@ -1136,7 +1136,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-http://docs.puppetlabs.com/puppet/latest/reference/environments.html
+http://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### name

--- a/source/puppet/4.3/deprecated_language.markdown
+++ b/source/puppet/4.3/deprecated_language.markdown
@@ -21,7 +21,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.3/dirs_codedir.markdown
+++ b/source/puppet/4.3/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and Data Directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.3/dirs_confdir.markdown
+++ b/source/puppet/4.3/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config Directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: /puppetserver/2.2/configuration.html#puppetserverconf

--- a/source/puppet/4.3/dirs_manifest.markdown
+++ b/source/puppet/4.3/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Main Manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.3/dirs_modulepath.markdown
+++ b/source/puppet/4.3/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.3/dirs_ssldir.markdown
+++ b/source/puppet/4.3/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.3/dirs_vardir.markdown
+++ b/source/puppet/4.3/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Cache Directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.3/environments.markdown
+++ b/source/puppet/4.3/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.3/environments_configuring.markdown
+++ b/source/puppet/4.3/environments_configuring.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuring Environments"
-canonical: "/puppet/latest/reference/environments_configuring.html"
+canonical: "/puppet/latest/environments_configuring.html"
 ---
 
 [environmentpath]: ./configuration.html#environmentpath

--- a/source/puppet/4.3/environments_https.markdown
+++ b/source/puppet/4.3/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS Interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.3/environments_limitations.markdown
+++ b/source/puppet/4.3/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of Environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.3/environments_suggestions.markdown
+++ b/source/puppet/4.3/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.3/experiments_msgpack.markdown
+++ b/source/puppet/4.3/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Msgpack Support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 Background on Msgpack

--- a/source/puppet/4.3/experiments_overview.markdown
+++ b/source/puppet/4.3/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.3/format_report.markdown
+++ b/source/puppet/4.3/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.3/function.md
+++ b/source/puppet/4.3/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -276,7 +276,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -367,7 +367,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -390,12 +390,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -448,7 +448,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -608,7 +608,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -678,7 +678,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -756,7 +756,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -839,7 +839,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -909,12 +909,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -948,14 +948,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](http://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](http://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -994,7 +994,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1096,7 +1096,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1230,7 +1230,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1593,9 +1593,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.3/index.md
+++ b/source/puppet/4.3/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.3 Reference Manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.3/indirection.md
+++ b/source/puppet/4.3/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.3/install_linux.markdown
+++ b/source/puppet/4.3/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: /puppetserver/2.2/install_from_packages.html#memory-allocation
 [puppetserver_confd]: /puppetserver/2.2/configuration.html
 [server_install]: /puppetserver/2.2/install_from_packages.html

--- a/source/puppet/4.3/install_osx.md
+++ b/source/puppet/4.3/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: /puppetserver/2.2/install_from_packages.html

--- a/source/puppet/4.3/install_pre.markdown
+++ b/source/puppet/4.3/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-Install Tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: /pe/latest/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: /puppetdb/latest
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.3/install_windows.markdown
+++ b/source/puppet/4.3/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/
@@ -102,10 +102,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.3/lang_classes.markdown
+++ b/source/puppet/4.3/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.3/lang_collectors.markdown
+++ b/source/puppet/4.3/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.3/lang_comments.markdown
+++ b/source/puppet/4.3/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.3/lang_conditional.markdown
+++ b/source/puppet/4.3/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional Statements and Expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.3/lang_containment.markdown
+++ b/source/puppet/4.3/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of Resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.3/lang_data.md
+++ b/source/puppet/4.3/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About Values and Data Types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.3/lang_data_abstract.md
+++ b/source/puppet/4.3/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Abstract Data Types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.3/lang_data_array.md
+++ b/source/puppet/4.3/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.3/lang_data_boolean.md
+++ b/source/puppet/4.3/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.3/lang_data_default.md
+++ b/source/puppet/4.3/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.3/lang_data_hash.md
+++ b/source/puppet/4.3/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.3/lang_data_number.md
+++ b/source/puppet/4.3/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.3/lang_data_regexp.md
+++ b/source/puppet/4.3/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Regular Expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.3/lang_data_resource_reference.md
+++ b/source/puppet/4.3/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource and Class References"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.3/lang_data_resource_type.md
+++ b/source/puppet/4.3/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource Types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.3/lang_data_string.md
+++ b/source/puppet/4.3/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.3/lang_data_type.md
+++ b/source/puppet/4.3/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Data Type Syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.3/lang_data_undef.md
+++ b/source/puppet/4.3/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.3/lang_defaults.markdown
+++ b/source/puppet/4.3/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Default Statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.3/lang_defined_types.markdown
+++ b/source/puppet/4.3/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined Resource Types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.3/lang_exported.markdown
+++ b/source/puppet/4.3/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported Resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.3/lang_expressions.markdown
+++ b/source/puppet/4.3/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and Operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html
@@ -481,7 +481,7 @@ Assignment Operators
 
 ### `=` (assignment)
 
-The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/reference/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
+The assignment operator sets the [variable](http://docs.puppetlabs.com/puppet/latest/lang_variables.html) on the left hand side to the value on the right hand side. The entire expression resolves to the value of the right hand side.
 
 Note that variables can only be set once, after which any attempt to set the variable to a new value will cause an error.
 

--- a/source/puppet/4.3/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.3/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and Built-in Variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.3/lang_functions.markdown
+++ b/source/puppet/4.3/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.3/lang_iteration.md
+++ b/source/puppet/4.3/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and Loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.3/lang_lambdas.md
+++ b/source/puppet/4.3/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (Code Blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.3/lang_namespaces.markdown
+++ b/source/puppet/4.3/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and Autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.3/lang_node_definitions.markdown
+++ b/source/puppet/4.3/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node Definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: /hiera/latest

--- a/source/puppet/4.3/lang_relationships.markdown
+++ b/source/puppet/4.3/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and Ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.3/lang_reserved.markdown
+++ b/source/puppet/4.3/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved Words and Acceptable Names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.3/lang_resources.markdown
+++ b/source/puppet/4.3/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.3/lang_resources_advanced.md
+++ b/source/puppet/4.3/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (Advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.3/lang_run_stages.markdown
+++ b/source/puppet/4.3/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run Stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.3/lang_scope.markdown
+++ b/source/puppet/4.3/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.3/lang_summary.markdown
+++ b/source/puppet/4.3/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.3/lang_tags.markdown
+++ b/source/puppet/4.3/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.3/lang_template.md
+++ b/source/puppet/4.3/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using Templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.3/lang_template_epp.md
+++ b/source/puppet/4.3/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html

--- a/source/puppet/4.3/lang_template_erb.md
+++ b/source/puppet/4.3/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.3/lang_updating_manifests.markdown
+++ b/source/puppet/4.3/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-Check to Make Sure It's Safe Before Purging `cron` Resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.3/lang_variables.markdown
+++ b/source/puppet/4.3/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.3/lang_virtual.markdown
+++ b/source/puppet/4.3/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual Resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.3/lang_visual_index.markdown
+++ b/source/puppet/4.3/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual Index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.3/lang_windows_file_paths.markdown
+++ b/source/puppet/4.3/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling File Paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: /guides/templating.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using Backslashes in Double-Quoted Strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.3/lookup_quick.md
+++ b/source/puppet/4.3/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick Reference for Hiera Users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.3/lookup_quick_module.md
+++ b/source/puppet/4.3/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick Intro to Module Data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.3/metaparameter.md
+++ b/source/puppet/4.3/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](http://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](http://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](http://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 

--- a/source/puppet/4.3/modules_documentation.markdown
+++ b/source/puppet/4.3/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting Modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.3/modules_fundamentals.markdown
+++ b/source/puppet/4.3/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.3/modules_installing.markdown
+++ b/source/puppet/4.3/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppetlabs.com
@@ -256,7 +256,7 @@ By default, the tool won't uninstall a module that other modules depend on, or w
 
 #### Upgrade/Uninstall
 
-The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
 You might see an error similar to the following when upgrading or uninstalling:
 

--- a/source/puppet/4.3/modules_metadata.md
+++ b/source/puppet/4.3/modules_metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Metadata and metadata.json"
-canonical: "/puppet/latest/reference/modules_metadata.html"
+canonical: "/puppet/latest/modules_metadata.html"
 ---
 
 [puppet lookup]: ./lookup_quick.html

--- a/source/puppet/4.3/modules_publishing.markdown
+++ b/source/puppet/4.3/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing Modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 

--- a/source/puppet/4.3/puppet_collections.md
+++ b/source/puppet/4.3/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and Packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.3/quick_start.markdown
+++ b/source/puppet/4.3/quick_start.markdown
@@ -29,7 +29,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, World!
- Modules contain [classes](./puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](./puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a Module
  Next, learn how to install a Puppet Labs module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html). 

--- a/source/puppet/4.3/quick_start_adding_classes_nix.markdown
+++ b/source/puppet/4.3/quick_start_adding_classes_nix.markdown
@@ -41,7 +41,7 @@ Every module contains one or more **classes**. [Classes](./lang_classes.html) ar
 
 ## Editing Class Parameters in the Main Manifest
 
-You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#defining-classes) of a class in `site.pp` as well. Parameters allow a class to request external data. If a class needs to configure itself with data other than [Puppet facts](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html), provide that data to the class via a parameter.
+You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/lang_classes.html#defining-classes) of a class in `site.pp` as well. Parameters allow a class to request external data. If a class needs to configure itself with data other than [Puppet facts](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html), provide that data to the class via a parameter.
 
 
 **To edit the parameters of the** `apache` **class**:
@@ -54,7 +54,7 @@ You can edit the [parameters](https://docs.puppetlabs.com/puppet/latest/referenc
     	  docroot => '/var/www'
 		}
 
-	>**Note**: You must remove `include apache` because Puppet will only allow you to [declare a class once](https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#declaring-classes).
+	>**Note**: You must remove `include apache` because Puppet will only allow you to [declare a class once](https://docs.puppetlabs.com/puppet/latest/lang_classes.html#declaring-classes).
 
 > That's it! You have set the Apache web server's root directory to `/var/www` instead of its default `/var/www/html`. If you refresh `http://myagentnodeIP:80/` in your web browser, it shows the list of files in `/var/www`. If you click `html`, the browser will again show the contents of `/var/www/html/index.html`.
 >

--- a/source/puppet/4.3/quick_start_firewall.markdown
+++ b/source/puppet/4.3/quick_start_firewall.markdown
@@ -135,7 +135,7 @@ Modules are directory trees. For this task, you'll create the following files:
 		    purge => true,
 		  }
 
-4. Add the following Puppet code to your `site.pp` file. These defaults will ensure that the `pre` and `post` classes are [run in the correct order](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html) to avoid locking you out of your box during the first Puppet run, and declaring `my_fw::pre` and `my_fw::post` satisfies the specified dependencies.
+4. Add the following Puppet code to your `site.pp` file. These defaults will ensure that the `pre` and `post` classes are [run in the correct order](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html) to avoid locking you out of your box during the first Puppet run, and declaring `my_fw::pre` and `my_fw::post` satisfies the specified dependencies.
 
 		  Firewall {
 		    before  => Class['my_fw::post'],

--- a/source/puppet/4.3/quick_start_helloworld.markdown
+++ b/source/puppet/4.3/quick_start_helloworld.markdown
@@ -30,9 +30,9 @@ Modules are directory trees. For this task, you'll create the following structur
       - `init.pp` (manifest file that contains the `helloworld` class)
       - `motd.pp` (manifest file that contains a file resource that ensures the creation of the motd)
 
-Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `helloworld`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>`, or in this case, `helloworld::motd`.
+Every manifest (.pp file) in a module contains a single class. File names map to class names in a predictable way, described in the [Autoloader Behavior documentation](https://docs.puppetlabs.com/puppet/latest/lang_namespaces.html#autoloader-behavior). The `init.pp` file is a special case that contains a class named after the module, `helloworld`. Other manifest files contain classes called `<MODULE NAME>::<FILE NAME>`, or in this case, `helloworld::motd`.
 
-* For more on how modules work, see [Module Fundamentals](/puppet/3.8/reference/modules_fundamentals.html) in the Puppet documentation.
+* For more on how modules work, see [Module Fundamentals](/puppet/3.8/modules_fundamentals.html) in the Puppet documentation.
 * For more on best practices, methods, and approaches to writing modules, see the [Beginners Guide to Modules](/guides/module_guides/bgtm.html).
 * For a more detailed guided tour, also see [the module chapters of Learning Puppet](/learning/modules1.html).
 

--- a/source/puppet/4.3/quick_start_user_group.markdown
+++ b/source/puppet/4.3/quick_start_user_group.markdown
@@ -91,7 +91,7 @@ Puppet uses some defaults for unspecified user and group attributes, so all you'
 13. From the command line on your Puppet agent, use `puppet agent -t` to trigger a Puppet run.
 
 > Success! You have created a user, `jargyle`, and added jargyle to the group with `groups => web`.
-> For more information on users and groups, check out the documentation for Puppet resource types regarding [users](https://docs.puppetlabs.com/puppet/latest/reference/type.html#user) and [groups](https://docs.puppetlabs.com/puppet/latest/reference/type.html#group).
+> For more information on users and groups, check out the documentation for Puppet resource types regarding [users](https://docs.puppetlabs.com/puppet/latest/type.html#user) and [groups](https://docs.puppetlabs.com/puppet/latest/type.html#group).
 > With users and groups, you can assign different permissions for managing Puppet.
 
 ---------

--- a/source/puppet/4.3/release_notes.markdown
+++ b/source/puppet/4.3/release_notes.markdown
@@ -15,9 +15,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If You're Upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.2 release notes](/puppet/4.2/reference/release_notes.html) and [Puppet 4.1 release notes](/puppet/4.1/reference/release_notes.html).
+Also of interest: the [Puppet 4.2 release notes](/puppet/4.2/release_notes.html) and [Puppet 4.1 release notes](/puppet/4.1/release_notes.html).
 
 ## Puppet 4.3.2
 

--- a/source/puppet/4.3/release_notes_agent.md
+++ b/source/puppet/4.3/release_notes_agent.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "Puppet Agent Release Notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
-[Puppet 4.3.0]: /puppet/4.3/reference/release_notes.html#puppet-430
-[Puppet 4.3.1]: /puppet/4.3/reference/release_notes.html#puppet-431
-[Puppet 4.3.2]: /puppet/4.3/reference/release_notes.html#puppet-432
+[Puppet 4.3.0]: /puppet/4.3/release_notes.html#puppet-430
+[Puppet 4.3.1]: /puppet/4.3/release_notes.html#puppet-431
+[Puppet 4.3.2]: /puppet/4.3/release_notes.html#puppet-432
 
 [Facter 3.1.2]: /facter/3.1/release_notes.html#facter-312
 [Facter 3.1.3]: /facter/3.1/release_notes.html#facter-313
@@ -30,7 +30,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If You're Upgrading from Puppet 3.x
 
-The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.3 release notes](./release_notes.html).
 
@@ -166,6 +166,6 @@ However, the bundle we provide in `puppet-agent` 1.3.0 and 1.3.1 includes only a
 
 ### 1.2.x and earlier
 
-For details on `puppet-agent` 1.2.x releases, see [their release notes](/puppet/4.2/reference/release_notes_agent.html).
+For details on `puppet-agent` 1.2.x releases, see [their release notes](/puppet/4.2/release_notes_agent.html).
 
 For details on `puppet-agent` 1.1.x and earlier, see the [puppet-announce Google Group](https://groups.google.com/forum/#!forum/puppet-announce).

--- a/source/puppet/4.3/report.md
+++ b/source/puppet/4.3/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.3/reporting_about.md
+++ b/source/puppet/4.3/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About Reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools](/pe/latest/CM_reports.html) in the console. [PuppetDB](/puppetdb/latest/), with [its report processor enabled](/puppetdb/latest/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.3/reporting_write_processors.md
+++ b/source/puppet/4.3/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing Custom Report Processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.3/resources_file_windows.markdown
+++ b/source/puppet/4.3/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource Tips and Examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.3/resources_service.markdown
+++ b/source/puppet/4.3/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource Tips and Examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.3/resources_user_group_windows.markdown
+++ b/source/puppet/4.3/resources_user_group_windows.markdown
@@ -5,10 +5,10 @@ title: "Resource Tips and Examples: User and Group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
 [relationships]: /puppet/4.3.latest/reference/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.

--- a/source/puppet/4.3/services_agent_unix.markdown
+++ b/source/puppet/4.3/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on *nix Systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.3/services_agent_windows.markdown
+++ b/source/puppet/4.3/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on Windows Systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.3/services_apply.markdown
+++ b/source/puppet/4.3/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.3/services_master_rack.markdown
+++ b/source/puppet/4.3/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The Rack Puppet Master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.3/services_master_webrick.markdown
+++ b/source/puppet/4.3/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The WEBrick Puppet Master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.3/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.3/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: CSR Attributes and Certificate Extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.3/ssl_autosign.markdown
+++ b/source/puppet/4.3/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: Autosigning Certificate Requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.3/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.3/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating All Certificates in a Puppet Deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.3/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.3/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/Master HTTPS Communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.3/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.3/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog Compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.3/system_requirements.markdown
+++ b/source/puppet/4.3/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.3 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view the pre-install tasks](/pre_install.html).

--- a/source/puppet/4.3/type.md
+++ b/source/puppet/4.3/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 3b5d15cb1c5ed830cb460f2687fde710e5383e69
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.

--- a/source/puppet/4.3/upgrade_major_agent.markdown
+++ b/source/puppet/4.3/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.3/upgrade_major_post.md
+++ b/source/puppet/4.3/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-Upgrade Clean-Up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the Per-Environment `parser` Setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` Class from Nodes
 

--- a/source/puppet/4.3/upgrade_major_pre.md
+++ b/source/puppet/4.3/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get Upgrade-Ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/latest/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for Deprecated Features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable Directory Environments and Move Code into Them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the Future Parser and Fix Broken Code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x Release Notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), and [4.3](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), and [4.3](./release_notes.html) and prepare accordingly.
 
 ## You're Ready!
 

--- a/source/puppet/4.3/upgrade_major_server.markdown
+++ b/source/puppet/4.3/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: /puppetserver/2.2/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: /hiera/latest/configuring.html
 [Hiera]: /hiera/
 [r10k]: /pe/latest/r10k.html
@@ -66,7 +66,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser](/puppet/latest/reference/experiments_future.html).
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser](/puppet/latest/experiments_future.html).
 
 ### Reconcile `auth.conf`
 
@@ -164,13 +164,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move Code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser](/puppet/latest/reference/experiments_future.html) in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser](/puppet/latest/experiments_future.html) in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.3/upgrade_minor.md
+++ b/source/puppet/4.3/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor Upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.3/whered_it_go.markdown
+++ b/source/puppet/4.3/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where Did Everything Go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.4/about_agent.md
+++ b/source/puppet/4.4/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What Is It, and What's In It?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: {{facter}}/
@@ -25,7 +25,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's Up With the Version Numbers?
 

--- a/source/puppet/4.4/config_about_settings.markdown
+++ b/source/puppet/4.4/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is Configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.4/config_file_auth.markdown
+++ b/source/puppet/4.4/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: auth.conf (LEGACY)"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.4/config_file_autosign.markdown
+++ b/source/puppet/4.4/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.4/config_file_csr_attributes.markdown
+++ b/source/puppet/4.4/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config Files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.4/config_file_device.markdown
+++ b/source/puppet/4.4/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.4/config_file_environment.markdown
+++ b/source/puppet/4.4/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config Files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.4/config_file_fileserver.markdown
+++ b/source/puppet/4.4/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.4/config_file_hiera.markdown
+++ b/source/puppet/4.4/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.4/config_file_main.markdown
+++ b/source/puppet/4.4/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: The Main Config File (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.4/config_file_oid_map.md
+++ b/source/puppet/4.4/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.4/config_file_puppetdb.markdown
+++ b/source/puppet/4.4/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: {{puppetdb}}/puppetdb_connection.html

--- a/source/puppet/4.4/config_file_routes.markdown
+++ b/source/puppet/4.4/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.4/config_important_settings.markdown
+++ b/source/puppet/4.4/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short List of Important Settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.4/config_print.markdown
+++ b/source/puppet/4.4/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking Values of Settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.4/config_set.markdown
+++ b/source/puppet/4.4/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing Settings on the Command Line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.4/configuration.md
+++ b/source/puppet/4.4/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -39,7 +39,7 @@ canonical: /puppet/latest/reference/configuration.html
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -131,7 +131,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -144,7 +144,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -284,15 +284,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -397,7 +397,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### configprint
@@ -646,7 +646,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: $codedir/environments
 
@@ -1041,7 +1041,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppetlabs.com/puppet/latest/environments.html
 
 - *Default*: 
 
@@ -1137,7 +1137,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+https://docs.puppetlabs.com/puppet/latest/environments.html
 
 
 ### name

--- a/source/puppet/4.4/deprecated_language.markdown
+++ b/source/puppet/4.4/deprecated_language.markdown
@@ -19,7 +19,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.4/deprecated_win2003.md
+++ b/source/puppet/4.4/deprecated_win2003.md
@@ -6,4 +6,4 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.

--- a/source/puppet/4.4/dirs_codedir.markdown
+++ b/source/puppet/4.4/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and Data Directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.4/dirs_confdir.markdown
+++ b/source/puppet/4.4/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config Directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: {{puppetserver}}/config_file_puppetserver.html

--- a/source/puppet/4.4/dirs_manifest.markdown
+++ b/source/puppet/4.4/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Main Manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.4/dirs_modulepath.markdown
+++ b/source/puppet/4.4/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Modulepath (Default Config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.4/dirs_ssldir.markdown
+++ b/source/puppet/4.4/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.4/dirs_vardir.markdown
+++ b/source/puppet/4.4/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The Cache Directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.4/environments.markdown
+++ b/source/puppet/4.4/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.4/environments_configuring.markdown
+++ b/source/puppet/4.4/environments_configuring.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuring Environments"
-canonical: "/puppet/latest/reference/environments_configuring.html"
+canonical: "/puppet/latest/environments_configuring.html"
 ---
 
 [environmentpath]: ./configuration.html#environmentpath

--- a/source/puppet/4.4/environments_https.markdown
+++ b/source/puppet/4.4/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS Interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.4/environments_limitations.markdown
+++ b/source/puppet/4.4/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of Environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.4/environments_suggestions.markdown
+++ b/source/puppet/4.4/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.4/experiments_msgpack.markdown
+++ b/source/puppet/4.4/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Msgpack Support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 Background on Msgpack

--- a/source/puppet/4.4/experiments_overview.markdown
+++ b/source/puppet/4.4/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental Features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.4/format_report.markdown
+++ b/source/puppet/4.4/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.4/function.md
+++ b/source/puppet/4.4/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -276,7 +276,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -367,7 +367,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -390,12 +390,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -448,7 +448,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -608,7 +608,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -678,7 +678,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -756,7 +756,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -839,7 +839,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -909,12 +909,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -948,14 +948,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -994,7 +994,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1096,7 +1096,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1230,7 +1230,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1575,9 +1575,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.4/index.md
+++ b/source/puppet/4.4/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.4 Reference Manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.4/indirection.md
+++ b/source/puppet/4.4/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.4/install_linux.markdown
+++ b/source/puppet/4.4/install_linux.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers

--- a/source/puppet/4.4/install_osx.md
+++ b/source/puppet/4.4/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.4/install_pre.markdown
+++ b/source/puppet/4.4/install_pre.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-Install Tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: {{pe}}/install_basic.html

--- a/source/puppet/4.4/install_windows.markdown
+++ b/source/puppet/4.4/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet Agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/

--- a/source/puppet/4.4/lang_classes.markdown
+++ b/source/puppet/4.4/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.4/lang_collectors.markdown
+++ b/source/puppet/4.4/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.4/lang_comments.markdown
+++ b/source/puppet/4.4/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.4/lang_conditional.markdown
+++ b/source/puppet/4.4/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional Statements and Expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.4/lang_containment.markdown
+++ b/source/puppet/4.4/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of Resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.4/lang_data.md
+++ b/source/puppet/4.4/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About Values and Data Types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.4/lang_data_abstract.md
+++ b/source/puppet/4.4/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Abstract Data Types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.4/lang_data_array.md
+++ b/source/puppet/4.4/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.4/lang_data_boolean.md
+++ b/source/puppet/4.4/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.4/lang_data_default.md
+++ b/source/puppet/4.4/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.4/lang_data_hash.md
+++ b/source/puppet/4.4/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.4/lang_data_number.md
+++ b/source/puppet/4.4/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.4/lang_data_regexp.md
+++ b/source/puppet/4.4/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Regular Expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.4/lang_data_resource_reference.md
+++ b/source/puppet/4.4/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource and Class References"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.4/lang_data_resource_type.md
+++ b/source/puppet/4.4/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Resource Types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.4/lang_data_string.md
+++ b/source/puppet/4.4/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.4/lang_data_type.md
+++ b/source/puppet/4.4/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Data Type Syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.4/lang_data_undef.md
+++ b/source/puppet/4.4/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data Types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.4/lang_defaults.markdown
+++ b/source/puppet/4.4/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource Default Statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.4/lang_defined_types.markdown
+++ b/source/puppet/4.4/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined Resource Types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.4/lang_exported.markdown
+++ b/source/puppet/4.4/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported Resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.4/lang_expressions.markdown
+++ b/source/puppet/4.4/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and Operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html

--- a/source/puppet/4.4/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.4/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and Built-in Variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.4/lang_functions.markdown
+++ b/source/puppet/4.4/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.4/lang_iteration.md
+++ b/source/puppet/4.4/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and Loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.4/lang_lambdas.md
+++ b/source/puppet/4.4/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (Code Blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.4/lang_namespaces.markdown
+++ b/source/puppet/4.4/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and Autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.4/lang_node_definitions.markdown
+++ b/source/puppet/4.4/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node Definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.4/lang_relationships.markdown
+++ b/source/puppet/4.4/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and Ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.4/lang_reserved.markdown
+++ b/source/puppet/4.4/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved Words and Acceptable Names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.4/lang_resources.markdown
+++ b/source/puppet/4.4/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.4/lang_resources_advanced.md
+++ b/source/puppet/4.4/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (Advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.4/lang_run_stages.markdown
+++ b/source/puppet/4.4/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run Stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.4/lang_scope.markdown
+++ b/source/puppet/4.4/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.4/lang_summary.markdown
+++ b/source/puppet/4.4/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.4/lang_tags.markdown
+++ b/source/puppet/4.4/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.4/lang_template.md
+++ b/source/puppet/4.4/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using Templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.4/lang_template_epp.md
+++ b/source/puppet/4.4/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -17,7 +17,7 @@ canonical: "/puppet/latest/reference/lang_template_epp.html"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.4/lang_template_erb.md
+++ b/source/puppet/4.4/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) Template Syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.4/lang_updating_manifests.markdown
+++ b/source/puppet/4.4/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-Check to Make Sure It's Safe Before Purging `cron` Resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.4/lang_variables.markdown
+++ b/source/puppet/4.4/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.4/lang_virtual.markdown
+++ b/source/puppet/4.4/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.4/lang_visual_index.markdown
+++ b/source/puppet/4.4/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual Index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.4/lang_windows_file_paths.markdown
+++ b/source/puppet/4.4/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling File Paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: ./lang_template.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using Backslashes in Double-Quoted Strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.4/lookup_quick.md
+++ b/source/puppet/4.4/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick Reference for Hiera Users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.4/lookup_quick_module.md
+++ b/source/puppet/4.4/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick Intro to Module Data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.4/metaparameter.md
+++ b/source/puppet/4.4/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 

--- a/source/puppet/4.4/modules_documentation.markdown
+++ b/source/puppet/4.4/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting Modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.4/modules_fundamentals.markdown
+++ b/source/puppet/4.4/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.4/modules_installing.markdown
+++ b/source/puppet/4.4/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppetlabs.com
@@ -256,7 +256,7 @@ By default, the tool won't uninstall a module that other modules depend on, or w
 
 #### Upgrade/Uninstall
 
-The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/reference/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
+The PMT from Puppet 3.6 has a known issue wherein modules that were published to the Puppet Forge that had not performed the [migration steps](/puppet/3.7/modules_publishing.html#build-your-module) before publishing will have erroneous checksum information in their metadata.json. These checksums will cause errors that prevent you from upgrading or uninstalling the module.
 
 You might see an error similar to the following when upgrading or uninstalling:
 

--- a/source/puppet/4.4/modules_metadata.md
+++ b/source/puppet/4.4/modules_metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module Metadata and metadata.json"
-canonical: "/puppet/latest/reference/modules_metadata.html"
+canonical: "/puppet/latest/modules_metadata.html"
 ---
 
 [puppet lookup]: ./lookup_quick.html

--- a/source/puppet/4.4/modules_publishing.markdown
+++ b/source/puppet/4.4/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing Modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 

--- a/source/puppet/4.4/passenger.markdown
+++ b/source/puppet/4.4/passenger.markdown
@@ -54,7 +54,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -229,8 +229,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.4/puppet_collections.md
+++ b/source/puppet/4.4/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and Packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.4/quick_start.markdown
+++ b/source/puppet/4.4/quick_start.markdown
@@ -29,7 +29,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, World!
- Modules contain [classes](./puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](./puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a Module
  Next, learn how to install a Puppet module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html).

--- a/source/puppet/4.4/release_notes.markdown
+++ b/source/puppet/4.4/release_notes.markdown
@@ -16,9 +16,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.3 release notes](/puppet/4.3/reference/release_notes.html) and [Puppet 4.2 release notes](/puppet/4.2/reference/release_notes.html).
+Also of interest: the [Puppet 4.3 release notes](/puppet/4.3/release_notes.html) and [Puppet 4.2 release notes](/puppet/4.2/release_notes.html).
 
 ## Puppet 4.4.2
 

--- a/source/puppet/4.4/release_notes_agent.md
+++ b/source/puppet/4.4/release_notes_agent.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "Puppet Agent Release Notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
-[Puppet 4.4.0]: /puppet/4.4/reference/release_notes.html#puppet-440
-[Puppet 4.4.1]: /puppet/4.4/reference/release_notes.html#puppet-441
-[Puppet 4.4.2]: /puppet/4.4/reference/release_notes.html#puppet-442
+[Puppet 4.4.0]: /puppet/4.4/release_notes.html#puppet-440
+[Puppet 4.4.1]: /puppet/4.4/release_notes.html#puppet-441
+[Puppet 4.4.2]: /puppet/4.4/release_notes.html#puppet-442
 
 [Facter 3.1.5]: /facter/3.1/release_notes.html#facter-315
 [Facter 3.1.6]: /facter/3.1/release_notes.html#facter-316
@@ -31,7 +31,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If You're Upgrading from Puppet 3.x
 
-The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.4 release notes](./release_notes.html).
 
@@ -71,7 +71,7 @@ Includes [Puppet 4.4.0][], [Facter 3.1.5][], [Hiera 3.1.0][], [MCollective 2.8.8
 
 ### Component Updates
 
-* Updates [Puppet](/puppet/4.4/reference/), [Hiera](/hiera/3.1/), and [Facter](/facter/3.1/). This release also updates Mcollective and pxp-agent, but the updates to these components contain no functional changes.
+* Updates [Puppet](/puppet/4.4/), [Hiera](/hiera/3.1/), and [Facter](/facter/3.1/). This release also updates Mcollective and pxp-agent, but the updates to these components contain no functional changes.
 
 ### New Platforms
 
@@ -84,8 +84,8 @@ This release adds `puppet-agent` packages for Fedora 23. Windows packages will a
 
 ### 1.3.x and earlier
 
-For details on `puppet-agent` 1.3.x releases, see [their release notes](/puppet/4.3/reference/release_notes_agent.html).
+For details on `puppet-agent` 1.3.x releases, see [their release notes](/puppet/4.3/release_notes_agent.html).
 
-For details on `puppet-agent` 1.2.x releases, see [their release notes](/puppet/4.2/reference/release_notes_agent.html).
+For details on `puppet-agent` 1.2.x releases, see [their release notes](/puppet/4.2/release_notes_agent.html).
 
 For details on `puppet-agent` 1.1.x and earlier, see the [puppet-announce Google Group](https://groups.google.com/forum/#!forum/puppet-announce).

--- a/source/puppet/4.4/report.md
+++ b/source/puppet/4.4/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.4/reporting_about.md
+++ b/source/puppet/4.4/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About Reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.4/reporting_write_processors.md
+++ b/source/puppet/4.4/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing Custom Report Processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.4/resources_file_windows.markdown
+++ b/source/puppet/4.4/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource Tips and Examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.4/resources_service.markdown
+++ b/source/puppet/4.4/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource Tips and Examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.4/resources_user_group_windows.markdown
+++ b/source/puppet/4.4/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource Tips and Examples: User and Group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/4.4/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/4.4/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.4/services_agent_unix.markdown
+++ b/source/puppet/4.4/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on *nix Systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.4/services_agent_windows.markdown
+++ b/source/puppet/4.4/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Agent on Windows Systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.4/services_apply.markdown
+++ b/source/puppet/4.4/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: Puppet Apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.4/services_master_rack.markdown
+++ b/source/puppet/4.4/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The Rack Puppet Master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.4/services_master_webrick.markdown
+++ b/source/puppet/4.4/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's Services: The WEBrick Puppet Master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.4/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.4/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: CSR Attributes and Certificate Extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.4/ssl_autosign.markdown
+++ b/source/puppet/4.4/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL Configuration: Autosigning Certificate Requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.4/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.4/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating All Certificates in a Puppet Deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.4/static_catalogs.md
+++ b/source/puppet/4.4/static_catalogs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Static Catalogs"
-canonical: "/puppet/latest/reference/static_catalogs.html"
+canonical: "/puppet/latest/static_catalogs.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.4/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.4/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/Master HTTPS Communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.4/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.4/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog Compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.4/system_requirements.markdown
+++ b/source/puppet/4.4/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.4 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 [pe-requirements]: {{pe}}/install_system_requirements.html#supported-operating-systems

--- a/source/puppet/4.4/type.md
+++ b/source/puppet/4.4/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: e800bc25e695b8e8b58521d0a6ecdbd18aab031b
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.

--- a/source/puppet/4.4/upgrade_major_agent.markdown
+++ b/source/puppet/4.4/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x Agent Upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.4/upgrade_major_post.md
+++ b/source/puppet/4.4/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-Upgrade Clean-Up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the Per-Environment `parser` Setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` Class from Nodes
 

--- a/source/puppet/4.4/upgrade_major_pre.md
+++ b/source/puppet/4.4/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get Upgrade-Ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for Deprecated Features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable Directory Environments and Move Code into Them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the Future Parser and Fix Broken Code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x Release Notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html) [4.4](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html) [4.4](./release_notes.html) and prepare accordingly.
 
 ## You're Ready!
 

--- a/source/puppet/4.4/upgrade_major_server.markdown
+++ b/source/puppet/4.4/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -20,7 +20,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -67,7 +67,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -165,13 +165,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move Code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.4/upgrade_minor.md
+++ b/source/puppet/4.4/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor Upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.4/whered_it_go.markdown
+++ b/source/puppet/4.4/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where Did Everything Go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.4/windows_overview.md
+++ b/source/puppet/4.4/windows_overview.md
@@ -3,11 +3,11 @@ layout: default
 title: "Overview of Puppet on Windows"
 ---
 
-[win_commands]: /puppet/latest/reference/services_commands_windows.html
-[win_agent]: /puppet/latest/reference/services_agent_windows.html
-[arch]: /puppet/latest/reference/architecture.html
-[the confdir]: /puppet/latest/reference/dirs_confdir.html
-[the vardir]: /puppet/latest/reference/dirs_vardir.html
+[win_commands]: /puppet/latest/services_commands_windows.html
+[win_agent]: /puppet/latest/services_agent_windows.html
+[arch]: /puppet/latest/architecture.html
+[the confdir]: /puppet/latest/dirs_confdir.html
+[the vardir]: /puppet/latest/dirs_vardir.html
 
 **Puppet runs on Microsoft Windows® and can manage Windows systems alongside \*nix systems.** This page will help get you oriented and ready to manage Windows systems with Puppet.
 
@@ -16,8 +16,8 @@ title: "Overview of Puppet on Windows"
 
 To install open source Puppet on Windows, follow the instructions on the following pages, in order:
 
-* [Pre-install tasks](/puppet/latest/reference/install_pre.html)
-* [Installation instructions](/puppet/latest/reference/install_windows.html)
+* [Pre-install tasks](/puppet/latest/install_pre.html)
+* [Installation instructions](/puppet/latest/install_windows.html)
 
 
 ## Running
@@ -44,28 +44,28 @@ Some \*nix resource types aren't supported on Windows, and there are some Window
 
 The following core resource types can be managed on Windows:
 
-* [file](/puppet/latest/reference/type.html#file) ([tips for Windows](/puppet/latest/reference/resources_file_windows.html))
-* [user](/puppet/latest/reference/type.html#user) ([tips for Windows](/puppet/latest/reference/resources_user_group_windows.html))
-* [group](/puppet/latest/reference/type.html#group) ([tips for Windows](/puppet/latest/reference/resources_user_group_windows.html))
-* [scheduled_task](/puppet/latest/reference/type.html#scheduledtask) ([tips for Windows](/puppet/latest/reference/resources_scheduled_task_windows.html))
-* [package](/puppet/latest/reference/type.html#package) ([tips for Windows](/puppet/latest/reference/resources_package_windows.html))
-* [service](/puppet/latest/reference/type.html#service) ([tips for Windows](/puppet/latest/reference/resources_service.html))
-* [exec](/puppet/latest/reference/type.html#exec) ([tips for Windows](/puppet/latest/reference/resources_exec_windows.html))
-* [host](/puppet/latest/reference/type.html#host)
+* [file](/puppet/latest/type.html#file) ([tips for Windows](/puppet/latest/resources_file_windows.html))
+* [user](/puppet/latest/type.html#user) ([tips for Windows](/puppet/latest/resources_user_group_windows.html))
+* [group](/puppet/latest/type.html#group) ([tips for Windows](/puppet/latest/resources_user_group_windows.html))
+* [scheduled_task](/puppet/latest/type.html#scheduledtask) ([tips for Windows](/puppet/latest/resources_scheduled_task_windows.html))
+* [package](/puppet/latest/type.html#package) ([tips for Windows](/puppet/latest/resources_package_windows.html))
+* [service](/puppet/latest/type.html#service) ([tips for Windows](/puppet/latest/resources_service.html))
+* [exec](/puppet/latest/type.html#exec) ([tips for Windows](/puppet/latest/resources_exec_windows.html))
+* [host](/puppet/latest/type.html#host)
 
-Also, there are some popular [optional resource types for Windows.](/puppet/latest/reference/resources_windows_optional.html)
+Also, there are some popular [optional resource types for Windows.](/puppet/latest/resources_windows_optional.html)
 
 ### Handling file paths
 
 Some resource types take file paths as attributes. On Windows, there are some extra things to take into account when writing file paths, including directory separators. For more info, see:
 
-* [Handling File Paths on Windows](/puppet/latest/reference/lang_windows_file_paths.html)
+* [Handling File Paths on Windows](/puppet/latest/lang_windows_file_paths.html)
 
 ### Line endings
 
 Windows systems generally use different line endings in text files than \*nix systems do. Puppet manifest files can use either kind of line ending.
 
-There are a few subtleties of behavior when handling the content of managed files. For details, [see the note on line endings in the language reference.](/puppet/latest/reference/lang_summary.html#line-endings-in-windows-text-files)
+There are a few subtleties of behavior when handling the content of managed files. For details, [see the note on line endings in the language reference.](/puppet/latest/lang_summary.html#line-endings-in-windows-text-files)
 
 ### Facts
 
@@ -97,7 +97,7 @@ For more information, see the following pages in the Puppet reference manual:
 
 As of Puppet 3.7, the Puppet agent can run as either a 32- or a 64-bit process. This means that as long as you've installed the correct package for your version of Windows, file system redirection should no longer be an issue.
 
-However, if you are using an earlier version of Puppet, file system redirection will still affect you. Please see [Language: Handling file paths on windows](/puppet/latest/reference/lang_windows_file_paths.html) for how to safely handle file system redirection when running 32-bit Puppet on a 64-bit Windows system. The information about file system redirection applies to extensions as well.
+However, if you are using an earlier version of Puppet, file system redirection will still affect you. Please see [Language: Handling file paths on windows](/puppet/latest/lang_windows_file_paths.html) for how to safely handle file system redirection when running 32-bit Puppet on a 64-bit Windows system. The information about file system redirection applies to extensions as well.
 
 >*Note*: By end of year 2016, running 32-bit Puppet agent on a 64-bit Windows system will be deprecated. Upgrade your Puppet installation to 64-bit by December 31, 2016.
 

--- a/source/puppet/4.5/about_agent.md
+++ b/source/puppet/4.5/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What is it, and what's in it?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: {{facter}}/
@@ -27,7 +27,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's up with the version numbers?
 

--- a/source/puppet/4.5/config_about_settings.markdown
+++ b/source/puppet/4.5/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.5/config_file_auth.markdown
+++ b/source/puppet/4.5/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: auth.conf (LEGACY)"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.5/config_file_autosign.markdown
+++ b/source/puppet/4.5/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.5/config_file_csr_attributes.markdown
+++ b/source/puppet/4.5/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.5/config_file_device.markdown
+++ b/source/puppet/4.5/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.5/config_file_environment.markdown
+++ b/source/puppet/4.5/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.5/config_file_fileserver.markdown
+++ b/source/puppet/4.5/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.5/config_file_hiera.markdown
+++ b/source/puppet/4.5/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.5/config_file_main.markdown
+++ b/source/puppet/4.5/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: The main config file (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.5/config_file_oid_map.md
+++ b/source/puppet/4.5/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.5/config_file_puppetdb.markdown
+++ b/source/puppet/4.5/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: {{puppetdb}}/puppetdb_connection.html

--- a/source/puppet/4.5/config_file_routes.markdown
+++ b/source/puppet/4.5/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.5/config_important_settings.markdown
+++ b/source/puppet/4.5/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short list of important settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.5/config_print.markdown
+++ b/source/puppet/4.5/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking values of settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.5/config_set.markdown
+++ b/source/puppet/4.5/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing settings on the command line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.5/configuration.md
+++ b/source/puppet/4.5/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -39,7 +39,7 @@ canonical: /puppet/latest/reference/configuration.html
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -604,7 +604,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -684,7 +684,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1076,7 +1076,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1172,7 +1172,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1243,7 +1243,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1424,7 +1424,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.5/deprecated_language.markdown
+++ b/source/puppet/4.5/deprecated_language.markdown
@@ -19,7 +19,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.5/deprecated_win2003.md
+++ b/source/puppet/4.5/deprecated_win2003.md
@@ -6,4 +6,4 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.

--- a/source/puppet/4.5/dirs_codedir.markdown
+++ b/source/puppet/4.5/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and data directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.5/dirs_confdir.markdown
+++ b/source/puppet/4.5/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: {{puppetserver}}/config_file_puppetserver.html

--- a/source/puppet/4.5/dirs_manifest.markdown
+++ b/source/puppet/4.5/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The main manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.5/dirs_modulepath.markdown
+++ b/source/puppet/4.5/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The modulepath (default config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.5/dirs_ssldir.markdown
+++ b/source/puppet/4.5/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.5/dirs_vardir.markdown
+++ b/source/puppet/4.5/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The cache directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.5/environments.markdown
+++ b/source/puppet/4.5/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.5/environments_https.markdown
+++ b/source/puppet/4.5/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.5/environments_limitations.markdown
+++ b/source/puppet/4.5/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.5/environments_suggestions.markdown
+++ b/source/puppet/4.5/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.5/experiments_msgpack.markdown
+++ b/source/puppet/4.5/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Msgpack support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 ## Background on Msgpack

--- a/source/puppet/4.5/experiments_overview.markdown
+++ b/source/puppet/4.5/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.5/format_report.markdown
+++ b/source/puppet/4.5/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.5/function.md
+++ b/source/puppet/4.5/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ```
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -301,7 +301,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -392,7 +392,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -415,12 +415,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -473,7 +473,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -633,7 +633,7 @@ $users = hiera('users', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -703,7 +703,7 @@ $allusers = hiera_array('users', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -781,7 +781,7 @@ $allusers = hiera_hash('users', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -864,7 +864,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -934,12 +934,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -957,7 +957,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -973,14 +973,14 @@ END
 ```
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -988,7 +988,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -1087,7 +1087,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1186,7 +1186,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1844,7 +1844,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2014,7 +2014,7 @@ resource and relationship expressions.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2201,7 +2201,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -2394,9 +2394,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.5/index.md
+++ b/source/puppet/4.5/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.5 reference manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.5/indirection.md
+++ b/source/puppet/4.5/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.5/install_linux.markdown
+++ b/source/puppet/4.5/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.5/install_osx.md
+++ b/source/puppet/4.5/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.5/install_pre.markdown
+++ b/source/puppet/4.5/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-install tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.5/install_windows.markdown
+++ b/source/puppet/4.5/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/
@@ -102,10 +102,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.5/lang_classes.markdown
+++ b/source/puppet/4.5/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.5/lang_collectors.markdown
+++ b/source/puppet/4.5/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.5/lang_comments.markdown
+++ b/source/puppet/4.5/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.5/lang_conditional.markdown
+++ b/source/puppet/4.5/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional statements and expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.5/lang_containment.markdown
+++ b/source/puppet/4.5/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.5/lang_data.md
+++ b/source/puppet/4.5/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About values and data types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.5/lang_data_abstract.md
+++ b/source/puppet/4.5/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Abstract data types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.5/lang_data_array.md
+++ b/source/puppet/4.5/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.5/lang_data_boolean.md
+++ b/source/puppet/4.5/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.5/lang_data_default.md
+++ b/source/puppet/4.5/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.5/lang_data_hash.md
+++ b/source/puppet/4.5/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.5/lang_data_number.md
+++ b/source/puppet/4.5/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.5/lang_data_regexp.md
+++ b/source/puppet/4.5/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Regular expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.5/lang_data_resource_reference.md
+++ b/source/puppet/4.5/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Resource and class references"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.5/lang_data_resource_type.md
+++ b/source/puppet/4.5/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: resource types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.5/lang_data_string.md
+++ b/source/puppet/4.5/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.5/lang_data_type.md
+++ b/source/puppet/4.5/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Data type syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.5/lang_data_undef.md
+++ b/source/puppet/4.5/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.5/lang_defaults.markdown
+++ b/source/puppet/4.5/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource default statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.5/lang_defined_types.markdown
+++ b/source/puppet/4.5/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined resource types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.5/lang_exported.markdown
+++ b/source/puppet/4.5/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.5/lang_expressions.markdown
+++ b/source/puppet/4.5/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html

--- a/source/puppet/4.5/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.5/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and built-in variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.5/lang_functions.markdown
+++ b/source/puppet/4.5/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.5/lang_iteration.md
+++ b/source/puppet/4.5/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.5/lang_lambdas.md
+++ b/source/puppet/4.5/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (code blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.5/lang_namespaces.markdown
+++ b/source/puppet/4.5/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.5/lang_node_definitions.markdown
+++ b/source/puppet/4.5/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.5/lang_relationships.markdown
+++ b/source/puppet/4.5/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.5/lang_reserved.markdown
+++ b/source/puppet/4.5/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved words and acceptable names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.5/lang_resources.markdown
+++ b/source/puppet/4.5/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.5/lang_resources_advanced.md
+++ b/source/puppet/4.5/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.5/lang_run_stages.markdown
+++ b/source/puppet/4.5/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.5/lang_scope.markdown
+++ b/source/puppet/4.5/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.5/lang_summary.markdown
+++ b/source/puppet/4.5/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.5/lang_tags.markdown
+++ b/source/puppet/4.5/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.5/lang_template.md
+++ b/source/puppet/4.5/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.5/lang_template_epp.md
+++ b/source/puppet/4.5/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) template syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -17,7 +17,7 @@ canonical: "/puppet/latest/reference/lang_template_epp.html"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.5/lang_template_erb.md
+++ b/source/puppet/4.5/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) template syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.5/lang_updating_manifests.markdown
+++ b/source/puppet/4.5/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.5/lang_variables.markdown
+++ b/source/puppet/4.5/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.5/lang_virtual.markdown
+++ b/source/puppet/4.5/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.5/lang_visual_index.markdown
+++ b/source/puppet/4.5/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.5/lang_windows_file_paths.markdown
+++ b/source/puppet/4.5/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling file paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: ./lang_template.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.5/lookup_quick.md
+++ b/source/puppet/4.5/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick reference for Hiera users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.5/lookup_quick_module.md
+++ b/source/puppet/4.5/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick intro to module data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.5/metaparameter.md
+++ b/source/puppet/4.5/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -180,7 +180,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -226,7 +226,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -252,7 +252,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -302,7 +302,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.5/modules_documentation.markdown
+++ b/source/puppet/4.5/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.5/modules_fundamentals.markdown
+++ b/source/puppet/4.5/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.5/modules_installing.markdown
+++ b/source/puppet/4.5/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppet.com

--- a/source/puppet/4.5/modules_metadata.md
+++ b/source/puppet/4.5/modules_metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module metadata and metadata.json"
-canonical: "/puppet/latest/reference/modules_metadata.html"
+canonical: "/puppet/latest/modules_metadata.html"
 ---
 
 [puppet lookup]: ./lookup_quick.html

--- a/source/puppet/4.5/modules_publishing.markdown
+++ b/source/puppet/4.5/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 

--- a/source/puppet/4.5/passenger.markdown
+++ b/source/puppet/4.5/passenger.markdown
@@ -54,7 +54,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -229,8 +229,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.5/puppet_collections.md
+++ b/source/puppet/4.5/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.5/quick_start.markdown
+++ b/source/puppet/4.5/quick_start.markdown
@@ -28,7 +28,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, world!
- Modules contain [classes](./puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](./puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a module
  Next, learn how to install a Puppet module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html).

--- a/source/puppet/4.5/release_notes.markdown
+++ b/source/puppet/4.5/release_notes.markdown
@@ -15,9 +15,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.4 release notes](/puppet/4.4/reference/release_notes.html) and [Puppet 4.3 release notes](/puppet/4.3/reference/release_notes.html).
+Also of interest: the [Puppet 4.4 release notes](/puppet/4.4/release_notes.html) and [Puppet 4.3 release notes](/puppet/4.3/release_notes.html).
 
 ## Puppet 4.5.3
 

--- a/source/puppet/4.5/release_notes_agent.md
+++ b/source/puppet/4.5/release_notes_agent.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Puppet agent release notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
-[Puppet 4.5.0]: /puppet/4.5/reference/release_notes.html#puppet-450
-[Puppet 4.5.1]: /puppet/4.5/reference/release_notes.html#puppet-451
-[Puppet 4.5.2]: /puppet/4.5/reference/release_notes.html#puppet-452
-[Puppet 4.5.3]: /puppet/4.5/reference/release_notes.html#puppet-453
+[Puppet 4.5.0]: /puppet/4.5/release_notes.html#puppet-450
+[Puppet 4.5.1]: /puppet/4.5/release_notes.html#puppet-451
+[Puppet 4.5.2]: /puppet/4.5/release_notes.html#puppet-452
+[Puppet 4.5.3]: /puppet/4.5/release_notes.html#puppet-453
 
 [Facter 3.1.7]: /facter/3.1/release_notes.html#facter-317
 [Facter 3.1.8]: /facter/3.1/release_notes.html#facter-318
@@ -31,7 +31,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.5 release notes](./release_notes.html).
 
@@ -88,10 +88,10 @@ MCollective, pxp-agent, and OpenSSL remain unchanged from `puppet-agent` 1.4.2.
 
 ## 1.4.x and earlier
 
-* [`puppet-agent` 1.4.x release notes](/puppet/4.4/reference/release_notes_agent.html).
+* [`puppet-agent` 1.4.x release notes](/puppet/4.4/release_notes_agent.html).
 
-* [`puppet-agent` 1.3.x release notes](/puppet/4.3/reference/release_notes_agent.html).
+* [`puppet-agent` 1.3.x release notes](/puppet/4.3/release_notes_agent.html).
 
-* [`puppet-agent` 1.2.x release notes](/puppet/4.2/reference/release_notes_agent.html).
+* [`puppet-agent` 1.2.x release notes](/puppet/4.2/release_notes_agent.html).
 
 * For details on `puppet-agent` 1.1.x and earlier, see the [puppet-announce Google Group](https://groups.google.com/forum/#!forum/puppet-announce).

--- a/source/puppet/4.5/report.md
+++ b/source/puppet/4.5/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.5/reporting_about.md
+++ b/source/puppet/4.5/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.5/reporting_write_processors.md
+++ b/source/puppet/4.5/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing custom report processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.5/resources_file_windows.markdown
+++ b/source/puppet/4.5/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.5/resources_service.markdown
+++ b/source/puppet/4.5/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.5/resources_user_group_windows.markdown
+++ b/source/puppet/4.5/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.5/services_agent_unix.markdown
+++ b/source/puppet/4.5/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on *nix systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.5/services_agent_windows.markdown
+++ b/source/puppet/4.5/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on Windows systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.5/services_apply.markdown
+++ b/source/puppet/4.5/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.5/services_master_rack.markdown
+++ b/source/puppet/4.5/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The Rack Puppet master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.5/services_master_webrick.markdown
+++ b/source/puppet/4.5/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The WEBrick Puppet master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.5/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.5/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.5/ssl_autosign.markdown
+++ b/source/puppet/4.5/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: autosigning certificate requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.5/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.5/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating all Certificates in a Puppet deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.5/static_catalogs.md
+++ b/source/puppet/4.5/static_catalogs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Static catalogs"
-canonical: "/puppet/latest/reference/static_catalogs.html"
+canonical: "/puppet/latest/static_catalogs.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.5/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.5/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/master HTTPS communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.5/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.5/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.5/system_requirements.markdown
+++ b/source/puppet/4.5/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.5 System Requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view the pre-install tasks](./install_pre.html).

--- a/source/puppet/4.5/type.md
+++ b/source/puppet/4.5/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 44f2fdad9d3a565123ceae69c267403981e0141a
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1294,8 +1294,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1853,7 +1853,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8448,7 +8448,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10025,7 +10025,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.5/upgrade_major_agent.markdown
+++ b/source/puppet/4.5/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x agent upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.5/upgrade_major_post.md
+++ b/source/puppet/4.5/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-upgrade clean-up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.5/upgrade_major_pre.md
+++ b/source/puppet/4.5/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get upgrade-ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x release notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 ## You're ready!
 

--- a/source/puppet/4.5/upgrade_major_server.markdown
+++ b/source/puppet/4.5/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -20,7 +20,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -67,7 +67,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -165,13 +165,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.5/upgrade_minor.md
+++ b/source/puppet/4.5/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.5/whered_it_go.markdown
+++ b/source/puppet/4.5/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.6/about_agent.md
+++ b/source/puppet/4.6/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What is it, and what's in it?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: {{facter}}/
@@ -27,7 +27,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's up with the version numbers?
 

--- a/source/puppet/4.6/config_about_settings.markdown
+++ b/source/puppet/4.6/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.6/config_file_auth.markdown
+++ b/source/puppet/4.6/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: auth.conf (LEGACY)"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.6/config_file_autosign.markdown
+++ b/source/puppet/4.6/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.6/config_file_csr_attributes.markdown
+++ b/source/puppet/4.6/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.6/config_file_device.markdown
+++ b/source/puppet/4.6/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.6/config_file_environment.markdown
+++ b/source/puppet/4.6/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.6/config_file_fileserver.markdown
+++ b/source/puppet/4.6/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.6/config_file_hiera.markdown
+++ b/source/puppet/4.6/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.6/config_file_main.markdown
+++ b/source/puppet/4.6/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: The main config file (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.6/config_file_oid_map.md
+++ b/source/puppet/4.6/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.6/config_file_puppetdb.markdown
+++ b/source/puppet/4.6/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: {{puppetdb}}/puppetdb_connection.html

--- a/source/puppet/4.6/config_file_routes.markdown
+++ b/source/puppet/4.6/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.6/config_important_settings.markdown
+++ b/source/puppet/4.6/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short list of important settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.6/config_print.markdown
+++ b/source/puppet/4.6/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking values of settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.6/config_set.markdown
+++ b/source/puppet/4.6/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing settings on the command line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.6/configuration.md
+++ b/source/puppet/4.6/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -39,7 +39,7 @@ canonical: /puppet/latest/reference/configuration.html
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -605,7 +605,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -685,7 +685,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1077,7 +1077,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1173,7 +1173,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1244,7 +1244,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1425,7 +1425,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.6/deprecated_language.markdown
+++ b/source/puppet/4.6/deprecated_language.markdown
@@ -19,7 +19,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.6/deprecated_win2003.md
+++ b/source/puppet/4.6/deprecated_win2003.md
@@ -6,4 +6,4 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.

--- a/source/puppet/4.6/dirs_codedir.markdown
+++ b/source/puppet/4.6/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and data directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.6/dirs_confdir.markdown
+++ b/source/puppet/4.6/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: {{puppetserver}}/config_file_puppetserver.html

--- a/source/puppet/4.6/dirs_manifest.markdown
+++ b/source/puppet/4.6/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The main manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.6/dirs_modulepath.markdown
+++ b/source/puppet/4.6/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The modulepath (default config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.6/dirs_ssldir.markdown
+++ b/source/puppet/4.6/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.6/dirs_vardir.markdown
+++ b/source/puppet/4.6/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The cache directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.6/environment_isolation.md
+++ b/source/puppet/4.6/environment_isolation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environment Isolation"
-canonical: "/puppet/latest/reference/environment_isolation.html"
+canonical: "/puppet/latest/environment_isolation.html"
 ---
 
 

--- a/source/puppet/4.6/environments.markdown
+++ b/source/puppet/4.6/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.6/environments_https.markdown
+++ b/source/puppet/4.6/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.6/environments_limitations.markdown
+++ b/source/puppet/4.6/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.6/environments_suggestions.markdown
+++ b/source/puppet/4.6/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.6/experiments_msgpack.markdown
+++ b/source/puppet/4.6/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Msgpack support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 ## Background on Msgpack

--- a/source/puppet/4.6/experiments_overview.markdown
+++ b/source/puppet/4.6/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.6/format_report.markdown
+++ b/source/puppet/4.6/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.6/function.md
+++ b/source/puppet/4.6/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -306,7 +306,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -397,7 +397,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -420,12 +420,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -478,7 +478,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -638,7 +638,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -708,7 +708,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -786,7 +786,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -869,7 +869,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -939,12 +939,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -962,7 +962,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -978,14 +978,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -993,7 +993,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -1092,7 +1092,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1191,7 +1191,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1849,7 +1849,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2019,7 +2019,7 @@ resource and relationship expressions.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2206,7 +2206,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -2399,9 +2399,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.6/index.md
+++ b/source/puppet/4.6/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.6 reference manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.6/indirection.md
+++ b/source/puppet/4.6/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.6/install_linux.markdown
+++ b/source/puppet/4.6/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.6/install_osx.md
+++ b/source/puppet/4.6/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.6/install_pre.markdown
+++ b/source/puppet/4.6/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-install tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.6/install_windows.markdown
+++ b/source/puppet/4.6/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/
@@ -102,10 +102,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.6/lang_classes.markdown
+++ b/source/puppet/4.6/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.6/lang_collectors.markdown
+++ b/source/puppet/4.6/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.6/lang_comments.markdown
+++ b/source/puppet/4.6/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.6/lang_conditional.markdown
+++ b/source/puppet/4.6/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional statements and expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.6/lang_containment.markdown
+++ b/source/puppet/4.6/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.6/lang_data.md
+++ b/source/puppet/4.6/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About values and data types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.6/lang_data_abstract.md
+++ b/source/puppet/4.6/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Abstract data types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.6/lang_data_array.md
+++ b/source/puppet/4.6/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.6/lang_data_boolean.md
+++ b/source/puppet/4.6/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.6/lang_data_default.md
+++ b/source/puppet/4.6/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.6/lang_data_hash.md
+++ b/source/puppet/4.6/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.6/lang_data_number.md
+++ b/source/puppet/4.6/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.6/lang_data_regexp.md
+++ b/source/puppet/4.6/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Regular expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.6/lang_data_resource_reference.md
+++ b/source/puppet/4.6/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Resource and class references"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.6/lang_data_resource_type.md
+++ b/source/puppet/4.6/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: resource types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.6/lang_data_sensitive.md
+++ b/source/puppet/4.6/lang_data_sensitive.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Sensitive"
-canonical: "/puppet/latest/reference/lang_data_sensitive.html"
+canonical: "/puppet/latest/lang_data_sensitive.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.6/lang_data_string.md
+++ b/source/puppet/4.6/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.6/lang_data_type.md
+++ b/source/puppet/4.6/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Data type syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.6/lang_data_undef.md
+++ b/source/puppet/4.6/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.6/lang_defaults.markdown
+++ b/source/puppet/4.6/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource default statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.6/lang_defined_types.markdown
+++ b/source/puppet/4.6/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined resource types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.6/lang_exported.markdown
+++ b/source/puppet/4.6/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.6/lang_expressions.markdown
+++ b/source/puppet/4.6/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html

--- a/source/puppet/4.6/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.6/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and built-in variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.6/lang_functions.markdown
+++ b/source/puppet/4.6/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.6/lang_iteration.md
+++ b/source/puppet/4.6/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.6/lang_lambdas.md
+++ b/source/puppet/4.6/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (code blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.6/lang_namespaces.markdown
+++ b/source/puppet/4.6/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.6/lang_node_definitions.markdown
+++ b/source/puppet/4.6/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.6/lang_relationships.markdown
+++ b/source/puppet/4.6/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.6/lang_reserved.markdown
+++ b/source/puppet/4.6/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved words and acceptable names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.6/lang_resources.markdown
+++ b/source/puppet/4.6/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.6/lang_resources_advanced.md
+++ b/source/puppet/4.6/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.6/lang_run_stages.markdown
+++ b/source/puppet/4.6/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.6/lang_scope.markdown
+++ b/source/puppet/4.6/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.6/lang_summary.markdown
+++ b/source/puppet/4.6/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.6/lang_tags.markdown
+++ b/source/puppet/4.6/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.6/lang_template.md
+++ b/source/puppet/4.6/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.6/lang_template_epp.md
+++ b/source/puppet/4.6/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) template syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -17,7 +17,7 @@ canonical: "/puppet/latest/reference/lang_template_epp.html"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.6/lang_template_erb.md
+++ b/source/puppet/4.6/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) template syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.6/lang_updating_manifests.markdown
+++ b/source/puppet/4.6/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.6/lang_variables.markdown
+++ b/source/puppet/4.6/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.6/lang_virtual.markdown
+++ b/source/puppet/4.6/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.6/lang_visual_index.markdown
+++ b/source/puppet/4.6/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.6/lang_windows_file_paths.markdown
+++ b/source/puppet/4.6/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling file paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: ./lang_template.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.6/lookup_quick.md
+++ b/source/puppet/4.6/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick reference for Hiera users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.6/lookup_quick_module.md
+++ b/source/puppet/4.6/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick intro to module data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.6/metaparameter.md
+++ b/source/puppet/4.6/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -180,7 +180,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -226,7 +226,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -252,7 +252,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -302,7 +302,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.6/modules_documentation.markdown
+++ b/source/puppet/4.6/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.6/modules_fundamentals.markdown
+++ b/source/puppet/4.6/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.6/modules_installing.markdown
+++ b/source/puppet/4.6/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppet.com

--- a/source/puppet/4.6/modules_metadata.md
+++ b/source/puppet/4.6/modules_metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module metadata and metadata.json"
-canonical: "/puppet/latest/reference/modules_metadata.html"
+canonical: "/puppet/latest/modules_metadata.html"
 ---
 
 [puppet lookup]: ./lookup_quick.html

--- a/source/puppet/4.6/modules_publishing.markdown
+++ b/source/puppet/4.6/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 

--- a/source/puppet/4.6/passenger.markdown
+++ b/source/puppet/4.6/passenger.markdown
@@ -54,7 +54,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -229,8 +229,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.6/puppet_collections.md
+++ b/source/puppet/4.6/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.6/quick_start.markdown
+++ b/source/puppet/4.6/quick_start.markdown
@@ -28,7 +28,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, world!
- Modules contain [classes](/puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](/puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a module
  Next, learn how to install a Puppet module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html).

--- a/source/puppet/4.6/release_notes.markdown
+++ b/source/puppet/4.6/release_notes.markdown
@@ -15,9 +15,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.5 release notes](/puppet/4.5/reference/release_notes.html) and [Puppet 4.4 release notes](/puppet/4.4/reference/release_notes.html).
+Also of interest: the [Puppet 4.5 release notes](/puppet/4.5/release_notes.html) and [Puppet 4.4 release notes](/puppet/4.4/release_notes.html).
 
 ## Puppet 4.6.2
 

--- a/source/puppet/4.6/release_notes_agent.md
+++ b/source/puppet/4.6/release_notes_agent.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "Puppet agent release notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
-[Puppet 4.6.0]: /puppet/4.6/reference/release_notes.html#puppet-460
-[Puppet 4.6.1]: /puppet/4.6/reference/release_notes.html#puppet-461
-[Puppet 4.6.2]: /puppet/4.6/reference/release_notes.html#puppet-462
+[Puppet 4.6.0]: /puppet/4.6/release_notes.html#puppet-460
+[Puppet 4.6.1]: /puppet/4.6/release_notes.html#puppet-461
+[Puppet 4.6.2]: /puppet/4.6/release_notes.html#puppet-462
 
 [Facter 3.4.0]: /facter/3.4/release_notes.html#facter-340
 [Facter 3.4.1]: /facter/3.4/release_notes.html#facter-341
@@ -28,7 +28,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.6 release notes](./release_notes.html).
 

--- a/source/puppet/4.6/report.md
+++ b/source/puppet/4.6/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.6/reporting_about.md
+++ b/source/puppet/4.6/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.6/reporting_write_processors.md
+++ b/source/puppet/4.6/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing custom report processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.6/resources_file_windows.markdown
+++ b/source/puppet/4.6/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.6/resources_service.markdown
+++ b/source/puppet/4.6/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.6/resources_user_group_windows.markdown
+++ b/source/puppet/4.6/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.6/services_agent_unix.markdown
+++ b/source/puppet/4.6/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on *nix systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.6/services_agent_windows.markdown
+++ b/source/puppet/4.6/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on Windows systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.6/services_apply.markdown
+++ b/source/puppet/4.6/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.6/services_master_rack.markdown
+++ b/source/puppet/4.6/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The Rack Puppet master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.6/services_master_webrick.markdown
+++ b/source/puppet/4.6/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The WEBrick Puppet master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.6/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.6/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.6/ssl_autosign.markdown
+++ b/source/puppet/4.6/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: autosigning certificate requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.6/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.6/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating all Certificates in a Puppet deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.6/static_catalogs.md
+++ b/source/puppet/4.6/static_catalogs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Static catalogs"
-canonical: "/puppet/latest/reference/static_catalogs.html"
+canonical: "/puppet/latest/static_catalogs.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.6/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.6/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/master HTTPS communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.6/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.6/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.6/system_requirements.markdown
+++ b/source/puppet/4.6/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet system requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view the pre-install tasks](./install_pre.html).

--- a/source/puppet/4.6/type.md
+++ b/source/puppet/4.6/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 4e0b2b9b2c68e41c386308d71d23d9b26fbfa154
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1294,8 +1294,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1853,7 +1853,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8475,7 +8475,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10052,7 +10052,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.6/upgrade_major_agent.markdown
+++ b/source/puppet/4.6/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x agent upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.6/upgrade_major_post.md
+++ b/source/puppet/4.6/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-upgrade clean-up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.6/upgrade_major_pre.md
+++ b/source/puppet/4.6/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get upgrade-ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x release notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 ## You're ready!
 

--- a/source/puppet/4.6/upgrade_major_server.markdown
+++ b/source/puppet/4.6/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -20,7 +20,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -67,7 +67,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -165,13 +165,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.6/upgrade_minor.md
+++ b/source/puppet/4.6/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.6/whered_it_go.markdown
+++ b/source/puppet/4.6/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.7/about_agent.md
+++ b/source/puppet/4.7/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What is it, and what's in it?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: {{facter}}/
@@ -27,7 +27,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's up with the version numbers?
 

--- a/source/puppet/4.7/config_about_settings.markdown
+++ b/source/puppet/4.7/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.7/config_file_auth.markdown
+++ b/source/puppet/4.7/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: auth.conf (LEGACY)"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.7/config_file_autosign.markdown
+++ b/source/puppet/4.7/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.7/config_file_csr_attributes.markdown
+++ b/source/puppet/4.7/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.7/config_file_device.markdown
+++ b/source/puppet/4.7/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.7/config_file_environment.markdown
+++ b/source/puppet/4.7/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.7/config_file_fileserver.markdown
+++ b/source/puppet/4.7/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.7/config_file_hiera.markdown
+++ b/source/puppet/4.7/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.7/config_file_main.markdown
+++ b/source/puppet/4.7/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: The main config file (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.7/config_file_oid_map.md
+++ b/source/puppet/4.7/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.7/config_file_puppetdb.markdown
+++ b/source/puppet/4.7/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: {{puppetdb}}/puppetdb_connection.html

--- a/source/puppet/4.7/config_file_routes.markdown
+++ b/source/puppet/4.7/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.7/config_important_settings.markdown
+++ b/source/puppet/4.7/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short list of important settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.7/config_print.markdown
+++ b/source/puppet/4.7/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking values of settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.7/config_set.markdown
+++ b/source/puppet/4.7/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing settings on the command line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.7/configuration.md
+++ b/source/puppet/4.7/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 569f28bea57644ed05719c92ecf19fcc532111aa
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -39,7 +39,7 @@ canonical: /puppet/latest/reference/configuration.html
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -605,7 +605,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -685,7 +685,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1077,7 +1077,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1173,7 +1173,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1244,7 +1244,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1425,7 +1425,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.7/deprecated_language.markdown
+++ b/source/puppet/4.7/deprecated_language.markdown
@@ -19,7 +19,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.7/deprecated_win2003.md
+++ b/source/puppet/4.7/deprecated_win2003.md
@@ -6,4 +6,4 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.

--- a/source/puppet/4.7/dirs_codedir.markdown
+++ b/source/puppet/4.7/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and data directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.7/dirs_confdir.markdown
+++ b/source/puppet/4.7/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: {{puppetserver}}/config_file_puppetserver.html

--- a/source/puppet/4.7/dirs_manifest.markdown
+++ b/source/puppet/4.7/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The main manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.7/dirs_modulepath.markdown
+++ b/source/puppet/4.7/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The modulepath (default config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.7/dirs_ssldir.markdown
+++ b/source/puppet/4.7/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.7/dirs_vardir.markdown
+++ b/source/puppet/4.7/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The cache directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.7/environment_isolation.md
+++ b/source/puppet/4.7/environment_isolation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environment Isolation"
-canonical: "/puppet/latest/reference/environment_isolation.html"
+canonical: "/puppet/latest/environment_isolation.html"
 ---
 
 

--- a/source/puppet/4.7/environments.markdown
+++ b/source/puppet/4.7/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.7/environments_https.markdown
+++ b/source/puppet/4.7/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.7/environments_limitations.markdown
+++ b/source/puppet/4.7/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.7/environments_suggestions.markdown
+++ b/source/puppet/4.7/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.7/experiments_msgpack.markdown
+++ b/source/puppet/4.7/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Msgpack support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 ## Background on Msgpack

--- a/source/puppet/4.7/experiments_overview.markdown
+++ b/source/puppet/4.7/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.7/format_report.markdown
+++ b/source/puppet/4.7/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.7/function.md
+++ b/source/puppet/4.7/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -306,7 +306,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -397,7 +397,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -420,12 +420,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -478,7 +478,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -638,7 +638,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -708,7 +708,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -786,7 +786,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -869,7 +869,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -939,12 +939,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -962,7 +962,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -978,14 +978,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -993,7 +993,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1069,7 +1069,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1168,7 +1168,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1826,7 +1826,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1996,7 +1996,7 @@ resource and relationship expressions.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2183,7 +2183,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -2295,7 +2295,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -2444,9 +2444,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.7/index.md
+++ b/source/puppet/4.7/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.7 reference manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.7/indirection.md
+++ b/source/puppet/4.7/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 569f28bea57644ed05719c92ecf19fcc532111aa
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.7/install_linux.markdown
+++ b/source/puppet/4.7/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.7/install_osx.md
+++ b/source/puppet/4.7/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.7/install_pre.markdown
+++ b/source/puppet/4.7/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-install tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.7/install_windows.markdown
+++ b/source/puppet/4.7/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/
@@ -102,10 +102,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.7/lang_classes.markdown
+++ b/source/puppet/4.7/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.7/lang_collectors.markdown
+++ b/source/puppet/4.7/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.7/lang_comments.markdown
+++ b/source/puppet/4.7/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.7/lang_conditional.markdown
+++ b/source/puppet/4.7/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional statements and expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.7/lang_containment.markdown
+++ b/source/puppet/4.7/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.7/lang_data.md
+++ b/source/puppet/4.7/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About values and data types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.7/lang_data_abstract.md
+++ b/source/puppet/4.7/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Abstract data types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.7/lang_data_array.md
+++ b/source/puppet/4.7/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.7/lang_data_boolean.md
+++ b/source/puppet/4.7/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.7/lang_data_default.md
+++ b/source/puppet/4.7/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.7/lang_data_hash.md
+++ b/source/puppet/4.7/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.7/lang_data_number.md
+++ b/source/puppet/4.7/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.7/lang_data_regexp.md
+++ b/source/puppet/4.7/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Regular expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.7/lang_data_resource_reference.md
+++ b/source/puppet/4.7/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Resource and class references"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.7/lang_data_resource_type.md
+++ b/source/puppet/4.7/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: resource types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.7/lang_data_sensitive.md
+++ b/source/puppet/4.7/lang_data_sensitive.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Sensitive"
-canonical: "/puppet/latest/reference/lang_data_sensitive.html"
+canonical: "/puppet/latest/lang_data_sensitive.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.7/lang_data_string.md
+++ b/source/puppet/4.7/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.7/lang_data_type.md
+++ b/source/puppet/4.7/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Data type syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.7/lang_data_undef.md
+++ b/source/puppet/4.7/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.7/lang_defaults.markdown
+++ b/source/puppet/4.7/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource default statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.7/lang_defined_types.markdown
+++ b/source/puppet/4.7/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined resource types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.7/lang_exported.markdown
+++ b/source/puppet/4.7/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.7/lang_expressions.markdown
+++ b/source/puppet/4.7/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html

--- a/source/puppet/4.7/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.7/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and built-in variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.7/lang_functions.markdown
+++ b/source/puppet/4.7/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.7/lang_iteration.md
+++ b/source/puppet/4.7/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.7/lang_lambdas.md
+++ b/source/puppet/4.7/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (code blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.7/lang_namespaces.markdown
+++ b/source/puppet/4.7/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.7/lang_node_definitions.markdown
+++ b/source/puppet/4.7/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.7/lang_relationships.markdown
+++ b/source/puppet/4.7/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.7/lang_reserved.markdown
+++ b/source/puppet/4.7/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved words and acceptable names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.7/lang_resources.markdown
+++ b/source/puppet/4.7/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.7/lang_resources_advanced.md
+++ b/source/puppet/4.7/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.7/lang_run_stages.markdown
+++ b/source/puppet/4.7/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.7/lang_scope.markdown
+++ b/source/puppet/4.7/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.7/lang_summary.markdown
+++ b/source/puppet/4.7/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.7/lang_tags.markdown
+++ b/source/puppet/4.7/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.7/lang_template.md
+++ b/source/puppet/4.7/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.7/lang_template_epp.md
+++ b/source/puppet/4.7/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) template syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -17,7 +17,7 @@ canonical: "/puppet/latest/reference/lang_template_epp.html"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.7/lang_template_erb.md
+++ b/source/puppet/4.7/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) template syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.7/lang_updating_manifests.markdown
+++ b/source/puppet/4.7/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.7/lang_variables.markdown
+++ b/source/puppet/4.7/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.7/lang_virtual.markdown
+++ b/source/puppet/4.7/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.7/lang_visual_index.markdown
+++ b/source/puppet/4.7/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.7/lang_windows_file_paths.markdown
+++ b/source/puppet/4.7/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling file paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: ./lang_template.html
@@ -59,7 +59,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.7/lookup_quick.md
+++ b/source/puppet/4.7/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick reference for Hiera users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.7/lookup_quick_module.md
+++ b/source/puppet/4.7/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick intro to module data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.7/metaparameter.md
+++ b/source/puppet/4.7/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 569f28bea57644ed05719c92ecf19fcc532111aa
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -180,7 +180,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -226,7 +226,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -252,7 +252,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -302,7 +302,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.7/modules_documentation.markdown
+++ b/source/puppet/4.7/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.7/modules_fundamentals.markdown
+++ b/source/puppet/4.7/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.7/modules_installing.markdown
+++ b/source/puppet/4.7/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppet.com

--- a/source/puppet/4.7/modules_metadata.md
+++ b/source/puppet/4.7/modules_metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module metadata and metadata.json"
-canonical: "/puppet/latest/reference/modules_metadata.html"
+canonical: "/puppet/latest/modules_metadata.html"
 ---
 
 [puppet lookup]: ./lookup_quick.html

--- a/source/puppet/4.7/modules_publishing.markdown
+++ b/source/puppet/4.7/modules_publishing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Publishing modules on the Puppet Forge"
-canonical: "/puppet/latest/reference/modules_publishing.html"
+canonical: "/puppet/latest/modules_publishing.html"
 ---
 
 

--- a/source/puppet/4.7/passenger.markdown
+++ b/source/puppet/4.7/passenger.markdown
@@ -54,7 +54,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -229,8 +229,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.7/puppet_collections.md
+++ b/source/puppet/4.7/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.7/quick_start.markdown
+++ b/source/puppet/4.7/quick_start.markdown
@@ -28,7 +28,7 @@ Learn how to create a Puppet user and group with [these instructions](./quick_st
 Instructions are available for *nix only.
 
 ### 4. Hello, world!
- Modules contain [classes](./puppet/3.8/reference/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
+ Modules contain [classes](./puppet/3.8/lang_classes.html), which are named chunks of Puppet code and are the primary means by which Puppet configures and manages nodes. The instructions in the [Hello World! Quick Start Guide](./quick_start_helloworld.html) lead you through the fundamentals of Puppet module writing. You'll write a very simple module that contains classes to manage your message of the day (motd) and create a Hello, World! notification on the command line.
 
 ### 5. Install a module
  Next, learn how to install a Puppet module by following the [Module Installation Quick Start Guide](./quick_start_module_install_nix.html).

--- a/source/puppet/4.7/release_notes.markdown
+++ b/source/puppet/4.7/release_notes.markdown
@@ -18,9 +18,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.6 release notes](/puppet/4.6/reference/release_notes.html) and [Puppet 4.5 release notes](/puppet/4.5/reference/release_notes.html).
+Also of interest: the [Puppet 4.6 release notes](/puppet/4.6/release_notes.html) and [Puppet 4.5 release notes](/puppet/4.5/release_notes.html).
 
 
 >**Note**: This version of Puppet is included in the Long Term Support release [Puppet Enterprise 2016.4][], so while there may be [newer versions of Puppet](/puppet/latest) available (and sometimes referenced in these release notes), we will continue updating this version until Puppet Enterprise 2016.4 reaches end of life.

--- a/source/puppet/4.7/release_notes_agent.md
+++ b/source/puppet/4.7/release_notes_agent.md
@@ -32,7 +32,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html) and the [Puppet 4.7 release notes](./release_notes.html).
 

--- a/source/puppet/4.7/report.md
+++ b/source/puppet/4.7/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 569f28bea57644ed05719c92ecf19fcc532111aa
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.7/reporting_about.md
+++ b/source/puppet/4.7/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.7/reporting_write_processors.md
+++ b/source/puppet/4.7/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing custom report processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.7/resources_file_windows.markdown
+++ b/source/puppet/4.7/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.7/resources_service.markdown
+++ b/source/puppet/4.7/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.7/resources_user_group_windows.markdown
+++ b/source/puppet/4.7/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.7/services_agent_unix.markdown
+++ b/source/puppet/4.7/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on *nix systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.7/services_agent_windows.markdown
+++ b/source/puppet/4.7/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on Windows systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.7/services_apply.markdown
+++ b/source/puppet/4.7/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.7/services_master_rack.markdown
+++ b/source/puppet/4.7/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The Rack Puppet master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.7/services_master_webrick.markdown
+++ b/source/puppet/4.7/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The WEBrick Puppet master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.7/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.7/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.7/ssl_autosign.markdown
+++ b/source/puppet/4.7/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: autosigning certificate requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.7/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.7/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating all Certificates in a Puppet deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.7/static_catalogs.md
+++ b/source/puppet/4.7/static_catalogs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Static catalogs"
-canonical: "/puppet/latest/reference/static_catalogs.html"
+canonical: "/puppet/latest/static_catalogs.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.7/style_guide.markdown
+++ b/source/puppet/4.7/style_guide.markdown
@@ -243,7 +243,7 @@ Every module must have metadata defined in the metadata.json file.  Your metadat
     }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 ### 8.1 Dependencies
 
@@ -809,7 +809,7 @@ You should help indicate to the user which classes are which by making sure all 
 
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -927,7 +927,7 @@ class my_module(
 
 Exported resources should be opt-in rather than opt-out. Your module should not be written to use exported resources to function by default unless it is expressly required. When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 
@@ -1154,9 +1154,9 @@ All publicly available modules should include the documentation covered below.
 
 ### 17.1 README
 
-Your module should have a README in .md (or .markdown) format. READMEs help users of your module get the full benefit of your work. The [Puppet README template](https://docs.puppet.com/puppet/latest/reference/READMEtemplate.txt) offers a basic format you can use. If you create modules with `puppet module generate`, the generated README includes the template. Using the .md/.markdown format allows your README to be parsed and displayed by Puppet Strings, GitHub, and the Puppet Forge.
+Your module should have a README in .md (or .markdown) format. READMEs help users of your module get the full benefit of your work. The [Puppet README template](https://docs.puppet.com/puppet/latest/READMEtemplate.txt) offers a basic format you can use. If you create modules with `puppet module generate`, the generated README includes the template. Using the .md/.markdown format allows your README to be parsed and displayed by Puppet Strings, GitHub, and the Puppet Forge.
 
-There's an entire [guide](https://docs.puppet.com/puppet/latest/reference/modules_documentation.html) to writing a great README, but overall your README should:
+There's an entire [guide](https://docs.puppet.com/puppet/latest/modules_documentation.html) to writing a great README, but overall your README should:
 
 * Summarize what your module does.
 * Note any setup requirements or limitations (such as "This module requires the puppetlabs-apache module and only works on Ubuntu.").

--- a/source/puppet/4.7/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.7/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/master HTTPS communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.7/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.7/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.7/system_requirements.markdown
+++ b/source/puppet/4.7/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet system requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view the pre-install tasks](./install_pre.html).

--- a/source/puppet/4.7/type.md
+++ b/source/puppet/4.7/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 569f28bea57644ed05719c92ecf19fcc532111aa
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1294,8 +1294,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1853,7 +1853,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8474,7 +8474,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10051,7 +10051,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.7/upgrade_major_agent.markdown
+++ b/source/puppet/4.7/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x agent upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.7/upgrade_major_post.md
+++ b/source/puppet/4.7/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-upgrade clean-up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.7/upgrade_major_pre.md
+++ b/source/puppet/4.7/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get upgrade-ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x release notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 ## You're ready!
 

--- a/source/puppet/4.7/upgrade_major_server.markdown
+++ b/source/puppet/4.7/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -20,7 +20,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -67,7 +67,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -165,13 +165,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.7/upgrade_minor.md
+++ b/source/puppet/4.7/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.7/whered_it_go.markdown
+++ b/source/puppet/4.7/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.8/about_agent.md
+++ b/source/puppet/4.8/about_agent.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "puppet-agent: What is it, and what's in it?"
-canonical: "/puppet/latest/reference/about_agent.html"
+canonical: "/puppet/latest/about_agent.html"
 ---
 
 [Facter]: {{facter}}/
@@ -27,7 +27,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages:
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/reference/pre_install.html#next-install-puppet).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent). To install Puppet agent on Puppet 3, see the [Puppet 3 installation documentation](/puppet/3.8/pre_install.html#next-install-puppet).
 
 ## What's up with the version numbers?
 

--- a/source/puppet/4.8/config_about_settings.markdown
+++ b/source/puppet/4.8/config_about_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: How Puppet is configured"
-canonical: "/puppet/latest/reference/config_about_settings.html"
+canonical: "/puppet/latest/config_about_settings.html"
 ---
 
 [short list]: ./config_important_settings.html

--- a/source/puppet/4.8/config_file_auth.markdown
+++ b/source/puppet/4.8/config_file_auth.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: auth.conf (LEGACY)"
-canonical: "/puppet/latest/reference/config_file_auth.html"
+canonical: "/puppet/latest/config_file_auth.html"
 ---
 
 [rest_authconfig]: ./configuration.html#restauthconfig

--- a/source/puppet/4.8/config_file_autosign.markdown
+++ b/source/puppet/4.8/config_file_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: autosign.conf"
-canonical: "/puppet/latest/reference/config_file_autosign.html"
+canonical: "/puppet/latest/config_file_autosign.html"
 ---
 
 [autosigning]: ./ssl_autosign.html

--- a/source/puppet/4.8/config_file_csr_attributes.markdown
+++ b/source/puppet/4.8/config_file_csr_attributes.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "Config files: csr_attributes.yaml"
-canonical: "/puppet/latest/reference/config_file_csr_attributes.html"
+canonical: "/puppet/latest/config_file_csr_attributes.html"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.8/config_file_device.markdown
+++ b/source/puppet/4.8/config_file_device.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: device.conf"
-canonical: "/puppet/latest/reference/config_file_device.html"
+canonical: "/puppet/latest/config_file_device.html"
 ---
 
 [deviceconfig]: ./configuration.html#deviceconfig

--- a/source/puppet/4.8/config_file_environment.markdown
+++ b/source/puppet/4.8/config_file_environment.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: "Config files: environment.conf"
-canonical: "/puppet/latest/reference/config_file_environment.html"
+canonical: "/puppet/latest/config_file_environment.html"
 ---
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.8/config_file_fileserver.markdown
+++ b/source/puppet/4.8/config_file_fileserver.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: fileserver.conf"
-canonical: "/puppet/latest/reference/config_file_fileserver.html"
+canonical: "/puppet/latest/config_file_fileserver.html"
 ---
 
 [file]: ./type.html#file

--- a/source/puppet/4.8/config_file_hiera.markdown
+++ b/source/puppet/4.8/config_file_hiera.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config Files: hiera.yaml"
-canonical: "/puppet/latest/reference/config_file_hiera.html"
+canonical: "/puppet/latest/config_file_hiera.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.8/config_file_main.markdown
+++ b/source/puppet/4.8/config_file_main.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: The main config file (puppet.conf)"
-canonical: "/puppet/latest/reference/config_file_main.html"
+canonical: "/puppet/latest/config_file_main.html"
 ---
 
 [conf_ref]: ./configuration.html

--- a/source/puppet/4.8/config_file_oid_map.md
+++ b/source/puppet/4.8/config_file_oid_map.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: custom_trusted_oid_mapping.yaml"
-canonical: "/puppet/latest/reference/config_file_oid_map.html"
+canonical: "/puppet/latest/config_file_oid_map.html"
 ---
 
 [extensions]: ./ssl_attributes_extensions.html

--- a/source/puppet/4.8/config_file_puppetdb.markdown
+++ b/source/puppet/4.8/config_file_puppetdb.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: puppetdb.conf"
-canonical: "/puppet/latest/reference/config_file_puppetdb.html"
+canonical: "/puppet/latest/config_file_puppetdb.html"
 ---
 
 [puppetdb_connection]: {{puppetdb}}/puppetdb_connection.html

--- a/source/puppet/4.8/config_file_routes.markdown
+++ b/source/puppet/4.8/config_file_routes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Config files: routes.yaml"
-canonical: "/puppet/latest/reference/config_file_routes.html"
+canonical: "/puppet/latest/config_file_routes.html"
 ---
 
 [route_file]: ./configuration.html#routefile

--- a/source/puppet/4.8/config_important_settings.markdown
+++ b/source/puppet/4.8/config_important_settings.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Short list of important settings"
-canonical: "/puppet/latest/reference/config_important_settings.html"
+canonical: "/puppet/latest/config_important_settings.html"
 ---
 
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line

--- a/source/puppet/4.8/config_print.markdown
+++ b/source/puppet/4.8/config_print.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Checking values of settings"
-canonical: "/puppet/latest/reference/config_print.html"
+canonical: "/puppet/latest/config_print.html"
 ---
 
 

--- a/source/puppet/4.8/config_set.markdown
+++ b/source/puppet/4.8/config_set.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Configuration: Editing settings on the command line"
-canonical: "/puppet/latest/reference/config_set.html"
+canonical: "/puppet/latest/config_set.html"
 ---
 
 [config_sections]: ./config_file_main.html#config-sections

--- a/source/puppet/4.8/configuration.md
+++ b/source/puppet/4.8/configuration.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Configuration Reference
 toc: columns
-canonical: /puppet/latest/reference/configuration.html
+canonical: /puppet/latest/configuration.html
 ---
 
 
@@ -39,7 +39,7 @@ canonical: /puppet/latest/reference/configuration.html
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -605,7 +605,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -685,7 +685,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1077,7 +1077,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1173,7 +1173,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1244,7 +1244,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1425,7 +1425,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.8/deprecated_language.markdown
+++ b/source/puppet/4.8/deprecated_language.markdown
@@ -25,7 +25,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.8/deprecated_win2003.md
+++ b/source/puppet/4.8/deprecated_win2003.md
@@ -6,4 +6,4 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet Agent package fails to install on Windows Server 2003 and 2003 R2.

--- a/source/puppet/4.8/dirs_codedir.markdown
+++ b/source/puppet/4.8/dirs_codedir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Code and data directory (codedir)"
-canonical: "/puppet/latest/reference/dirs_codedir.html"
+canonical: "/puppet/latest/dirs_codedir.html"
 ---
 
 [codedir]: ./configuration.html#codedir

--- a/source/puppet/4.8/dirs_confdir.markdown
+++ b/source/puppet/4.8/dirs_confdir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: Config directory (confdir)"
-canonical: "/puppet/latest/reference/dirs_confdir.html"
+canonical: "/puppet/latest/dirs_confdir.html"
 ---
 
 [puppetserver_conf]: {{puppetserver}}/config_file_puppetserver.html

--- a/source/puppet/4.8/dirs_manifest.markdown
+++ b/source/puppet/4.8/dirs_manifest.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The main manifest(s)"
-canonical: "/puppet/latest/reference/dirs_manifest.html"
+canonical: "/puppet/latest/dirs_manifest.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.8/dirs_modulepath.markdown
+++ b/source/puppet/4.8/dirs_modulepath.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The modulepath (default config)"
-canonical: "/puppet/latest/reference/dirs_modulepath.html"
+canonical: "/puppet/latest/dirs_modulepath.html"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html

--- a/source/puppet/4.8/dirs_ssldir.markdown
+++ b/source/puppet/4.8/dirs_ssldir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The SSLdir"
-canonical: "/puppet/latest/reference/dirs_ssldir.html"
+canonical: "/puppet/latest/dirs_ssldir.html"
 ---
 
 

--- a/source/puppet/4.8/dirs_vardir.markdown
+++ b/source/puppet/4.8/dirs_vardir.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Directories: The cache directory (vardir)"
-canonical: "/puppet/latest/reference/dirs_vardir.html"
+canonical: "/puppet/latest/dirs_vardir.html"
 ---
 
 [confdir]: ./dirs_confdir.html

--- a/source/puppet/4.8/environments.markdown
+++ b/source/puppet/4.8/environments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About environments"
-canonical: "/puppet/latest/reference/environments.html"
+canonical: "/puppet/latest/environments.html"
 ---
 
 

--- a/source/puppet/4.8/environments_https.markdown
+++ b/source/puppet/4.8/environments_https.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments and Puppet's HTTPS interface"
-canonical: "/puppet/latest/reference/environments_https.html"
+canonical: "/puppet/latest/environments_https.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.8/environments_limitations.markdown
+++ b/source/puppet/4.8/environments_limitations.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Limitations of environments"
-canonical: "/puppet/latest/reference/environments_limitations.html"
+canonical: "/puppet/latest/environments_limitations.html"
 ---
 
 [env_var]: ./environments.html#referencing-the-environment-in-manifests

--- a/source/puppet/4.8/environments_suggestions.markdown
+++ b/source/puppet/4.8/environments_suggestions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Environments: Suggestions for Use"
-canonical: "/puppet/latest/reference/environments_suggestions.html"
+canonical: "/puppet/latest/environments_suggestions.html"
 ---
 
 [adrien_blog]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments

--- a/source/puppet/4.8/experiments_msgpack.markdown
+++ b/source/puppet/4.8/experiments_msgpack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Msgpack support"
-canonical: "/puppet/latest/reference/experiments_msgpack.html"
+canonical: "/puppet/latest/experiments_msgpack.html"
 ---
 
 ## Background on Msgpack

--- a/source/puppet/4.8/experiments_overview.markdown
+++ b/source/puppet/4.8/experiments_overview.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Experimental features: Overview"
-canonical: "/puppet/latest/reference/experiments_overview.html"
+canonical: "/puppet/latest/experiments_overview.html"
 ---
 
 

--- a/source/puppet/4.8/format_report.markdown
+++ b/source/puppet/4.8/format_report.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Formats: Reports"
-canonical: "/puppet/latest/reference/format_report.html"
+canonical: "/puppet/latest/format_report.html"
 ---
 
 

--- a/source/puppet/4.8/function.md
+++ b/source/puppet/4.8/function.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Function Reference
 toc: columns
-canonical: /puppet/latest/reference/function.html
+canonical: /puppet/latest/function.html
 ---
 
 
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -366,7 +366,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -457,7 +457,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -480,12 +480,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -538,7 +538,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -721,7 +721,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -791,7 +791,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -869,7 +869,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -952,7 +952,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1023,12 +1023,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1046,7 +1046,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1062,14 +1062,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1077,7 +1077,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1153,7 +1153,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1252,7 +1252,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2342,7 +2342,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2581,7 +2581,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2773,7 +2773,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3067,7 +3067,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3216,9 +3216,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.8/index.md
+++ b/source/puppet/4.8/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 4.8 reference manual"
-canonical: "/puppet/latest/reference/index.html"
+canonical: "/puppet/latest/index.html"
 toc: false
 ---
 

--- a/source/puppet/4.8/indirection.md
+++ b/source/puppet/4.8/indirection.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Indirection Reference
 toc: columns
-canonical: /puppet/latest/reference/indirection.html
+canonical: /puppet/latest/indirection.html
 ---
 
 

--- a/source/puppet/4.8/install_linux.markdown
+++ b/source/puppet/4.8/install_linux.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet agent: Linux"
-canonical: "/puppet/latest/reference/install_linux.html"
+canonical: "/puppet/latest/install_linux.html"
 ---
 
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.8/install_osx.md
+++ b/source/puppet/4.8/install_osx.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: OS X"
-canonical: "/puppet/latest/reference/install_osx.html"
+canonical: "/puppet/latest/install_osx.html"
 ---
 
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.8/install_pre.markdown
+++ b/source/puppet/4.8/install_pre.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Installing Puppet: Pre-install tasks"
-canonical: "/puppet/latest/reference/install_pre.html"
+canonical: "/puppet/latest/install_pre.html"
 ---
 
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.8/install_windows.markdown
+++ b/source/puppet/4.8/install_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing Puppet agent: Microsoft Windows"
-canonical: "/puppet/latest/reference/install_windows.html"
+canonical: "/puppet/latest/install_windows.html"
 ---
 
 [downloads]: https://downloads.puppetlabs.com/windows/
@@ -95,10 +95,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.8/lang_classes.markdown
+++ b/source/puppet/4.8/lang_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Classes"
-canonical: "/puppet/latest/reference/lang_classes.html"
+canonical: "/puppet/latest/lang_classes.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.8/lang_collectors.markdown
+++ b/source/puppet/4.8/lang_collectors.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource collectors"
-canonical: "/puppet/latest/reference/lang_collectors.html"
+canonical: "/puppet/latest/lang_collectors.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.8/lang_comments.markdown
+++ b/source/puppet/4.8/lang_comments.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Comments"
-canonical: "/puppet/latest/reference/lang_comments.html"
+canonical: "/puppet/latest/lang_comments.html"
 ---
 
 Puppet supports two kinds of comments:

--- a/source/puppet/4.8/lang_conditional.markdown
+++ b/source/puppet/4.8/lang_conditional.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Conditional statements and expressions"
 layout: default
-canonical: "/puppet/latest/reference/lang_conditional.html"
+canonical: "/puppet/latest/lang_conditional.html"
 ---
 
 

--- a/source/puppet/4.8/lang_containment.markdown
+++ b/source/puppet/4.8/lang_containment.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Containment of resources"
-canonical: "/puppet/latest/reference/lang_containment.html"
+canonical: "/puppet/latest/lang_containment.html"
 ---
 
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib

--- a/source/puppet/4.8/lang_data.md
+++ b/source/puppet/4.8/lang_data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: About values and data types"
-canonical: "/puppet/latest/reference/lang_data.html"
+canonical: "/puppet/latest/lang_data.html"
 ---
 
 

--- a/source/puppet/4.8/lang_data_abstract.md
+++ b/source/puppet/4.8/lang_data_abstract.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Abstract data types"
-canonical: "/puppet/latest/reference/lang_data_abstract.html"
+canonical: "/puppet/latest/lang_data_abstract.html"
 ---
 
 [types]: ./lang_data_type.html

--- a/source/puppet/4.8/lang_data_array.md
+++ b/source/puppet/4.8/lang_data_array.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Arrays"
-canonical: "/puppet/latest/reference/lang_data_array.html"
+canonical: "/puppet/latest/lang_data_array.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.8/lang_data_boolean.md
+++ b/source/puppet/4.8/lang_data_boolean.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Booleans"
-canonical: "/puppet/latest/reference/lang_data_boolean.html"
+canonical: "/puppet/latest/lang_data_boolean.html"
 ---
 
 [if]: ./lang_conditional.html#if-statements

--- a/source/puppet/4.8/lang_data_default.md
+++ b/source/puppet/4.8/lang_data_default.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Default"
-canonical: "/puppet/latest/reference/lang_data_default.html"
+canonical: "/puppet/latest/lang_data_default.html"
 ---
 
 [case statements]: ./lang_conditional.html#case-statements

--- a/source/puppet/4.8/lang_data_hash.md
+++ b/source/puppet/4.8/lang_data_hash.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Hashes"
-canonical: "/puppet/latest/reference/lang_data_hash.html"
+canonical: "/puppet/latest/lang_data_hash.html"
 ---
 
 [undef]: ./lang_data_undef.html

--- a/source/puppet/4.8/lang_data_number.md
+++ b/source/puppet/4.8/lang_data_number.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Numbers"
-canonical: "/puppet/latest/reference/lang_data_number.html"
+canonical: "/puppet/latest/lang_data_number.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.8/lang_data_regexp.md
+++ b/source/puppet/4.8/lang_data_regexp.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Regular expressions"
-canonical: "/puppet/latest/reference/lang_data_regexp.html"
+canonical: "/puppet/latest/lang_data_regexp.html"
 ---
 
 [regsubst]: ./function.html#regsubst

--- a/source/puppet/4.8/lang_data_resource_reference.md
+++ b/source/puppet/4.8/lang_data_resource_reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Resource and class references"
-canonical: "/puppet/latest/reference/lang_data_resource_reference.html"
+canonical: "/puppet/latest/lang_data_resource_reference.html"
 ---
 
 [relationship]: ./lang_relationships.html

--- a/source/puppet/4.8/lang_data_resource_type.md
+++ b/source/puppet/4.8/lang_data_resource_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: resource types"
-canonical: "/puppet/latest/reference/lang_data_resource_type.html"
+canonical: "/puppet/latest/lang_data_resource_type.html"
 ---
 
 [data type]: ./lang_data_type.html

--- a/source/puppet/4.8/lang_data_sensitive.md
+++ b/source/puppet/4.8/lang_data_sensitive.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Sensitive"
-canonical: "/puppet/latest/reference/lang_data_sensitive.html"
+canonical: "/puppet/latest/lang_data_sensitive.html"
 ---
 
 [arithmetic]: ./lang_expressions.html#arithmetic-operators

--- a/source/puppet/4.8/lang_data_string.md
+++ b/source/puppet/4.8/lang_data_string.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Strings"
-canonical: "/puppet/latest/reference/lang_data_string.html"
+canonical: "/puppet/latest/lang_data_string.html"
 ---
 
 [variables]: ./lang_variables.html

--- a/source/puppet/4.8/lang_data_type.md
+++ b/source/puppet/4.8/lang_data_type.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Data type syntax"
-canonical: "/puppet/latest/reference/lang_data_type.html"
+canonical: "/puppet/latest/lang_data_type.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.8/lang_data_undef.md
+++ b/source/puppet/4.8/lang_data_undef.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Data types: Undef"
-canonical: "/puppet/latest/reference/lang_data_undef.html"
+canonical: "/puppet/latest/lang_data_undef.html"
 ---
 
 

--- a/source/puppet/4.8/lang_defaults.markdown
+++ b/source/puppet/4.8/lang_defaults.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resource default statements"
-canonical: "/puppet/latest/reference/lang_defaults.html"
+canonical: "/puppet/latest/lang_defaults.html"
 ---
 
 [sitemanifest]: ./dirs_manifest.html

--- a/source/puppet/4.8/lang_defined_types.markdown
+++ b/source/puppet/4.8/lang_defined_types.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Defined resource types"
 layout: default
-canonical: "/puppet/latest/reference/lang_defined_types.html"
+canonical: "/puppet/latest/lang_defined_types.html"
 ---
 
 [literal_types]: ./lang_data_type.html

--- a/source/puppet/4.8/lang_exported.markdown
+++ b/source/puppet/4.8/lang_exported.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Exported resources"
-canonical: "/puppet/latest/reference/lang_exported.html"
+canonical: "/puppet/latest/lang_exported.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.8/lang_expressions.markdown
+++ b/source/puppet/4.8/lang_expressions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Expressions and operators"
 layout: default
-canonical: "/puppet/latest/reference/lang_expressions.html"
+canonical: "/puppet/latest/lang_expressions.html"
 ---
 
 [datatypes]: ./lang_data.html

--- a/source/puppet/4.8/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.8/lang_facts_and_builtin_vars.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Facts and built-in variables"
-canonical: "/puppet/latest/reference/lang_facts_and_builtin_vars.html"
+canonical: "/puppet/latest/lang_facts_and_builtin_vars.html"
 ---
 
 [definedtype]: ./lang_defined_types.html

--- a/source/puppet/4.8/lang_functions.markdown
+++ b/source/puppet/4.8/lang_functions.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Language: Functions"
 layout: default
-canonical: "/puppet/latest/reference/lang_functions.html"
+canonical: "/puppet/latest/lang_functions.html"
 ---
 
 [func_ref]: ./function.html

--- a/source/puppet/4.8/lang_iteration.md
+++ b/source/puppet/4.8/lang_iteration.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Iteration and loops"
 layout: default
-canonical: "/puppet/latest/reference/lang_iteration.html"
+canonical: "/puppet/latest/lang_iteration.html"
 ---
 
 [functions]: ./lang_functions.html

--- a/source/puppet/4.8/lang_lambdas.md
+++ b/source/puppet/4.8/lang_lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: "Language: Lambdas (code blocks)"
 layout: default
-canonical: "/puppet/latest/reference/lang_lambdas.html"
+canonical: "/puppet/latest/lang_lambdas.html"
 ---
 
 [define_unique]: ./lang_defined_types.html#resource-uniqueness

--- a/source/puppet/4.8/lang_namespaces.markdown
+++ b/source/puppet/4.8/lang_namespaces.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Namespaces and autoloading"
-canonical: "/puppet/latest/reference/lang_namespaces.html"
+canonical: "/puppet/latest/lang_namespaces.html"
 ---
 
 [classes]: ./lang_classes.html

--- a/source/puppet/4.8/lang_node_definitions.markdown
+++ b/source/puppet/4.8/lang_node_definitions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Node definitions"
-canonical: "/puppet/latest/reference/lang_node_definitions.html"
+canonical: "/puppet/latest/lang_node_definitions.html"
 ---
 
 [hiera]: {{hiera}}/

--- a/source/puppet/4.8/lang_relationships.markdown
+++ b/source/puppet/4.8/lang_relationships.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Relationships and ordering"
-canonical: "/puppet/latest/reference/lang_relationships.html"
+canonical: "/puppet/latest/lang_relationships.html"
 ---
 
 [virtual]: ./lang_virtual.html

--- a/source/puppet/4.8/lang_reserved.markdown
+++ b/source/puppet/4.8/lang_reserved.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Reserved words and acceptable names"
-canonical: "/puppet/latest/reference/lang_reserved.html"
+canonical: "/puppet/latest/lang_reserved.html"
 ---
 
 [settings]: ./config_about_settings.html

--- a/source/puppet/4.8/lang_resources.markdown
+++ b/source/puppet/4.8/lang_resources.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources"
-canonical: "/puppet/latest/reference/lang_resources.html"
+canonical: "/puppet/latest/lang_resources.html"
 ---
 
 [realize]: ./lang_virtual.html#syntax
@@ -18,9 +18,9 @@ canonical: "/puppet/latest/reference/lang_resources.html"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -203,6 +203,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.8/lang_resources_advanced.md
+++ b/source/puppet/4.8/lang_resources_advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Resources (advanced)"
-canonical: "/puppet/latest/reference/lang_resources_advanced.html"
+canonical: "/puppet/latest/lang_resources_advanced.html"
 ---
 
 

--- a/source/puppet/4.8/lang_run_stages.markdown
+++ b/source/puppet/4.8/lang_run_stages.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Run stages"
-canonical: "/puppet/latest/reference/lang_run_stages.html"
+canonical: "/puppet/latest/lang_run_stages.html"
 ---
 
 [metaparameter]: ./lang_resources.html#metaparameters

--- a/source/puppet/4.8/lang_scope.markdown
+++ b/source/puppet/4.8/lang_scope.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Scope"
-canonical: "/puppet/latest/reference/lang_scope.html"
+canonical: "/puppet/latest/lang_scope.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.8/lang_summary.markdown
+++ b/source/puppet/4.8/lang_summary.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Basics"
-canonical: "/puppet/latest/reference/lang_summary.html"
+canonical: "/puppet/latest/lang_summary.html"
 ---
 
 [site_manifest]: ./dirs_manifest.html

--- a/source/puppet/4.8/lang_tags.markdown
+++ b/source/puppet/4.8/lang_tags.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Tags"
-canonical: "/puppet/latest/reference/lang_tags.html"
+canonical: "/puppet/latest/lang_tags.html"
 ---
 
 

--- a/source/puppet/4.8/lang_template.md
+++ b/source/puppet/4.8/lang_template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Using templates"
-canonical: "/puppet/latest/reference/lang_template.html"
+canonical: "/puppet/latest/lang_template.html"
 ---
 
 [interpolate]: ./lang_data_string.html#interpolation

--- a/source/puppet/4.8/lang_template_epp.md
+++ b/source/puppet/4.8/lang_template_epp.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: "Language: Embedded Puppet (EPP) template syntax"
-canonical: "/puppet/latest/reference/lang_template_epp.html"
+canonical: "/puppet/latest/lang_template_epp.html"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -17,7 +17,7 @@ canonical: "/puppet/latest/reference/lang_template_epp.html"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.8/lang_template_erb.md
+++ b/source/puppet/4.8/lang_template_erb.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Embedded Ruby (ERB) template syntax"
-canonical: "/puppet/latest/reference/lang_template_erb.html"
+canonical: "/puppet/latest/lang_template_erb.html"
 ---
 
 [erb]: http://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html

--- a/source/puppet/4.8/lang_updating_manifests.markdown
+++ b/source/puppet/4.8/lang_updating_manifests.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Updating 3.x Manifests for Puppet 4.x"
-canonical: "/puppet/latest/reference/lang_updating_manifests.html"
+canonical: "/puppet/latest/lang_updating_manifests.html"
 ---
 
 [str2bool]: https://forge.puppetlabs.com/puppetlabs/stdlib#str2bool
@@ -22,7 +22,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.8/lang_variables.markdown
+++ b/source/puppet/4.8/lang_variables.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Variables"
-canonical: "/puppet/latest/reference/lang_variables.html"
+canonical: "/puppet/latest/lang_variables.html"
 ---
 
 

--- a/source/puppet/4.8/lang_virtual.markdown
+++ b/source/puppet/4.8/lang_virtual.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Virtual resources"
-canonical: "/puppet/latest/reference/lang_virtual.html"
+canonical: "/puppet/latest/lang_virtual.html"
 ---
 
 [resources]: ./lang_resources.html

--- a/source/puppet/4.8/lang_visual_index.markdown
+++ b/source/puppet/4.8/lang_visual_index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Visual index"
-canonical: "/puppet/latest/reference/lang_visual_index.html"
+canonical: "/puppet/latest/lang_visual_index.html"
 ---
 
 

--- a/source/puppet/4.8/lang_windows_file_paths.markdown
+++ b/source/puppet/4.8/lang_windows_file_paths.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Language: Handling file paths on Windows"
-canonical: "/puppet/latest/reference/lang_windows_file_paths.html"
+canonical: "/puppet/latest/lang_windows_file_paths.html"
 ---
 
 [template]: ./lang_template.html
@@ -60,7 +60,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.8/lookup_quick.md
+++ b/source/puppet/4.8/lookup_quick.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick reference for Hiera users"
-canonical: "/puppet/latest/reference/lookup_quick.html"
+canonical: "/puppet/latest/lookup_quick.html"
 ---
 
 [lookup_function]: ./function.html#lookup

--- a/source/puppet/4.8/lookup_quick_module.md
+++ b/source/puppet/4.8/lookup_quick_module.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Lookup: Quick intro to module data"
-canonical: "/puppet/latest/reference/lookup_quick_module.html"
+canonical: "/puppet/latest/lookup_quick_module.html"
 ---
 
 [hash merge operator]: ./lang_expressions.html#merging

--- a/source/puppet/4.8/metaparameter.md
+++ b/source/puppet/4.8/metaparameter.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Metaparameter Reference
 toc: columns
-canonical: /puppet/latest/reference/metaparameter.html
+canonical: /puppet/latest/metaparameter.html
 ---
 
 
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -180,7 +180,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -226,7 +226,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -252,7 +252,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -302,7 +302,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.8/modules_documentation.markdown
+++ b/source/puppet/4.8/modules_documentation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Documenting modules"
-canonical: "/puppet/latest/reference/modules_documentation.html"
+canonical: "/puppet/latest/modules_documentation.html"
 ---
 
 [installing]: ./modules_installing.html

--- a/source/puppet/4.8/modules_fundamentals.markdown
+++ b/source/puppet/4.8/modules_fundamentals.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Module fundamentals"
-canonical: "/puppet/latest/reference/modules_fundamentals.html"
+canonical: "/puppet/latest/modules_fundamentals.html"
 ---
 
 [modulepath]: ./dirs_modulepath.html

--- a/source/puppet/4.8/modules_installing.markdown
+++ b/source/puppet/4.8/modules_installing.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Installing modules"
-canonical: "/puppet/latest/reference/modules_installing.html"
+canonical: "/puppet/latest/modules_installing.html"
 ---
 
 [forge]: https://forge.puppet.com

--- a/source/puppet/4.8/passenger.markdown
+++ b/source/puppet/4.8/passenger.markdown
@@ -54,7 +54,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -229,8 +229,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.8/puppet_collections.md
+++ b/source/puppet/4.8/puppet_collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About Puppet Collections and packages"
-canonical: "/puppet/latest/reference/puppet_collections.html"
+canonical: "/puppet/latest/puppet_collections.html"
 ---
 
 {% include puppet-collections/_puppet_collections_intro.md %}

--- a/source/puppet/4.8/release_notes.markdown
+++ b/source/puppet/4.8/release_notes.markdown
@@ -14,9 +14,9 @@ Puppet's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-Read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover breaking changes since Puppet 3.8.
+Read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover breaking changes since Puppet 3.8.
 
-Also of interest: the [Puppet 4.7 release notes](/puppet/4.7/reference/release_notes.html) and [Puppet 4.6 release notes](/puppet/4.6/reference/release_notes.html).
+Also of interest: the [Puppet 4.7 release notes](/puppet/4.7/release_notes.html) and [Puppet 4.6 release notes](/puppet/4.6/release_notes.html).
 
 ## Puppet 4.8.2
 

--- a/source/puppet/4.8/release_notes_agent.md
+++ b/source/puppet/4.8/release_notes_agent.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "Puppet agent release notes"
-canonical: "/puppet/latest/reference/release_notes_agent.html"
+canonical: "/puppet/latest/release_notes_agent.html"
 ---
 
-[Puppet 4.8.0]: /puppet/4.8/reference/release_notes.html#puppet-480
-[Puppet 4.8.1]: /puppet/4.8/reference/release_notes.html#puppet-481
-[Puppet 4.8.2]: /puppet/4.8/reference/release_notes.html#puppet-482
+[Puppet 4.8.0]: /puppet/4.8/release_notes.html#puppet-480
+[Puppet 4.8.1]: /puppet/4.8/release_notes.html#puppet-481
+[Puppet 4.8.2]: /puppet/4.8/release_notes.html#puppet-482
 
 
 [Facter 3.5.0]: /facter/3.5/release_notes.html#facter-350
@@ -31,7 +31,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html), and the [Puppet 4.8 release notes](./release_notes.html).
 

--- a/source/puppet/4.8/report.md
+++ b/source/puppet/4.8/report.md
@@ -3,7 +3,7 @@ layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Report Reference
 toc: columns
-canonical: /puppet/latest/reference/report.html
+canonical: /puppet/latest/report.html
 ---
 
 
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.8/reporting_about.md
+++ b/source/puppet/4.8/reporting_about.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: "About reporting"
-canonical: "/puppet/latest/reference/reporting_about.html"
+canonical: "/puppet/latest/reporting_about.html"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -34,7 +34,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.8/reporting_write_processors.md
+++ b/source/puppet/4.8/reporting_write_processors.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Writing custom report processors"
-canonical: "/puppet/latest/reference/reporting_write_processors.html"
+canonical: "/puppet/latest/reporting_write_processors.html"
 ---
 
 [format]: ./format_report.html

--- a/source/puppet/4.8/resources_file_windows.markdown
+++ b/source/puppet/4.8/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.8/resources_service.markdown
+++ b/source/puppet/4.8/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.8/resources_user_group_windows.markdown
+++ b/source/puppet/4.8/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.8/services_agent_unix.markdown
+++ b/source/puppet/4.8/services_agent_unix.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on *nix systems"
-canonical: "/puppet/latest/reference/services_master_unix.html"
+canonical: "/puppet/latest/services_master_unix.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.8/services_agent_windows.markdown
+++ b/source/puppet/4.8/services_agent_windows.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet agent on Windows systems"
-canonical: "/puppet/latest/reference/services_master_windows.html"
+canonical: "/puppet/latest/services_master_windows.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.8/services_apply.markdown
+++ b/source/puppet/4.8/services_apply.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: Puppet apply"
-canonical: "/puppet/latest/reference/services_apply.html"
+canonical: "/puppet/latest/services_apply.html"
 ---
 
 

--- a/source/puppet/4.8/services_master_rack.markdown
+++ b/source/puppet/4.8/services_master_rack.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The Rack Puppet master"
-canonical: "/puppet/latest/reference/services_master_rack.html"
+canonical: "/puppet/latest/services_master_rack.html"
 ---
 
 

--- a/source/puppet/4.8/services_master_webrick.markdown
+++ b/source/puppet/4.8/services_master_webrick.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet's services: The WEBrick Puppet master"
-canonical: "/puppet/latest/reference/services_master_webrick.html"
+canonical: "/puppet/latest/services_master_webrick.html"
 ---
 
 [webrick]: http://ruby-doc.org/stdlib/libdoc/webrick/rdoc/WEBrick.html

--- a/source/puppet/4.8/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.8/ssl_attributes_extensions.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/reference/ssl_attributes_extensions.html"
+canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates

--- a/source/puppet/4.8/ssl_autosign.markdown
+++ b/source/puppet/4.8/ssl_autosign.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL configuration: autosigning certificate requests"
-canonical: "/puppet/latest/reference/ssl_autosign.html"
+canonical: "/puppet/latest/ssl_autosign.html"
 ---
 
 [external_ca]: ./config_ssl_external_ca.html

--- a/source/puppet/4.8/ssl_regenerate_certificates.markdown
+++ b/source/puppet/4.8/ssl_regenerate_certificates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSL: Regenerating all Certificates in a Puppet deployment"
-canonical: "/puppet/latest/reference/ssl_regenerate.html"
+canonical: "/puppet/latest/ssl_regenerate.html"
 description: "This page describes the steps for regenerating certs under an open source Puppet deployment."
 ---
 

--- a/source/puppet/4.8/static_catalogs.md
+++ b/source/puppet/4.8/static_catalogs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Static catalogs"
-canonical: "/puppet/latest/reference/static_catalogs.html"
+canonical: "/puppet/latest/static_catalogs.html"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html

--- a/source/puppet/4.8/style_guide.markdown
+++ b/source/puppet/4.8/style_guide.markdown
@@ -243,7 +243,7 @@ Every module must have metadata defined in the metadata.json file.  Your metadat
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 ### 8.1 Dependencies
 
@@ -806,7 +806,7 @@ You should help indicate to the user which classes are which by making sure all 
 
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -933,7 +933,7 @@ class my_module (
 
 Exported resources should be opt-in rather than opt-out. Your module should not be written to use exported resources to function by default unless it is expressly required. When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 
@@ -1162,9 +1162,9 @@ All publicly available modules should include the documentation covered below.
 
 ### 17.1 README
 
-Your module should have a README in .md (or .markdown) format. READMEs help users of your module get the full benefit of your work. The [Puppet README template](https://docs.puppet.com/puppet/latest/reference/READMEtemplate.txt) offers a basic format you can use. If you create modules with `puppet module generate`, the generated README includes the template. Using the .md/.markdown format allows your README to be parsed and displayed by Puppet Strings, GitHub, and the Puppet Forge.
+Your module should have a README in .md (or .markdown) format. READMEs help users of your module get the full benefit of your work. The [Puppet README template](https://docs.puppet.com/puppet/latest/READMEtemplate.txt) offers a basic format you can use. If you create modules with `puppet module generate`, the generated README includes the template. Using the .md/.markdown format allows your README to be parsed and displayed by Puppet Strings, GitHub, and the Puppet Forge.
 
-There's an entire [guide](https://docs.puppet.com/puppet/latest/reference/modules_documentation.html) to writing a great README, but overall your README should:
+There's an entire [guide](https://docs.puppet.com/puppet/latest/modules_documentation.html) to writing a great README, but overall your README should:
 
 * Summarize what your module does.
 * Note any setup requirements or limitations (such as "This module requires the puppetlabs-apache module and only works on Ubuntu.").

--- a/source/puppet/4.8/subsystem_agent_master_comm.markdown
+++ b/source/puppet/4.8/subsystem_agent_master_comm.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Subsystems: Agent/master HTTPS communications"
 layout: default
-canonical: "/puppet/latest/reference/subsystem_agent_master_comm.html"
+canonical: "/puppet/latest/subsystem_agent_master_comm.html"
 ---
 
 [http_api]: ./http_api/http_api_index.html

--- a/source/puppet/4.8/subsystem_catalog_compilation.markdown
+++ b/source/puppet/4.8/subsystem_catalog_compilation.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Subsystems: Catalog compilation"
-canonical: "/puppet/latest/reference/subsystem_catalog_compilation.html"
+canonical: "/puppet/latest/subsystem_catalog_compilation.html"
 ---
 
 [environment]: ./environments.html

--- a/source/puppet/4.8/system_requirements.markdown
+++ b/source/puppet/4.8/system_requirements.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet system requirements"
-canonical: "/puppet/latest/reference/system_requirements.html"
+canonical: "/puppet/latest/system_requirements.html"
 ---
 
 > To install Puppet, first [view the pre-install tasks](./install_pre.html).
@@ -35,7 +35,7 @@ Puppet and all of its prerequisites run on the following platforms, and Puppet p
 
 ### Red Hat Enterprise Linux (and derivatives)
 
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Red Hat Enterprise Linux (RHEL):
+We publish and test official [`puppet-agent`](/puppet/latest/about_agent.html) packages for the following versions of Red Hat Enterprise Linux (RHEL):
 
 * Enterprise Linux 7
 * Enterprise Linux 6
@@ -59,14 +59,14 @@ We also publish and test official `puppet-agent` packages for the following vers
 
 ### Fedora
 
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Fedora:
+We publish and test official [`puppet-agent`](/puppet/latest/about_agent.html) packages for the following versions of Fedora:
 
 * Fedora 24
 * Fedora 23
 
 ### Windows
 
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following versions of Windows:
+We publish and test official [`puppet-agent`](/puppet/latest/about_agent.html) packages for the following versions of Windows:
 
 * Windows Server 2012 R2
 * Windows Server 2008 R2
@@ -83,7 +83,7 @@ We also publish, but do not automatically test `puppet-agent` packages for the f
 
 ### OS X
 
-We publish and test official [`puppet-agent`](/puppet/latest/reference/about_agent.html) packages for the following OS X versions:
+We publish and test official [`puppet-agent`](/puppet/latest/about_agent.html) packages for the following OS X versions:
 
 * 10.11 El Capitan
 * 10.10 Yosemite

--- a/source/puppet/4.8/type.md
+++ b/source/puppet/4.8/type.md
@@ -2,7 +2,7 @@
 layout: default
 built_from_commit: 629a508e98d21e5fe98a8a35b2c31dbc62e6a669
 title: Resource Type Reference (Single-Page)
-canonical: /puppet/latest/reference/type.html
+canonical: /puppet/latest/type.html
 toc_levels: 2
 toc: columns
 ---
@@ -23,7 +23,7 @@ information on how to use its custom resource types.
 
 To manage resources on a target system, you should declare them in Puppet
 manifests. For more details, see
-[the resources page of the Puppet language reference.](/puppet/latest/reference/lang_resources.html)
+[the resources page of the Puppet language reference.](/puppet/latest/lang_resources.html)
 
 You can also browse and manage resources interactively using the
 `puppet resource` subcommand; run `puppet resource --help` for more information.
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1294,8 +1294,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1853,7 +1853,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8474,7 +8474,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10057,7 +10057,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.8/upgrade_major_agent.markdown
+++ b/source/puppet/4.8/upgrade_major_agent.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x agent upgrades"
-canonical: "/puppet/latest/reference/upgrade_major_agent.html"
+canonical: "/puppet/latest/upgrade_major_agent.html"
 ---
 
 [Hiera]: /hiera/
@@ -81,7 +81,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.8/upgrade_major_post.md
+++ b/source/puppet/4.8/upgrade_major_post.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Post-upgrade clean-up"
-canonical: "/puppet/latest/reference/upgrade_major_post.html"
+canonical: "/puppet/latest/upgrade_major_post.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -22,7 +22,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.8/upgrade_major_pre.md
+++ b/source/puppet/4.8/upgrade_major_pre.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Get upgrade-ready"
-canonical: "/puppet/latest/reference/upgrade_major_pre.html"
+canonical: "/puppet/latest/upgrade_major_pre.html"
 ---
 
 Puppet 4 is a major upgrade with lots of configuration and functionality changes. Since Puppet is likely managing your entire infrastructure, it should be **upgraded with care**. Specifically, you should try to:
@@ -19,7 +19,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -30,7 +30,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -38,7 +38,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -48,9 +48,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -58,7 +58,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -70,18 +70,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x release notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 ## You're ready!
 

--- a/source/puppet/4.8/upgrade_major_server.markdown
+++ b/source/puppet/4.8/upgrade_major_server.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
-canonical: "/puppet/latest/reference/upgrade_major_server.html"
+canonical: "/puppet/latest/upgrade_major_server.html"
 ---
 
 [moved]: ./whered_it_go.html
@@ -11,7 +11,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -20,7 +20,7 @@ canonical: "/puppet/latest/reference/upgrade_major_server.html"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -67,7 +67,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -165,13 +165,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.8/upgrade_minor.md
+++ b/source/puppet/4.8/upgrade_minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Minor upgrades: Within 4.x (Puppet Collection 1 / PC1)"
-canonical: "/puppet/latest/reference/upgrade_minor.html"
+canonical: "/puppet/latest/upgrade_minor.html"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/source/puppet/4.8/whered_it_go.markdown
+++ b/source/puppet/4.8/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/4.9/about_agent.md
+++ b/source/puppet/4.9/about_agent.md
@@ -33,7 +33,7 @@ Starting with Puppet 4, we distribute Puppet as two core packages.
 - `puppet-agent` --- This package contains Puppet's main code and all of the dependencies needed to run it, including [Facter][], [Hiera][], and bundled versions of Ruby and OpenSSL. It also includes [MCollective][]. Once it's installed, you have everything you need to run [the Puppet agent service][agent] and the [`puppet apply` command][apply].
 - `puppetserver` --- This package depends on `puppet-agent`, and adds the JVM-based [Puppet Server][] application. Once it's installed, Puppet Server can serve catalogs to nodes running the Puppet agent service.
 
-> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/reference/services_commands.html#puppet-agent).
+> **Note:** For information about Puppet agent in Puppet 3, see the [Puppet 3 services documentation](/puppet/3.8/services_commands.html#puppet-agent).
 
 ## How version numbers work
 

--- a/source/puppet/4.9/config_file_csr_attributes.markdown
+++ b/source/puppet/4.9/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/4.9/config_file_environment.markdown
+++ b/source/puppet/4.9/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/4.9/configuration.md
+++ b/source/puppet/4.9/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -153,7 +153,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -166,7 +166,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -306,15 +306,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -419,7 +419,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -608,7 +608,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -688,7 +688,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1086,7 +1086,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1182,7 +1182,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1253,7 +1253,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1434,7 +1434,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/4.9/deprecated_language.markdown
+++ b/source/puppet/4.9/deprecated_language.markdown
@@ -43,7 +43,7 @@ Enable `strict_variables` on your Puppet master, run as normal for a while, and 
 
 #### Now
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/4.9/deprecated_win2003.md
+++ b/source/puppet/4.9/deprecated_win2003.md
@@ -6,6 +6,6 @@ toc: false
 
 Microsoft ended support for Windows Server 2003 and 2003 R2 on July 14, 2015. These operating system versions will not receive further security updates from Microsoft, and Puppet no longer supports them. For more information and help migrating from Windows Server 2003 and 2003 R2, see [Microsoft's end-of-life page.](https://www.microsoft.com/en-us/server-cloud/products/windows-server-2003/)
 
-[Puppet 4.2](/puppet/4.2/reference/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet agent package fails to install on Windows Server 2003 and 2003 R2.
+[Puppet 4.2](/puppet/4.2/) is the final version compatible with Server 2003 and 2003 R2. As of Puppet 4.3, the Puppet agent package fails to install on Windows Server 2003 and 2003 R2.
 
 * Running 32-bit Puppet agent on a 64-bit Windows system was deprecated on December 31, 2016.

--- a/source/puppet/4.9/function.md
+++ b/source/puppet/4.9/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -366,7 +366,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -457,7 +457,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -480,12 +480,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -538,7 +538,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -721,7 +721,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -805,7 +805,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -897,7 +897,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -994,7 +994,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1079,12 +1079,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1102,7 +1102,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1118,14 +1118,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1133,7 +1133,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1209,7 +1209,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1308,7 +1308,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2398,7 +2398,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2637,7 +2637,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2829,7 +2829,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3123,7 +3123,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3272,9 +3272,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/4.9/hiera_use_hiera_functions.md
+++ b/source/puppet/4.9/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/4.9/install_linux.markdown
+++ b/source/puppet/4.9/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/4.9/install_pre.markdown
+++ b/source/puppet/4.9/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/4.9/install_windows.markdown
+++ b/source/puppet/4.9/install_windows.markdown
@@ -101,10 +101,10 @@ MSI Property                                                   | Puppet Setting 
 [`PUPPET_AGENT_ACCOUNT_PASSWORD`](#puppetagentaccountpassword) | n/a                | Puppet 3.4.0  / PE 3.2
 [`PUPPET_AGENT_ACCOUNT_DOMAIN`](#puppetagentaccountdomain)     | n/a                | Puppet 3.4.0  / PE 3.2
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 #### `INSTALLDIR`
 

--- a/source/puppet/4.9/lang_resources.markdown
+++ b/source/puppet/4.9/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/4.9/lang_template_epp.md
+++ b/source/puppet/4.9/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/4.9/lang_updating_manifests.markdown
+++ b/source/puppet/4.9/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/4.9/lang_windows_file_paths.markdown
+++ b/source/puppet/4.9/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/4.9/metaparameter.md
+++ b/source/puppet/4.9/metaparameter.md
@@ -88,7 +88,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -97,7 +97,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -180,7 +180,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -191,7 +191,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -204,12 +204,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -218,7 +218,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -226,7 +226,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -252,7 +252,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -270,7 +270,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -283,7 +283,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -302,7 +302,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/4.9/passenger.markdown
+++ b/source/puppet/4.9/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/4.9/release_notes_agent.md
+++ b/source/puppet/4.9/release_notes_agent.md
@@ -33,7 +33,7 @@ The `puppet-agent` package's version numbers use the format X.Y.Z, where:
 
 ## If you're upgrading from Puppet 3.x
 
-The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/reference/release_notes.html), since they cover any breaking changes since Puppet 3.8.
+The `puppet-agent` package installs the latest version of Puppet 4. Also read the [Puppet 4.0 release notes](/puppet/4.0/release_notes.html), since they cover any breaking changes since Puppet 3.8.
 
 Also of interest: [About Agent](./about_agent.html), and the [Puppet 4.9 release notes](./release_notes.html).
 

--- a/source/puppet/4.9/report.md
+++ b/source/puppet/4.9/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/4.9/reporting_about.md
+++ b/source/puppet/4.9/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/4.9/resources_file_windows.markdown
+++ b/source/puppet/4.9/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/4.9/resources_service.markdown
+++ b/source/puppet/4.9/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/4.9/resources_user_group_windows.markdown
+++ b/source/puppet/4.9/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/4.9/style_guide.markdown
+++ b/source/puppet/4.9/style_guide.markdown
@@ -243,7 +243,7 @@ Every module must have metadata defined in the metadata.json file.  Your metadat
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 ### 8.1 Dependencies
 
@@ -814,7 +814,7 @@ You should help indicate to the user which classes are which by making sure all 
 
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -942,7 +942,7 @@ class my_module (
 
 Exported resources should be opt-in rather than opt-out. Your module should not be written to use exported resources to function by default unless it is expressly required. When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/4.9/type.md
+++ b/source/puppet/4.9/type.md
@@ -1200,7 +1200,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1294,8 +1294,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -1853,7 +1853,7 @@ Filebuckets are used for the following features:
   puppet master's filebucket with the _desired_ content for each file,
   then instructs the agent to retrieve the content for a specific
   checksum. For more details,
-  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/reference/indirection.html#catalog).
+  [see the `static_compiler` section in the catalog indirection docs](https://docs.puppetlabs.com/puppet/latest/indirection.html#catalog).
 
 To use a central filebucket for backups, you will usually want to declare
 a filebucket resource and a resource default for the `backup` attribute
@@ -8474,7 +8474,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10057,7 +10057,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/4.9/upgrade_major_agent.markdown
+++ b/source/puppet/4.9/upgrade_major_agent.markdown
@@ -80,7 +80,7 @@ On \*nix systems, we [moved][] [`puppet.conf`](./config_file_main.html) from `/e
 Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
 * It includes any necessary modifications.
-* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+* It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
 * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 ### Start service or update cron job

--- a/source/puppet/4.9/upgrade_major_post.md
+++ b/source/puppet/4.9/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/4.9/upgrade_major_pre.md
+++ b/source/puppet/4.9/upgrade_major_pre.md
@@ -18,7 +18,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, this is the best time to [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -29,7 +29,7 @@ Before upgrading from Puppet 3 to 4, make sure all your Puppet components are ru
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 or require major workflow changes. Read our [lists of deprecated features][deprecations], and if you're using any of them, follow our advice for migrating away from them.
 
@@ -37,7 +37,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 4 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 - Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 4 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -47,9 +47,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet 4 organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 If you're using config file environments, [switch to directory environments now.][envs_config]
 
@@ -57,7 +57,7 @@ If you don't currently use environments, [enable directory environments][envs_co
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 4. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -69,18 +69,18 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 Run Puppet for a while with the future parser enabled to ensure you've got any kinks worked out.
 
 ## Read the Puppet 4.x release notes
 
-Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduces several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 ## You're ready!
 

--- a/source/puppet/4.9/upgrade_major_server.markdown
+++ b/source/puppet/4.9/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.x to 4.x: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -66,7 +66,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 4 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -164,13 +164,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/4.9/whered_it_go.markdown
+++ b/source/puppet/4.9/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "Where did everything go in Puppet 4.x?"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/5.0/_environment_conf_settings.md
+++ b/source/puppet/5.0/_environment_conf_settings.md
@@ -1,6 +1,0 @@
-In this version of Puppet, the environment.conf file is only allowed to override five settings:
-
-* `modulepath`
-* `manifest`
-* `config_version`
-* `environment_timeout`

--- a/source/puppet/5.0/config_file_csr_attributes.markdown
+++ b/source/puppet/5.0/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/5.0/config_file_environment.markdown
+++ b/source/puppet/5.0/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/5.0/configuration.md
+++ b/source/puppet/5.0/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: http://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -121,7 +121,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](http://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -134,7 +134,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -274,15 +274,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -379,7 +379,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -568,7 +568,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -648,7 +648,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1056,7 +1056,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1152,7 +1152,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1242,7 +1242,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1423,7 +1423,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/5.0/deprecated_language.markdown
+++ b/source/puppet/5.0/deprecated_language.markdown
@@ -39,7 +39,7 @@ If you set the `strict_variables` setting to `true`, Puppet raises an error if y
 
 ## Automatic symbolic links for `ensure` values in `file` resources
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/5.0/function.md
+++ b/source/puppet/5.0/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -366,7 +366,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -457,7 +457,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -480,12 +480,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -538,7 +538,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -721,7 +721,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -741,7 +741,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.0/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.0/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -805,7 +805,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -824,7 +824,7 @@ $allusers = hiera_array('users') | $key | { "Key '${key}' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.0/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.0/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -897,7 +897,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -917,7 +917,7 @@ $allusers = hiera_hash('users') | $key | { "Key '${key}' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.0/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.0/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -994,7 +994,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1011,7 +1011,7 @@ hiera_include('classes') | $key | {"Key '${key}' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/5.0/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/5.0/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1079,12 +1079,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1102,7 +1102,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1118,14 +1118,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1133,7 +1133,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1209,7 +1209,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1308,7 +1308,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2411,7 +2411,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2650,7 +2650,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2842,7 +2842,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3136,7 +3136,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3285,9 +3285,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.0/function_strings_prefer_v3.md
+++ b/source/puppet/5.0/function_strings_prefer_v3.md
@@ -102,9 +102,9 @@ is initialized with the nested hash for the respective type. The annotated objec
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -149,7 +149,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -475,7 +475,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each()`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -566,7 +566,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -592,12 +592,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -664,7 +664,7 @@ found, skipping any files that don't exist.
 * `filter()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -851,7 +851,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -936,7 +936,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -1029,7 +1029,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -1127,7 +1127,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1234,12 +1234,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1257,7 +1257,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1273,7 +1273,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 ## `inline_template`
 
@@ -1281,7 +1281,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1299,7 +1299,7 @@ how to use this function.
 * `lest()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1376,7 +1376,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1476,7 +1476,7 @@ remove values by prefixing them with `--`:
 * `map()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2586,7 +2586,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2828,7 +2828,7 @@ Note that the returned value is ignored if used in a class or user defined type.
     * Return type(s): `Any`. 
 
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -3029,7 +3029,7 @@ The first parameter is format string describing how the rest of the parameters s
     * Return type(s): `Any`. 
 
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3327,7 +3327,7 @@ return their outputs concatenated into a single string.
 * `then()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3591,9 +3591,9 @@ Log a message on the server at level notice.
 * `with()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.0/function_strings_prefer_v4.md
+++ b/source/puppet/5.0/function_strings_prefer_v4.md
@@ -104,9 +104,9 @@ is initialized with the nested hash for the respective type. The annotated objec
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -147,7 +147,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 ## `binary_file`
 
@@ -392,7 +392,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -473,7 +473,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `emerg`
@@ -497,12 +497,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -573,7 +573,7 @@ found, skipping any files that don't exist.
 * `filter(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -736,7 +736,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -807,7 +807,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -887,7 +887,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -976,7 +976,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1042,12 +1042,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1065,7 +1065,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1086,7 +1086,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1150,7 +1150,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1235,7 +1235,7 @@ but can adjust the merge with additional options. The available options are:
 * `map(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1375,7 +1375,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce(Iterable $enumerable, Any $memo, Callable[2,2] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1835,9 +1835,9 @@ Log a message on the server at level notice.
 * `with(Any *$arg, Callable &$block)`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.0/hiera_use_hiera_functions.md
+++ b/source/puppet/5.0/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/5.0/install_linux.markdown
+++ b/source/puppet/5.0/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/5.0/install_pre.markdown
+++ b/source/puppet/5.0/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/5.0/install_windows.markdown
+++ b/source/puppet/5.0/install_windows.markdown
@@ -93,10 +93,10 @@ MSI Property                    | Puppet Setting
 `PUPPET_AGENT_ACCOUNT_PASSWORD` |                 
 `PUPPET_AGENT_ACCOUNT_DOMAIN`   |              
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 ### `INSTALLDIR`

--- a/source/puppet/5.0/lang_resources.markdown
+++ b/source/puppet/5.0/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/5.0/lang_template_epp.md
+++ b/source/puppet/5.0/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/5.0/lang_updating_manifests.markdown
+++ b/source/puppet/5.0/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/5.0/lang_windows_file_paths.markdown
+++ b/source/puppet/5.0/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/5.0/metaparameter.md
+++ b/source/puppet/5.0/metaparameter.md
@@ -90,7 +90,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -99,7 +99,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -182,7 +182,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -193,7 +193,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -206,12 +206,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -220,7 +220,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -228,7 +228,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -254,7 +254,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -272,7 +272,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -285,7 +285,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -304,7 +304,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/5.0/passenger.markdown
+++ b/source/puppet/5.0/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/5.0/puppet_platform.md
+++ b/source/puppet/5.0/puppet_platform.md
@@ -4,7 +4,7 @@ title: "About Puppet Platform and its packages"
 ---
 
 > **Note:** This document covers the Puppet Platform repository of open source Puppet 5-compatible software packages.
-> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/reference/puppet_repositories.html).
+> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/puppet_repositories.html).
 > -   For Puppet Enterprise installation tarballs, see its [installation documentation](/pe/latest/install_basic.html).
 
 Puppet maintains official Puppet 5 Platform package repositories for several operating systems and distributions. Puppet 5 Platform has all of the software you need to run a functional Puppet deployment, in versions that are known to work well with each other.
@@ -40,7 +40,7 @@ Package                              | Contents
 
 The way you access Puppet 5 Platform  depends on your operating system, and its distribution, version, and installation methods. If you use a *nix operating system with a package manager, for example, you access a Puppet Platform by adding it as a package repository.
 
-> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/reference/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
+> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
 
 
 ### Yum-based systems

--- a/source/puppet/5.0/report.md
+++ b/source/puppet/5.0/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/5.0/reporting_about.md
+++ b/source/puppet/5.0/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/5.0/resources_file_windows.markdown
+++ b/source/puppet/5.0/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/5.0/resources_service.markdown
+++ b/source/puppet/5.0/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/5.0/resources_user_group_windows.markdown
+++ b/source/puppet/5.0/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/5.0/style_guide.markdown
+++ b/source/puppet/5.0/style_guide.markdown
@@ -270,7 +270,7 @@ Your metadata should follow the below format:
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 {:.section}
 ### 8.1 Dependencies
@@ -863,7 +863,7 @@ You should help indicate to the user which classes are which by making sure all 
 {:.section}
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -1000,7 +1000,7 @@ Exported resources should be opt-in rather than opt-out. Your module should not 
 
 When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/5.0/type.md
+++ b/source/puppet/5.0/type.md
@@ -1206,7 +1206,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1300,8 +1300,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -8489,7 +8489,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10072,7 +10072,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.0/type_strings.md
+++ b/source/puppet/5.0/type_strings.md
@@ -4381,7 +4381,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -5954,7 +5954,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.0/upgrade_major_agent.markdown
+++ b/source/puppet/5.0/upgrade_major_agent.markdown
@@ -78,7 +78,7 @@ Find your operating system in the sidebar navigation to the left and follow the 
    Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
    * It includes any necessary modifications.
-   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
    * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 4. Start service or update cron job.

--- a/source/puppet/5.0/upgrade_major_post.md
+++ b/source/puppet/5.0/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/5.0/upgrade_major_pre.md
+++ b/source/puppet/5.0/upgrade_major_pre.md
@@ -18,7 +18,7 @@ This page provides steps you should take before starting the upgrade to help pre
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -29,7 +29,7 @@ This page provides steps you should take before starting the upgrade to help pre
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 and 5 or require major workflow changes. Read the [lists of deprecated features][deprecations], and if you're using any of them, follow steps for migrating away from them.
 
@@ -37,7 +37,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 5 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 1. Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 5 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -47,9 +47,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 1. If you're using config file environments, [switch to directory environments.][envs_config]
 
@@ -57,7 +57,7 @@ Puppet now organizes all code into [directory environments](./environments.html)
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -69,12 +69,12 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 For a more complete list, see [Updating 3.x Manifests for Puppet 4+.](./lang_updating_manifests.html)
 
@@ -82,7 +82,7 @@ Run Puppet for several runs with the future parser enabled to ensure you've got 
 
 ## Read the release notes
 
-Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 Also read the [Puppet 5 release notes](./release_notes.html) to see breaking changes since Puppet 4.
 

--- a/source/puppet/5.0/upgrade_major_server.markdown
+++ b/source/puppet/5.0/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -64,7 +64,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -162,13 +162,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/5.0/whered_it_go.markdown
+++ b/source/puppet/5.0/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "File location changes since Puppet 3.8.x"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/5.1/config_file_csr_attributes.markdown
+++ b/source/puppet/5.1/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/5.1/config_file_environment.markdown
+++ b/source/puppet/5.1/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/5.1/configuration.md
+++ b/source/puppet/5.1/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: https://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -121,7 +121,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -134,7 +134,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -274,15 +274,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -379,7 +379,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -568,7 +568,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -648,7 +648,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1056,7 +1056,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1152,7 +1152,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1242,7 +1242,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1423,7 +1423,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/5.1/deprecated_language.markdown
+++ b/source/puppet/5.1/deprecated_language.markdown
@@ -39,7 +39,7 @@ If you set the `strict_variables` setting to `true`, Puppet raises an error if y
 
 ## Automatic symbolic links for `ensure` values in `file` resources
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/5.1/function.md
+++ b/source/puppet/5.1/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -366,7 +366,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -457,7 +457,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -480,12 +480,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -538,7 +538,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -721,7 +721,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -741,7 +741,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.1/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.1/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -805,7 +805,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -824,7 +824,7 @@ $allusers = hiera_array('users') | $key | { "Key '${key}' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.1/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.1/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -897,7 +897,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -917,7 +917,7 @@ $allusers = hiera_hash('users') | $key | { "Key '${key}' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.1/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.1/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -994,7 +994,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1011,7 +1011,7 @@ hiera_include('classes') | $key | {"Key '${key}' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/5.1/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/5.1/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1079,12 +1079,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1102,7 +1102,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1118,14 +1118,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1133,7 +1133,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1209,7 +1209,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1308,7 +1308,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2478,7 +2478,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2748,7 +2748,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2940,7 +2940,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3234,7 +3234,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3383,9 +3383,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.1/function_strings_prefer_v3.md
+++ b/source/puppet/5.1/function_strings_prefer_v3.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -231,9 +231,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -278,7 +278,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -604,7 +604,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each()`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -695,7 +695,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -721,12 +721,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -793,7 +793,7 @@ found, skipping any files that don't exist.
 * `filter()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -980,7 +980,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -1065,7 +1065,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -1158,7 +1158,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -1256,7 +1256,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1363,12 +1363,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1386,7 +1386,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1402,7 +1402,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 ## `inline_template`
 
@@ -1410,7 +1410,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1428,7 +1428,7 @@ how to use this function.
 * `lest()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1505,7 +1505,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1605,7 +1605,7 @@ remove values by prefixing them with `--`:
 * `map()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2782,7 +2782,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -3055,7 +3055,7 @@ Note that the returned value is ignored if used in a class or user defined type.
     * Return type(s): `Any`. 
 
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -3256,7 +3256,7 @@ The first parameter is format string describing how the rest of the parameters s
     * Return type(s): `Any`. 
 
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3554,7 +3554,7 @@ return their outputs concatenated into a single string.
 * `then()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3666,7 +3666,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -3869,9 +3869,9 @@ Log a message on the server at level notice.
 * `with()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.1/function_strings_prefer_v4.md
+++ b/source/puppet/5.1/function_strings_prefer_v4.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -233,9 +233,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -276,7 +276,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 ## `binary_file`
 
@@ -521,7 +521,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -602,7 +602,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `emerg`
@@ -626,12 +626,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -702,7 +702,7 @@ found, skipping any files that don't exist.
 * `filter(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -865,7 +865,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -936,7 +936,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1016,7 +1016,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1105,7 +1105,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1171,12 +1171,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1194,7 +1194,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1215,7 +1215,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1279,7 +1279,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1364,7 +1364,7 @@ but can adjust the merge with additional options. The available options are:
 * `map(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1504,7 +1504,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce(Iterable $enumerable, Any $memo, Callable[2,2] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1885,7 +1885,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -2044,9 +2044,9 @@ Log a message on the server at level notice.
 * `with(Any *$arg, Callable &$block)`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.1/hiera_use_hiera_functions.md
+++ b/source/puppet/5.1/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/5.1/install_linux.markdown
+++ b/source/puppet/5.1/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/5.1/install_pre.markdown
+++ b/source/puppet/5.1/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/5.1/install_windows.markdown
+++ b/source/puppet/5.1/install_windows.markdown
@@ -93,10 +93,10 @@ MSI Property                    | Puppet Setting
 `PUPPET_AGENT_ACCOUNT_PASSWORD` |                 
 `PUPPET_AGENT_ACCOUNT_DOMAIN`   |              
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 ### `INSTALLDIR`

--- a/source/puppet/5.1/lang_resources.markdown
+++ b/source/puppet/5.1/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/5.1/lang_template_epp.md
+++ b/source/puppet/5.1/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/5.1/lang_updating_manifests.markdown
+++ b/source/puppet/5.1/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/5.1/lang_windows_file_paths.markdown
+++ b/source/puppet/5.1/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/5.1/metaparameter.md
+++ b/source/puppet/5.1/metaparameter.md
@@ -90,7 +90,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -99,7 +99,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -182,7 +182,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -193,7 +193,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -206,12 +206,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -220,7 +220,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -228,7 +228,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -254,7 +254,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -272,7 +272,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -285,7 +285,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -304,7 +304,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/5.1/passenger.markdown
+++ b/source/puppet/5.1/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/5.1/puppet_platform.md
+++ b/source/puppet/5.1/puppet_platform.md
@@ -4,7 +4,7 @@ title: "About Puppet Platform and its packages"
 ---
 
 > **Note:** This document covers the Puppet Platform repository of open source Puppet 5-compatible software packages.
-> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/reference/puppet_repositories.html).
+> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/puppet_repositories.html).
 > -   For Puppet Enterprise installation tarballs, see its [installation documentation](/pe/latest/install_basic.html).
 
 Puppet maintains official Puppet 5 Platform package repositories for several operating systems and distributions. Puppet 5 Platform has all of the software you need to run a functional Puppet deployment, in versions that are known to work well with each other.
@@ -40,7 +40,7 @@ Package                              | Contents
 
 The way you access Puppet 5 Platform  depends on your operating system, and its distribution, version, and installation methods. If you use a *nix operating system with a package manager, for example, you access a Puppet Platform by adding it as a package repository.
 
-> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/reference/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
+> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
 
 
 ### Yum-based systems

--- a/source/puppet/5.1/report.md
+++ b/source/puppet/5.1/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/5.1/reporting_about.md
+++ b/source/puppet/5.1/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/5.1/resources_file_windows.markdown
+++ b/source/puppet/5.1/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/5.1/resources_service.markdown
+++ b/source/puppet/5.1/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/5.1/resources_user_group_windows.markdown
+++ b/source/puppet/5.1/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/5.1/style_guide.markdown
+++ b/source/puppet/5.1/style_guide.markdown
@@ -270,7 +270,7 @@ Your metadata should follow the below format:
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 {:.section}
 ### 8.1 Dependencies
@@ -863,7 +863,7 @@ You should help indicate to the user which classes are which by making sure all 
 {:.section}
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -1000,7 +1000,7 @@ Exported resources should be opt-in rather than opt-out. Your module should not 
 
 When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/5.1/type.md
+++ b/source/puppet/5.1/type.md
@@ -1206,7 +1206,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1300,8 +1300,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -8491,7 +8491,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10074,7 +10074,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.1/type_strings.md
+++ b/source/puppet/5.1/type_strings.md
@@ -4383,7 +4383,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -5956,7 +5956,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.1/upgrade_major_agent.markdown
+++ b/source/puppet/5.1/upgrade_major_agent.markdown
@@ -78,7 +78,7 @@ Find your operating system in the sidebar navigation to the left and follow the 
    Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
    * It includes any necessary modifications.
-   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
    * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 4. Start service or update cron job.

--- a/source/puppet/5.1/upgrade_major_post.md
+++ b/source/puppet/5.1/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/5.1/upgrade_major_pre.md
+++ b/source/puppet/5.1/upgrade_major_pre.md
@@ -18,7 +18,7 @@ This page provides steps you should take before starting the upgrade to help pre
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -29,7 +29,7 @@ This page provides steps you should take before starting the upgrade to help pre
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 and 5 or require major workflow changes. Read the [lists of deprecated features][deprecations], and if you're using any of them, follow steps for migrating away from them.
 
@@ -37,7 +37,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 5 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 1. Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 5 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -47,9 +47,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 1. If you're using config file environments, [switch to directory environments.][envs_config]
 
@@ -57,7 +57,7 @@ Puppet now organizes all code into [directory environments](./environments.html)
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -69,12 +69,12 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 For a more complete list, see [Updating 3.x Manifests for Puppet 4+.](./lang_updating_manifests.html)
 
@@ -82,7 +82,7 @@ Run Puppet for several runs with the future parser enabled to ensure you've got 
 
 ## Read the release notes
 
-Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 Also read the [Puppet 5 release notes](./release_notes.html) to see breaking changes since Puppet 4.
 

--- a/source/puppet/5.1/upgrade_major_server.markdown
+++ b/source/puppet/5.1/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -64,7 +64,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -162,13 +162,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/5.1/whered_it_go.markdown
+++ b/source/puppet/5.1/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "File location changes since Puppet 3.8.x"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/5.2/config_file_csr_attributes.markdown
+++ b/source/puppet/5.2/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/5.2/config_file_environment.markdown
+++ b/source/puppet/5.2/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/5.2/configuration.md
+++ b/source/puppet/5.2/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: https://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -121,7 +121,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -134,7 +134,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -274,15 +274,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -379,7 +379,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -568,7 +568,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -648,7 +648,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1056,7 +1056,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1152,7 +1152,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1242,7 +1242,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1423,7 +1423,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/5.2/deprecated_language.markdown
+++ b/source/puppet/5.2/deprecated_language.markdown
@@ -39,7 +39,7 @@ If you set the `strict_variables` setting to `true`, Puppet raises an error if y
 
 ## Automatic symbolic links for `ensure` values in `file` resources
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/5.2/function.md
+++ b/source/puppet/5.2/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -375,7 +375,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -466,7 +466,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -489,12 +489,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -550,7 +550,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -733,7 +733,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -753,7 +753,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.2/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.2/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -817,7 +817,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -836,7 +836,7 @@ $allusers = hiera_array('users') | $key | { "Key '${key}' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.2/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.2/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -909,7 +909,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -929,7 +929,7 @@ $allusers = hiera_hash('users') | $key | { "Key '${key}' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.2/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.2/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1006,7 +1006,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1023,7 +1023,7 @@ hiera_include('classes') | $key | {"Key '${key}' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/5.2/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/5.2/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1091,12 +1091,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1114,7 +1114,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1130,14 +1130,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1145,7 +1145,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1221,7 +1221,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1320,7 +1320,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2490,7 +2490,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2760,7 +2760,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2952,7 +2952,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3246,7 +3246,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3395,9 +3395,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.2/function_strings_prefer_v3.md
+++ b/source/puppet/5.2/function_strings_prefer_v3.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -231,9 +231,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -278,7 +278,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -613,7 +613,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each()`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -704,7 +704,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -730,12 +730,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -805,7 +805,7 @@ found, skipping any files that don't exist.
 * `filter()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -992,7 +992,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -1077,7 +1077,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -1170,7 +1170,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -1268,7 +1268,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1375,12 +1375,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1398,7 +1398,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1414,7 +1414,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 ## `inline_template`
 
@@ -1422,7 +1422,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1440,7 +1440,7 @@ how to use this function.
 * `lest()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1517,7 +1517,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1617,7 +1617,7 @@ remove values by prefixing them with `--`:
 * `map()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2794,7 +2794,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -3067,7 +3067,7 @@ Note that the returned value is ignored if used in a class or user defined type.
     * Return type(s): `Any`. 
 
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -3268,7 +3268,7 @@ The first parameter is format string describing how the rest of the parameters s
     * Return type(s): `Any`. 
 
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3566,7 +3566,7 @@ return their outputs concatenated into a single string.
 * `then()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3678,7 +3678,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -3881,9 +3881,9 @@ Log a message on the server at level notice.
 * `with()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.2/function_strings_prefer_v4.md
+++ b/source/puppet/5.2/function_strings_prefer_v4.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -233,9 +233,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -276,7 +276,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 ## `binary_file`
 
@@ -521,7 +521,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -602,7 +602,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `emerg`
@@ -626,12 +626,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -705,7 +705,7 @@ found, skipping any files that don't exist.
 * `filter(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -868,7 +868,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -939,7 +939,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1019,7 +1019,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1108,7 +1108,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1174,12 +1174,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1197,7 +1197,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1218,7 +1218,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1282,7 +1282,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1368,7 +1368,7 @@ but can adjust the merge with additional options. The available options are:
 * `map(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1508,7 +1508,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce(Iterable $enumerable, Any $memo, Callable[2,2] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1889,7 +1889,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -2048,9 +2048,9 @@ Log a message on the server at level notice.
 * `with(Any *$arg, Callable &$block)`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.2/hiera_use_hiera_functions.md
+++ b/source/puppet/5.2/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/5.2/install_linux.markdown
+++ b/source/puppet/5.2/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/5.2/install_pre.markdown
+++ b/source/puppet/5.2/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/5.2/install_windows.markdown
+++ b/source/puppet/5.2/install_windows.markdown
@@ -93,10 +93,10 @@ MSI Property                    | Puppet Setting
 `PUPPET_AGENT_ACCOUNT_PASSWORD` |                 
 `PUPPET_AGENT_ACCOUNT_DOMAIN`   |              
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 ### `INSTALLDIR`

--- a/source/puppet/5.2/lang_resources.markdown
+++ b/source/puppet/5.2/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/5.2/lang_template_epp.md
+++ b/source/puppet/5.2/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/5.2/lang_updating_manifests.markdown
+++ b/source/puppet/5.2/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/5.2/lang_windows_file_paths.markdown
+++ b/source/puppet/5.2/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/5.2/metaparameter.md
+++ b/source/puppet/5.2/metaparameter.md
@@ -90,7 +90,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -99,7 +99,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -182,7 +182,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -193,7 +193,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -206,12 +206,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -220,7 +220,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -228,7 +228,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -254,7 +254,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -272,7 +272,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -285,7 +285,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -304,7 +304,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/5.2/passenger.markdown
+++ b/source/puppet/5.2/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/5.2/puppet_platform.md
+++ b/source/puppet/5.2/puppet_platform.md
@@ -4,7 +4,7 @@ title: "About Puppet Platform and its packages"
 ---
 
 > **Note:** This document covers the Puppet Platform repository of open source Puppet 5-compatible software packages.
-> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/reference/puppet_repositories.html).
+> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/puppet_repositories.html).
 > -   For Puppet Enterprise installation tarballs, see its [installation documentation](/pe/latest/install_basic.html).
 
 Puppet maintains official Puppet 5 Platform package repositories for several operating systems and distributions. Puppet 5 Platform has all of the software you need to run a functional Puppet deployment, in versions that are known to work well with each other.
@@ -40,7 +40,7 @@ Package                              | Contents
 
 The way you access Puppet 5 Platform  depends on your operating system, and its distribution, version, and installation methods. If you use a *nix operating system with a package manager, for example, you access a Puppet Platform by adding it as a package repository.
 
-> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/reference/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
+> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
 
 
 ### Yum-based systems

--- a/source/puppet/5.2/report.md
+++ b/source/puppet/5.2/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/5.2/reporting_about.md
+++ b/source/puppet/5.2/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/5.2/resources_file_windows.markdown
+++ b/source/puppet/5.2/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/5.2/resources_service.markdown
+++ b/source/puppet/5.2/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/5.2/resources_user_group_windows.markdown
+++ b/source/puppet/5.2/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/5.2/style_guide.markdown
+++ b/source/puppet/5.2/style_guide.markdown
@@ -270,7 +270,7 @@ Your metadata should follow the below format:
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 {:.section}
 ### 8.1 Dependencies
@@ -863,7 +863,7 @@ You should help indicate to the user which classes are which by making sure all 
 {:.section}
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -1000,7 +1000,7 @@ Exported resources should be opt-in rather than opt-out. Your module should not 
 
 When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/5.2/type.md
+++ b/source/puppet/5.2/type.md
@@ -1206,7 +1206,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1300,8 +1300,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -8491,7 +8491,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10082,7 +10082,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.2/type_strings.md
+++ b/source/puppet/5.2/type_strings.md
@@ -4383,7 +4383,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -5964,7 +5964,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.2/upgrade_major_agent.markdown
+++ b/source/puppet/5.2/upgrade_major_agent.markdown
@@ -78,7 +78,7 @@ Find your operating system in the sidebar navigation to the left and follow the 
    Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
    * It includes any necessary modifications.
-   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
    * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 4. Start service or update cron job.

--- a/source/puppet/5.2/upgrade_major_post.md
+++ b/source/puppet/5.2/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/5.2/upgrade_major_pre.md
+++ b/source/puppet/5.2/upgrade_major_pre.md
@@ -18,7 +18,7 @@ This page provides steps you should take before starting the upgrade to help pre
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -29,7 +29,7 @@ This page provides steps you should take before starting the upgrade to help pre
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 and 5 or require major workflow changes. Read the [lists of deprecated features][deprecations], and if you're using any of them, follow steps for migrating away from them.
 
@@ -37,7 +37,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 5 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 1. Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 5 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -47,9 +47,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 1. If you're using config file environments, [switch to directory environments.][envs_config]
 
@@ -57,7 +57,7 @@ Puppet now organizes all code into [directory environments](./environments.html)
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -69,12 +69,12 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 For a more complete list, see [Updating 3.x Manifests for Puppet 4+.](./lang_updating_manifests.html)
 
@@ -82,7 +82,7 @@ Run Puppet for several runs with the future parser enabled to ensure you've got 
 
 ## Read the release notes
 
-Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 Also read the [Puppet 5 release notes](./release_notes.html) to see breaking changes since Puppet 4.
 

--- a/source/puppet/5.2/upgrade_major_server.markdown
+++ b/source/puppet/5.2/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -64,7 +64,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -162,13 +162,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/5.2/whered_it_go.markdown
+++ b/source/puppet/5.2/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "File location changes since Puppet 3.8.x"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 

--- a/source/puppet/5.3/config_file_csr_attributes.markdown
+++ b/source/puppet/5.3/config_file_csr_attributes.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Config files: csr_attributes.yaml"
 ---
 
-[csr_attributes]: /puppet/3.8/reference/configuration.html#csrattributes
+[csr_attributes]: /puppet/3.8/configuration.html#csrattributes
 
 The `csr_attributes.yaml` file defines custom data for new certificate signing requests (CSRs). It can set:
 

--- a/source/puppet/5.3/config_file_environment.markdown
+++ b/source/puppet/5.3/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments.html
 [environmentpath]: ./environments.html#about-environmentpath
-[modulepath]: /puppet/3.8/reference/configuration.html#modulepath
+[modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/reference/configuration.html#basemodulepath
+[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/source/puppet/5.3/configuration.md
+++ b/source/puppet/5.3/configuration.md
@@ -39,7 +39,7 @@ canonical: "/puppet/latest/configuration.html"
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: https://docs.puppetlabs.com/puppet/latest/config_about_settings.html
 
 * * *
 
@@ -121,7 +121,7 @@ user can use the `puppet cert sign` command to manually sign it, or can delete
 the request.
 
 For info on autosign configuration files, see
-[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html).
+[the guide to Puppet's config files](https://docs.puppetlabs.com/puppet/latest/config_about_settings.html).
 
 - *Default*: $confdir/autosign.conf
 
@@ -134,7 +134,7 @@ POSIX path separator is ':', and the Windows path separator is ';'.)
 These are the modules that will be used by _all_ environments. Note that
 the `modules` directory of the active environment will have priority over
 any global directories. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/modules:/opt/puppetlabs/puppet/modules
 
@@ -288,15 +288,15 @@ requests a certificate from the CA puppet master, it uses the value of the
 `certname` setting as its requested Subject CN.
 
 This is the name used when managing a node's permissions in
-[auth.conf](https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html).
+[auth.conf](https://docs.puppetlabs.com/puppet/latest/config_file_auth.html).
 In most cases, it is also used as the node's name when matching
-[node definitions](https://docs.puppetlabs.com/puppet/latest/reference/lang_node_definitions.html)
+[node definitions](https://docs.puppetlabs.com/puppet/latest/lang_node_definitions.html)
 and requesting data from an ENC. (This can be changed with the `node_name_value`
 and `node_name_fact` settings, although you should only do so if you have
 a compelling reason.)
 
 A node's certname is available in Puppet manifests as `$trusted['certname']`. (See
-[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html)
+[Facts and Built-In Variables](https://docs.puppetlabs.com/puppet/latest/lang_facts_and_builtin_vars.html)
 for more details.)
 
 * For best compatibility, you should limit the value of `certname` to
@@ -393,7 +393,7 @@ reports, allowing you to correlate changes on your hosts to the source version o
 Setting a global value for config_version in puppet.conf is not allowed
 (but it can be overridden from the commandline). Please set a
 per-environment value in environment.conf instead. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### configprint
@@ -590,7 +590,7 @@ change this setting; you also need to:
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
 * On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_ssldir.html).
+  from the [ssldir](https://docs.puppetlabs.com/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
   (`puppet cert sign --allow-dns-alt-names <NAME>`).
@@ -670,7 +670,7 @@ is ':', and the Windows path separator is ';'.)
 
 This setting must have a value set to enable **directory environments.** The
 recommended value is `$codedir/environments`. For more details, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: $codedir/environments
 
@@ -1078,7 +1078,7 @@ Setting a global value for `manifest` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 environment's `manifests` directory as the main manifest, you can set
 `manifest` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 - *Default*: 
 
@@ -1174,7 +1174,7 @@ Setting a global value for `modulepath` in puppet.conf is not allowed
 directory environments instead. If you need to use something other than the
 default modulepath of `<ACTIVE ENVIRONMENT'S MODULES DIR>:$basemodulepath`,
 you can set `modulepath` in environment.conf. For more info, see
-<https://docs.puppet.com/puppet/latest/reference/environments.html>
+<https://docs.puppet.com/puppet/latest/environments.html>
 
 
 ### name
@@ -1264,7 +1264,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)
+[The `noop` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#noop)
 allows you to apply individual resources in noop mode, and will override
 the global value of the `noop` setting. This means a resource with
 `noop => false` _will_ be changed if necessary, even when running puppet
@@ -1445,7 +1445,7 @@ as the fallback logging destination.
 For control over logging destinations, see the `--logdest` command line
 option in the manual pages for puppet master, puppet agent, and puppet
 apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
-or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/.
+or read them online at https://docs.puppetlabs.com/puppet/latest/man/.
 
 - *Default*: $logdir/puppetd.log
 

--- a/source/puppet/5.3/deprecated_language.markdown
+++ b/source/puppet/5.3/deprecated_language.markdown
@@ -39,7 +39,7 @@ If you set the `strict_variables` setting to `true`, Puppet raises an error if y
 
 ## Automatic symbolic links for `ensure` values in `file` resources
 
-Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/reference/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
+Puppet doesn't validate the value of the [`ensure` attribute in `file` resources](/puppet/latest/type.html#file-attribute-ensure). If the value is not `present`, `absent`, `file`, `directory`, or `link`, Puppet treats the value as an arbitrary path and creates a symbolic link to that path.
 
 For example, these resource declarations are equivalent:
 

--- a/source/puppet/5.3/function.md
+++ b/source/puppet/5.3/function.md
@@ -34,9 +34,9 @@ Log a message on the server at level alert.
 assert_type
 -----------
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -81,7 +81,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -375,7 +375,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 
 each
 ----
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -466,7 +466,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -489,12 +489,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -550,7 +550,7 @@ found, skipping any files that don't exist.
 
 filter
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -733,7 +733,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -753,7 +753,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.3/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.3/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -817,7 +817,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -836,7 +836,7 @@ $allusers = hiera_array('users') | $key | { "Key '${key}' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.3/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.3/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -909,7 +909,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -929,7 +929,7 @@ $allusers = hiera_hash('users') | $key | { "Key '${key}' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/5.3/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/5.3/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1006,7 +1006,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1023,7 +1023,7 @@ hiera_include('classes') | $key | {"Key '${key}' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/5.3/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/5.3/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |
@@ -1091,12 +1091,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1114,7 +1114,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1130,14 +1130,14 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 - *Type*: rvalue
 
 inline_template
 ---------------
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1145,7 +1145,7 @@ output is all concatenated and returned as the output of the function.
 
 lest
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1221,7 +1221,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1320,7 +1320,7 @@ remove values by prefixing them with `--`:
 
 map
 ---
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2490,7 +2490,7 @@ reference; e.g.: `realize User[luke]`.
 
 reduce
 ------
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -2760,7 +2760,7 @@ Note that the returned value is ignored if used in a class or user defined type.
 reverse_each
 ------------
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -2952,7 +2952,7 @@ The first parameter is format string describing how the rest of the parameters s
 step
 ----
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3246,7 +3246,7 @@ return their outputs concatenated into a single string.
 
 then
 ----
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3395,9 +3395,9 @@ Log a message on the server at level warning.
 
 with
 ----
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.3/function_strings_prefer_v3.md
+++ b/source/puppet/5.3/function_strings_prefer_v3.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -231,9 +231,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -278,7 +278,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 - Since 4.0.0
 
@@ -613,7 +613,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each()`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -704,7 +704,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 - Since 4.0.0
@@ -730,12 +730,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -805,7 +805,7 @@ found, skipping any files that don't exist.
 * `filter()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -992,7 +992,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera` with a lambda
@@ -1077,7 +1077,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_array` with a lambda
@@ -1170,7 +1170,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_hash` with a lambda
@@ -1268,7 +1268,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda
@@ -1375,12 +1375,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1398,7 +1398,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1414,7 +1414,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8
+- Requires [future parser](/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8
 
 ## `inline_template`
 
@@ -1422,7 +1422,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1440,7 +1440,7 @@ how to use this function.
 * `lest()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 (which should accept no arguments) if the argument given to the function is `undef`.
 Returns the result of calling the lambda if the argument is `undef`, otherwise the
 given argument.
@@ -1517,7 +1517,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1617,7 +1617,7 @@ remove values by prefixing them with `--`:
 * `map()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -2794,7 +2794,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce()`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -3067,7 +3067,7 @@ Note that the returned value is ignored if used in a class or user defined type.
     * Return type(s): `Any`. 
 
 Reverses the order of the elements of something that is iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes one to two arguments:
@@ -3268,7 +3268,7 @@ The first parameter is format string describing how the rest of the parameters s
     * Return type(s): `Any`. 
 
 Provides stepping with given interval over elements in an iterable and optionally runs a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) for each
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) for each
 element.
 
 This function takes two to three arguments:
@@ -3566,7 +3566,7 @@ return their outputs concatenated into a single string.
 * `then()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given argument unless the argument is undef. Return `undef` if argument is
 `undef`, and otherwise the result of giving the argument to the lambda.
 
@@ -3678,7 +3678,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -3881,9 +3881,9 @@ Log a message on the server at level notice.
 * `with()`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.3/function_strings_prefer_v4.md
+++ b/source/puppet/5.3/function_strings_prefer_v4.md
@@ -45,7 +45,7 @@ Log a message on the server at level alert.
 * `all(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
 makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
 
@@ -93,7 +93,7 @@ notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
 Would notice true.
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `annotate`
@@ -169,7 +169,7 @@ is initialized with the nested hash for the respective type. The annotated objec
 * `any(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure until the lambda returns a "truthy" value which
 makes the function return `true`, or if the end of the iteration is reached, false is returned.
 
@@ -222,7 +222,7 @@ notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
 Would notice true as the index `2` is even and not a `String`
 
 For an general examples that demonstrates iteration, see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `assert_type`
@@ -233,9 +233,9 @@ documentation.
     * Return type(s): `Any`. 
 
 Returns the given value if it is of the given
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html), or
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data.html), or
 otherwise either raises an error or executes an optional two-parameter
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html).
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html).
 
 The function takes two mandatory arguments, in this order:
 
@@ -276,7 +276,7 @@ $valid_username = assert_type(String[1], $raw_username) |$expected, $actual| {
 ~~~
 
 For more information about data types, see the
-[documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).
+[documentation](https://docs.puppetlabs.com/puppet/latest/lang_data.html).
 
 ## `binary_file`
 
@@ -521,7 +521,7 @@ Returns a hash value from a provided string using the digest_algorithm setting f
 * `each(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Runs a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 repeatedly using each value in a data structure, then returns the values unchanged.
 
 This function takes two mandatory arguments, in this order:
@@ -602,7 +602,7 @@ $data.each |$key, $value| {
 
 For an example that demonstrates how to create multiple `file` resources using `each`,
 see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `emerg`
@@ -626,12 +626,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`
@@ -705,7 +705,7 @@ found, skipping any files that don't exist.
 * `filter(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
 for which the lambda evaluates to `true`.
 
@@ -868,7 +868,7 @@ $users = hiera('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -939,7 +939,7 @@ $allusers = hiera_array('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1019,7 +1019,7 @@ $allusers = hiera_hash('users', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1108,7 +1108,7 @@ hiera_include('classes', undef)
 ~~~
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 ~~~ puppet
@@ -1174,12 +1174,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -1197,7 +1197,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -1218,7 +1218,7 @@ END
     * Return type(s): `Any`. 
 
 Evaluate a template string and return its value.  See
-[the templating docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_template.html) for
+[the templating docs](https://docs.puppetlabs.com/puppet/latest/lang_template.html) for
 more information. Note that if multiple template strings are specified, their
 output is all concatenated and returned as the output of the function.
 
@@ -1282,7 +1282,7 @@ The arguments accepted by `lookup` are as follows:
     first key, it will try again with the subsequent ones, only resorting to a
     default value if none of them succeed.
 2. `<VALUE TYPE>` (data type) --- A
-[data type](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_type.html)
+[data type](https://docs.puppetlabs.com/puppet/latest/lang_data_type.html)
 that must match the retrieved value; if not, the lookup (and catalog
 compilation) will fail. Defaults to `Data` (accepts any normal value).
 3. `<MERGE BEHAVIOR>` (string or hash; see **"Merge Behaviors"** below) ---
@@ -1368,7 +1368,7 @@ but can adjust the merge with additional options. The available options are:
 * `map(Iterable $enumerable, Callable[1,1] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array containing the results.
 
 This function takes two mandatory arguments, in this order:
@@ -1508,7 +1508,7 @@ reference; e.g.: `realize User[luke]`.
 * `reduce(Iterable $enumerable, Any $memo, Callable[2,2] &$block)`
     * Return type(s): `Any`. 
 
-Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+Applies a [lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html)
 to every value in a data structure from the first argument, carrying over the returned
 value of each iteration, and returns the result of the lambda's final iteration. This
 lets you create a new value or data structure by combining values from the first
@@ -1889,7 +1889,7 @@ further as each filtered result appears as a `Tuple` with `[path, value]`.
 
 
 For general examples that demonstrates iteration see the Puppet
-[iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+[iteration](https://docs.puppetlabs.com/puppet/latest/lang_iteration.html)
 documentation.
 
 ## `type`
@@ -2048,9 +2048,9 @@ Log a message on the server at level notice.
 * `with(Any *$arg, Callable &$block)`
     * Return type(s): `Any`. 
 
-Call a [lambda](https://docs.puppet.com/puppet/latest/reference/lang_lambdas.html)
+Call a [lambda](https://docs.puppet.com/puppet/latest/lang_lambdas.html)
 with the given arguments and return the result. Since a lambda's scope is
-[local](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html#lambda-scope)
+[local](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html#lambda-scope)
 to the lambda, you can use the `with` function to create private blocks of code within a
 class using variables whose values cannot be accessed outside of the lambda.
 

--- a/source/puppet/5.3/hiera_use_hiera_functions.md
+++ b/source/puppet/5.3/hiera_use_hiera_functions.md
@@ -277,7 +277,7 @@ hiera_include('classes', undef)
 ```
 
 You can optionally generate the default value with a
-[lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
+[lambda](https://docs.puppetlabs.com/puppet/latest/lang_lambdas.html) that
 takes one parameter.
 
 **Example**: Using `hiera_include` with a lambda

--- a/source/puppet/5.3/install_linux.markdown
+++ b/source/puppet/5.3/install_linux.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet agent: Linux"
 [master_settings]: ./config_important_settings.html#settings-for-puppet-master-servers
 [agent_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 [where]: ./whered_it_go.html
-[dns_alt_names]: /puppet/latest/reference/configuration.html#dnsaltnames
+[dns_alt_names]: /puppet/latest/configuration.html#dnsaltnames
 [server_heap]: {{puppetserver}}/install_from_packages.html#memory-allocation
 [puppetserver_confd]: {{puppetserver}}/configuration.html
 [server_install]: {{puppetserver}}/install_from_packages.html

--- a/source/puppet/5.3/install_pre.markdown
+++ b/source/puppet/5.3/install_pre.markdown
@@ -6,7 +6,7 @@ title: "Installing Puppet: Pre-install tasks"
 [peinstall]: {{pe}}/install_basic.html
 [sysreqs]: ./system_requirements.html
 [ruby]: ./system_requirements.html#basic-requirements
-[architecture]: /puppet/latest/reference/architecture.html
+[architecture]: /puppet/latest/architecture.html
 [puppetdb]: {{puppetdb}}/
 [server_setting]: ./configuration.html#server
 

--- a/source/puppet/5.3/install_windows.markdown
+++ b/source/puppet/5.3/install_windows.markdown
@@ -93,10 +93,10 @@ MSI Property                    | Puppet Setting
 `PUPPET_AGENT_ACCOUNT_PASSWORD` |                 
 `PUPPET_AGENT_ACCOUNT_DOMAIN`   |              
 
-[s]: /puppet/latest/reference/configuration.html#server
-[c]: /puppet/latest/reference/configuration.html#caserver
-[r]: /puppet/latest/reference/configuration.html#certname
-[e]: /puppet/latest/reference/configuration.html#environment
+[s]: /puppet/latest/configuration.html#server
+[c]: /puppet/latest/configuration.html#caserver
+[r]: /puppet/latest/configuration.html#certname
+[e]: /puppet/latest/configuration.html#environment
 
 
 ### `INSTALLDIR`

--- a/source/puppet/5.3/lang_resources.markdown
+++ b/source/puppet/5.3/lang_resources.markdown
@@ -17,9 +17,9 @@ title: "Language: Resources"
 [class]: ./lang_classes.html
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
-[files]: /puppet/3.7/reference/type.html#file
-[cron jobs]: /puppet/3.7/reference/type.html#cron
-[services]: /puppet/3.7/reference/type.html#service
+[files]: /puppet/3.7/type.html#file
+[cron jobs]: /puppet/3.7/type.html#cron
+[services]: /puppet/3.7/type.html#service
 [custom_types]: /guides/custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
 [expressions]: ./lang_expressions.html
@@ -202,6 +202,6 @@ Some attributes in Puppet can be used with every resource type. These are called
 
 The most commonly used metaparameters are for specifying [order relationships][relationships] between resources.
 
-You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/reference/metaparameter.html).
+You can see the full list of all metaparameters in the [Metaparameter Reference](/puppet/3.7/metaparameter.html).
 
 

--- a/source/puppet/5.3/lang_template_epp.md
+++ b/source/puppet/5.3/lang_template_epp.md
@@ -4,9 +4,9 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 ---
 
 [erb]: ./lang_template_erb.html
-[epp]: /puppet/latest/reference/function.html#epp
+[epp]: /puppet/latest/function.html#epp
 [ntp]: https://forge.puppetlabs.com/puppetlabs/ntp
-[inline_epp]: /puppet/latest/reference/function.html#inlineepp
+[inline_epp]: /puppet/latest/function.html#inlineepp
 [functions]: ./lang_functions.html
 [hash]: ./lang_data_hash.html
 [local scope]: ./lang_scope.html
@@ -16,7 +16,7 @@ title: "Language: Embedded Puppet (EPP) template syntax"
 [variable_names]: ./lang_variables.html#naming
 [typed]: ./lang_data_type.html
 
-Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/reference/experiments_future.html) enabled.
+Embedded Puppet (EPP) is a templating language based on the [Puppet language](./lang_summary.html). You can use EPP in Puppet 4 and higher, as well as Puppet 3.5 through 3.8 with the [future parser](/puppet/3.8/experiments_future.html) enabled.
 
 Puppet can evaluate EPP templates with the [`epp`][epp] and [`inline_epp`][inline_epp] functions.
 

--- a/source/puppet/5.3/lang_updating_manifests.markdown
+++ b/source/puppet/5.3/lang_updating_manifests.markdown
@@ -21,7 +21,7 @@ The locations of code directories and important config files have changed. Read 
 
 ## Double-check to make sure it's safe before purging `cron` resources
 
-Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/reference/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
+Previously, using [`resources {'cron': purge => true}`](./type.html#resources) to purge `cron` resources would only purge jobs belonging to the current user performing the Puppet run (usually `root`). [In Puppet 4](/puppet/4.0/release_notes.html), this action is more aggressive and causes **all** unmanaged cron jobs to be purged.
 
 Make sure this is what you want. You might want to set `noop => true` on the purge resource to keep an eye on it.
 

--- a/source/puppet/5.3/lang_windows_file_paths.markdown
+++ b/source/puppet/5.3/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/reference/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/source/puppet/5.3/metaparameter.md
+++ b/source/puppet/5.3/metaparameter.md
@@ -90,7 +90,7 @@ and the second run will log the edit made by Puppet.)
 ### before
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -99,7 +99,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `require`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### consume
 
@@ -182,7 +182,7 @@ subscribing or notified resources, although Puppet will log that a refresh
 event _would_ have been sent.
 
 **Important note:**
-[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/reference/configuration.html#noop)
+[The `noop` setting](https://docs.puppetlabs.com/puppet/latest/configuration.html#noop)
 allows you to globally enable or disable noop mode, but it will _not_ override
 the `noop` metaparameter on individual resources. That is, the value of the
 global `noop` setting will _only_ affect resources that do not have an explicit
@@ -193,7 +193,7 @@ Valid values are `true`, `false`.
 ### notify
 
 One or more resources that depend on this resource, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -206,12 +206,12 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### require
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -220,7 +220,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `notify`, and `subscribe`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### schedule
 
@@ -228,7 +228,7 @@ A schedule to govern when Puppet is allowed to manage this resource.
 The value of this metaparameter must be the `name` of a `schedule`
 resource. This means you must declare a schedule resource, then
 refer to it by name; see
-[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/reference/type.html#schedule)
+[the docs for the `schedule` type](https://docs.puppetlabs.com/puppet/latest/type.html#schedule)
 for more info.
 
     schedule { 'everyday':
@@ -254,7 +254,7 @@ resources or on classes declared with `include`.
 By default, all classes are declared in the `main` stage. To assign a class
 to a different stage, you must:
 
-* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/reference/type.html#stage).
+* Declare the new stage as a [`stage` resource](https://docs.puppetlabs.com/puppet/latest/type.html#stage).
 * Declare an order relationship between the new stage and the `main` stage.
 * Use the resource-like syntax to declare the class, and set the `stage`
   metaparameter to the name of the desired stage.
@@ -272,7 +272,7 @@ For example:
 ### subscribe
 
 One or more resources that this resource depends on, expressed as
-[resource references](https://docs.puppetlabs.com/puppet/latest/reference/lang_data_resource_reference.html).
+[resource references](https://docs.puppetlabs.com/puppet/latest/lang_data_resource_reference.html).
 Multiple resources can be specified as an array of references. When this
 attribute is present:
 
@@ -285,7 +285,7 @@ attribute is present:
 This is one of the four relationship metaparameters, along with
 `before`, `require`, and `notify`. For more context, including the
 alternate chaining arrow (`->` and `~>`) syntax, see
-[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html).
+[the language page on relationships](https://docs.puppetlabs.com/puppet/latest/lang_relationships.html).
 
 ### tag
 
@@ -304,7 +304,7 @@ Multiple tags can be specified as an array:
     }
 
 Tags are useful for things like applying a subset of a host's configuration
-with [the `tags` setting](/puppet/latest/reference/configuration.html#tags)
+with [the `tags` setting](/puppet/latest/configuration.html#tags)
 (e.g. `puppet agent --test --tags bootstrap`).
 
 

--- a/source/puppet/5.3/passenger.markdown
+++ b/source/puppet/5.3/passenger.markdown
@@ -59,7 +59,7 @@ RHEL/CentOS (needs the Puppet Labs repository enabled, or the
 Configure Puppet
 -----
 
-If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/reference/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
+If you're running Puppet 3.x, make sure [the `always_cache_features` setting](/puppet/latest/configuration.html#alwayscachefeatures) is set to true in the `[master]` (not `[main]`) section of puppet.conf. This improves performance.
 
 In post-4.0 versions of Puppet, the example config.ru file hardcodes this setting to true.
 
@@ -234,8 +234,8 @@ For additional details about enabling and configuring Passenger, see the
 
 
 [sslvars]: http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#envvars
-[client]: /puppet/latest/reference/configuration.html#sslclientheader
-[clientverify]: /puppet/latest/reference/configuration.html#sslclientverifyheader
+[client]: /puppet/latest/configuration.html#sslclientheader
+[clientverify]: /puppet/latest/configuration.html#sslclientverifyheader
 
 
 Start or Restart the Apache service

--- a/source/puppet/5.3/puppet_platform.md
+++ b/source/puppet/5.3/puppet_platform.md
@@ -4,7 +4,7 @@ title: "About Puppet Platform and its packages"
 ---
 
 > **Note:** This document covers the Puppet Platform repository of open source Puppet 5-compatible software packages.
-> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/reference/puppet_repositories.html).
+> -   For Puppet 3.8 open source packages, see its [repository documentation](/puppet/3.8/puppet_repositories.html).
 > -   For Puppet Enterprise installation tarballs, see its [installation documentation](/pe/latest/install_basic.html).
 
 Puppet maintains official Puppet 5 Platform package repositories for several operating systems and distributions. Puppet 5 Platform has all of the software you need to run a functional Puppet deployment, in versions that are known to work well with each other.
@@ -39,7 +39,7 @@ Package                              | Contents
 
 The way you access Puppet 5 Platform depends on your operating system, and its distribution, version, and installation methods. If you use a *nix operating system with a package manager, for example, you access a Puppet Platform by adding it as a package repository.
 
-> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/reference/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
+> **Note:** macOS and Windows support the Puppet agent software only, via the [`puppet-agent` package](/puppet/latest/about_agent.html). macOS `puppet-agent` packages are organized by Puppet Platform; for more information, see [the macOS installation instructions](./install_osx.html).
 
 ### Yum-based systems
 

--- a/source/puppet/5.3/report.md
+++ b/source/puppet/5.3/report.md
@@ -22,7 +22,7 @@ Puppet master and Puppet apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 
-See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html)
+See [About Reporting](https://docs.puppetlabs.com/puppet/latest/reporting_about.html)
 for more details.
 
 http

--- a/source/puppet/5.3/reporting_about.md
+++ b/source/puppet/5.3/reporting_about.md
@@ -3,9 +3,9 @@ layout: default
 title: "About reporting"
 ---
 
-[report]: /puppet/latest/reference/configuration.html#report
-[reports]: /puppet/latest/reference/configuration.html#reports
-[reportdir]: /puppet/latest/reference/configuration.html#reportdir
+[report]: /puppet/latest/configuration.html#report
+[reports]: /puppet/latest/configuration.html#reports
+[reportdir]: /puppet/latest/configuration.html#reportdir
 [puppet.conf]: ./config_file_main.html
 
 Puppet creates a report about its actions and your infrastructure each time it applies a catalog during a Puppet run. You can create and use report processors to generate insightful information or alerts from those reports.
@@ -33,7 +33,7 @@ On Puppet master servers (and nodes running Puppet apply), you can configure ena
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. Puppet Enterprise includes [helpful reporting tools]({{pe}}/CM_reports.html) in the console. [PuppetDB]({{puppetdb}}/), with [its report processor enabled]({{puppetdb}}/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard) or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
-Puppet has several basic built-in [report processors](/puppet/latest/reference/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
+Puppet has several basic built-in [report processors](/puppet/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received logs to a local log file.
 
 Certain Puppet modules --- for instance, [`tagmail`](https://forge.puppetlabs.com/puppetlabs/tagmail) --- add additional report processors. Each module has its own requirements, such as Ruby gems, operating system packages, or other Puppet modules.
 

--- a/source/puppet/5.3/resources_file_windows.markdown
+++ b/source/puppet/5.3/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[relationships]: /puppet/latest/lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/source/puppet/5.3/resources_service.markdown
+++ b/source/puppet/5.3/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/reference/type.html#service
-[ensure]: /puppet/3.8/reference/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/reference/type.html#service-attribute-enable
-[start]: /puppet/3.8/reference/type.html#service-attribute-start
-[binary]: /puppet/3.8/reference/type.html#service-attribute-binary
-[stop]: /puppet/3.8/reference/type.html#service-attribute-stop
-[status]: /puppet/3.8/reference/type.html#service-attribute-status
-[pattern]: /puppet/3.8/reference/type.html#service-attribute-pattern
+[service]: /puppet/3.8/type.html#service
+[ensure]: /puppet/3.8/type.html#service-attribute-ensure
+[enable]: /puppet/3.8/type.html#service-attribute-enable
+[start]: /puppet/3.8/type.html#service-attribute-start
+[binary]: /puppet/3.8/type.html#service-attribute-binary
+[stop]: /puppet/3.8/type.html#service-attribute-stop
+[status]: /puppet/3.8/type.html#service-attribute-status
+[pattern]: /puppet/3.8/type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/source/puppet/5.3/resources_user_group_windows.markdown
+++ b/source/puppet/5.3/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/reference/type.html#user-attribute-auth_membership
+[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/reference/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/reference/lang_relationships.html
+[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
+[relationships]: /puppet/latest/lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/source/puppet/5.3/style_guide.markdown
+++ b/source/puppet/5.3/style_guide.markdown
@@ -270,7 +270,7 @@ Your metadata should follow the below format:
 }
 ```
 
-A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file).
+A more complete guide to the metadata.json format can be found in the [docs](http://docs.puppet.com/puppet/latest/modules_publishing.html#write-a-metadatajson-file).
 
 {:.section}
 ### 8.1 Dependencies
@@ -863,7 +863,7 @@ You should help indicate to the user which classes are which by making sure all 
 {:.section}
 ### 10.4. Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/reference/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](https://docs.puppet.com/puppet/latest/lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:** 
 
@@ -1000,7 +1000,7 @@ Exported resources should be opt-in rather than opt-out. Your module should not 
 
 When using exported resources, you should name the property `collect_exported`.
 
-Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/reference/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
+Exported resources should be exported and collected selectively using a [search expression](https://docs.puppet.com/puppet/3.7/lang_collectors.html#search-expressions), ideally allowing user-defined tags as parameters so tags can be used to selectively collect by environment or custom fact.
 
 **Good:**
 

--- a/source/puppet/5.3/type.md
+++ b/source/puppet/5.3/type.md
@@ -1206,7 +1206,7 @@ path to another file as the ensure value, it is equivalent to specifying
 
 However, we recommend using `link` and `target` explicitly, since this
 behavior can be harder to read and is
-[deprecated](https://docs.puppetlabs.com/puppet/4.3/reference/deprecated_language.html)
+[deprecated](https://docs.puppetlabs.com/puppet/4.3/deprecated_language.html)
 as of Puppet 4.3.0.
 
 Valid values are `absent` (also called `false`), `file`, `present`, `directory`, `link`. Values can match `/./`.
@@ -1300,8 +1300,8 @@ the manifest...
     }
 
 ...but for larger files, this attribute is more useful when combined with the
-[template](https://docs.puppetlabs.com/puppet/latest/reference/function.html#template)
-or [file](https://docs.puppetlabs.com/puppet/latest/reference/function.html#file)
+[template](https://docs.puppetlabs.com/puppet/latest/function.html#template)
+or [file](https://docs.puppetlabs.com/puppet/latest/function.html#file)
 function.
 
 ([↑ Back to file attributes](#file-attributes))
@@ -8491,7 +8491,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -10081,7 +10081,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.3/type_strings.md
+++ b/source/puppet/5.3/type_strings.md
@@ -4383,7 +4383,7 @@ schedule
 <h3 id="schedule-description">Description</h3>
 
 Define schedules for Puppet. Resources can be limited to a schedule by using the
-[`schedule`](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#schedule)
+[`schedule`](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#schedule)
 metaparameter.
 
 Currently, **schedules can only be used to stop a resource from being
@@ -5963,7 +5963,7 @@ stage
 A resource type for creating new run stages.  Once a stage is available,
 classes can be assigned to it by declaring them with the resource-like syntax
 and using
-[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#stage).
+[the `stage` metaparameter](https://docs.puppetlabs.com/puppet/latest/metaparameter.html#stage).
 
 Note that new stages are not useful unless you also declare their order
 in relation to the default `main` stage.

--- a/source/puppet/5.3/upgrade_major_agent.markdown
+++ b/source/puppet/5.3/upgrade_major_agent.markdown
@@ -78,7 +78,7 @@ Find your operating system in the sidebar navigation to the left and follow the 
    Examine the new `puppet.conf` regardless of your operating system and confirm that:
 
    * It includes any necessary modifications.
-   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/reference/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
+   * It excludes any settings that were [removed in Puppet 4.0](/puppet/3.8/deprecated_settings.html). Notably, if you set `stringify_facts=false` [before upgrading](./upgrade_major_pre.html), remove this setting.
    * All [important settings](./config_important_settings.html#settings-for-puppet-master-servers) are correctly configured for your site.
 
 4. Start service or update cron job.

--- a/source/puppet/5.3/upgrade_major_post.md
+++ b/source/puppet/5.3/upgrade_major_post.md
@@ -21,7 +21,7 @@ Avoid maintenance and configuration confusion by deleting the old `/etc/puppet` 
 
 ## Delete the per-environment `parser` setting
 
-If you set the [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
+If you set the [`parser`](/puppet/3.8/config_file_environment.html#parser) setting in `environment.conf` as part of your [upgrade preparations](./upgrade_major_pre.html), remove it from all environments. The setting is  inert, but Puppet will log warnings until it's gone.
 
 ## Unassign `puppet_agent` class from nodes
 

--- a/source/puppet/5.3/upgrade_major_pre.md
+++ b/source/puppet/5.3/upgrade_major_pre.md
@@ -18,7 +18,7 @@ This page provides steps you should take before starting the upgrade to help pre
 **Note**: PuppetDB remains optional, and you can skip it if you don't use it.
 
 - If you already use Puppet Server, update it across your infrastructure to the latest 1.1.x release.
-- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/reference/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
+- If you're still using Rack or WEBrick to run your Puppet master, [switch to Puppet Server](/puppetserver/1.1/install_from_packages.html). Puppet Server is designed to be a better-performing drop-in replacement for Rack and WEBrick Puppet masters, which are [deprecated as of Puppet 4.1](/puppet/4.1/release_notes.html#deprecated-rack-and-webrick-web-servers-for-puppet-master).
   - **This is a big change!** Make sure you can successfully switch to Puppet Server 1.1.x before tackling the Puppet 4 upgrade.
   - Check out [our overview](/puppetserver/1.1/puppetserver_vs_passenger.html) of what sets Puppet Server apart from a Rack Puppet master.
   - Puppet Server uses 2GB of memory by default. Depending on your server's specs, you might have to adjust [how much memory you allocate](/puppetserver/1.1/install_from_packages.html#memory-allocation) to Puppet Server before you launch it.
@@ -29,7 +29,7 @@ This page provides steps you should take before starting the upgrade to help pre
 
 ## Check for deprecated features
 
-[deprecations]: /puppet/3.8/reference/deprecated_summary.html
+[deprecations]: /puppet/3.8/deprecated_summary.html
 
 Puppet 3.8 [deprecated several features][deprecations] which are either removed from Puppet 4 and 5 or require major workflow changes. Read the [lists of deprecated features][deprecations], and if you're using any of them, follow steps for migrating away from them.
 
@@ -37,7 +37,7 @@ Puppet 3.8 [deprecated several features][deprecations] which are either removed 
 
 Puppet 5 always uses proper [data types](./lang_data.html) for facts, but Puppet 3 converts all facts to Strings by default. If any of your modules or manifests rely on this behavior, you'll need to adjust them before you upgrade.
 
-If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
+If you've already set [`stringify_facts = false`](/puppet/3.8/deprecated_settings.html#stringifyfacts--true) in `puppet.conf` on every node in your deployment, skip to the [next section](#enable-directory-environments-and-move-code-into-them). Otherwise:
 
 1. Check your Puppet code for any comparisons that _treat boolean facts like strings,_ like `if $::is_virtual == "true" {...}`, and change them so they'll work with true Boolean values.
   - If you need to support Puppet 3 and 5 with the same code, you can instead use something like `if str2bool("$::is_virtual") {...}`.
@@ -47,9 +47,9 @@ If you've already set [`stringify_facts = false`](/puppet/3.8/reference/deprecat
 
 ## Enable directory environments and move code into them
 
-Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated).
+Puppet now organizes all code into [directory environments](./environments.html), which are the only way to organize code now that [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated).
 
-[envs_config]: /puppet/3.8/reference/environments_configuring.html
+[envs_config]: /puppet/3.8/environments_configuring.html
 
 1. If you're using config file environments, [switch to directory environments.][envs_config]
 
@@ -57,7 +57,7 @@ Puppet now organizes all code into [directory environments](./environments.html)
 
 ## Enable the future parser and fix broken code
 
-The [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/reference/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
+The [future parser](/puppet/3.8/experiments_future.html) in Puppet 3 is the current parser in Puppet 5. If you haven't [enabled the future parser](/puppet/3.8/experiments_future.html#enabling-the-future-parser) yet, do so now and check for problems in your current Puppet code during the next Puppet run.
 
 To change the parser per-environment:
 
@@ -69,12 +69,12 @@ To change the parser per-environment:
 
 Some of the changes to look out for include:
 
-- [Changes to comparison operators](/puppet/3.8/reference/experiments_future.html#check-your-comparisons), particularly
+- [Changes to comparison operators](/puppet/3.8/experiments_future.html#check-your-comparisons), particularly
   - The `in` operator ignoring case when comparing strings.
   - Incompatible data types no longer being comparable.
   - New rules for converting values to Boolean (for example, empty strings are now true).
-- [Facts having additional data types](/puppet/3.8/reference/experiments_future.html#check-your-comparisons).
-- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/reference/experiments_future.html#quote-any-octal-numbers-in-file-modes).
+- [Facts having additional data types](/puppet/3.8/experiments_future.html#check-your-comparisons).
+- [Quoting required for octal numbers in `file` resources' `mode` attributes](/puppet/3.8/experiments_future.html#quote-any-octal-numbers-in-file-modes).
 
 For a more complete list, see [Updating 3.x Manifests for Puppet 4+.](./lang_updating_manifests.html)
 
@@ -82,7 +82,7 @@ Run Puppet for several runs with the future parser enabled to ensure you've got 
 
 ## Read the release notes
 
-Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/reference/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/reference/release_notes.html), [4.1](/puppet/4.1/reference/release_notes.html), [4.2](/puppet/4.2/reference/release_notes.html), [4.3](/puppet/4.3/reference/release_notes.html), [4.4](/puppet/4.4/reference/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
+Puppet 4.0 introduced several breaking changes, some of which didn't go through a formal deprecation period---for example, we moved the [tagmail report handler](/puppet/3.8/lang_tags.html#sending-tagmail-reports) out of Puppet's core and into an optional [module](https://forge.puppetlabs.com/puppetlabs/tagmail). Read the release notes for [4.0](/puppet/4.0/release_notes.html), [4.1](/puppet/4.1/release_notes.html), [4.2](/puppet/4.2/release_notes.html), [4.3](/puppet/4.3/release_notes.html), [4.4](/puppet/4.4/release_notes.html), and [4.5](./release_notes.html) and prepare accordingly.
 
 Also read the [Puppet 5 release notes](./release_notes.html) to see breaking changes since Puppet 4.
 

--- a/source/puppet/5.3/upgrade_major_server.markdown
+++ b/source/puppet/5.3/upgrade_major_server.markdown
@@ -10,7 +10,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [Puppet Server compatibility documentation]: {{puppetserver}}/compatibility_with_puppet_agent.html
 [main manifest]: ./dirs_manifest.html
 [default_manifest]: ./configuration.html#defaultmanifest
-[retrieve and apply a catalog]: /puppet/latest/reference/man/agent.html#USAGE-NOTES
+[retrieve and apply a catalog]: /puppet/latest/man/agent.html#USAGE-NOTES
 [hiera.yaml]: {{hiera}}/configuring.html
 [Hiera]: {{hiera}}/
 [r10k]: {{pe}}/r10k.html
@@ -19,7 +19,7 @@ title: "Puppet 3.8 to 5: Upgrade Puppet Server and PuppetDB"
 [upgrade PuppetDB]: {{puppetdb}}/install_via_module.html
 [puppetdb_module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [PuppetDB 3.0 release notes]: /puppetdb/3.0/release_notes.html
-[future]: /puppet/3.8/reference/experiments_future.html
+[future]: /puppet/3.8/experiments_future.html
 
 Unlike the automated upgrades of Puppet agents, Puppet Server upgrades are a manual process because you need to make more decisions during the upgrade.
 
@@ -64,7 +64,7 @@ In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are no
 
 We also moved [`puppet.conf`][puppet.conf] to `/etc/puppetlabs/puppet/puppet.conf`, changed a lot of defaults, and removed many settings. Compare the new `puppet.conf` to the old one, which is probably at `/etc/puppet/puppet.conf`, and copy over the settings you need to keep.
 
-If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting you enabled for the [future parser][future].
+If you are installing Puppet Server 5 onto a new node, look at the [list of important settings](./config_important_settings.html#settings-for-puppet-master-servers) for stuff you might want to set now. You can also remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting you enabled for the [future parser][future].
 
 ### Reconcile `auth.conf`
 
@@ -162,13 +162,13 @@ If this is a new Puppet master but _isn't_ serving as a certificate authority, u
 
 ### Move code
 
-> **Note:** You should have already switched to [directory environments](/puppet/latest/reference/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/reference/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
+> **Note:** You should have already switched to [directory environments](/puppet/latest/environments.html) in the pre-upgrade steps, as [config file environments are removed](/puppet/3.8/environments_classic.html#config-file-environments-are-deprecated) in Puppet 4+.
 
 Move the contents of your old `environments` directory to `/etc/puppetlabs/code/environments`. If you need multiple groups of environments, set the `environmentpath` in `puppet.conf`.
 
 If you're using a single [main manifest][] across all environments, move it to somewhere inside `/etc/puppetlabs/code` and confirm that [`default_manifest`][default_manifest] is correctly configured in `puppet.conf`.
 
-If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/reference/config_file_environment.html#parser) setting.
+If you're configuring individual environments, check your `environment.conf` files. If you enabled the [future parser][future] in environments, remove the now-unused [`parser`](/puppet/3.8/config_file_environment.html#parser) setting.
 
 If you're using [r10k][] or some other code deployment tool, change its configuration to use the new `environments` directory at `/etc/puppetlabs/code/environments`.
 

--- a/source/puppet/5.3/whered_it_go.markdown
+++ b/source/puppet/5.3/whered_it_go.markdown
@@ -4,10 +4,10 @@ title: "File location changes since Puppet 3.8.x"
 ---
 
 
-[confdir]: /puppet/latest/reference/dirs_confdir.html
-[directory environments]: /puppet/latest/reference/environments.html
+[confdir]: /puppet/latest/dirs_confdir.html
+[directory environments]: /puppet/latest/environments.html
 [spec]: https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
-[main manifest]: /puppet/latest/reference/dirs_manifest.html
+[main manifest]: /puppet/latest/dirs_manifest.html
 
 In Puppet 4, we changed the locations of a lot of important config files and directories. We also changed Puppet's packaging to install different things in different places.
 


### PR DESCRIPTION
Links to Puppet docs containing /reference/ (such as `/puppet/latest/reference/something.html`) are a legacy of an older URL structure. After  the reference directory was removed and all of its contents moved to the parent directory, the old docs site redirected such links to remove /reference/ from the URL.

This PR applies the same regex replacement from the redirect to all links in all /puppet/ content, negating the need to rewrite or redirect such links.