### PR TITLE
(DOC-3321) Make Markdown indentation consistent.

### DIFF
--- a/source/facter/3.0/custom_facts.md
+++ b/source/facter/3.0/custom_facts.md
@@ -6,9 +6,6 @@ title: "Facter 3.0: Custom Facts Walkthrough"
 [Facter 3.0.2 release notes]: ./release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-Custom Facts
-============
-
 Extend facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding Custom Facts to Facter
@@ -99,8 +96,8 @@ This allows you to do something like this:
 
 Setting aside external facts for now, most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 

--- a/source/facter/3.1/custom_facts.md
+++ b/source/facter/3.1/custom_facts.md
@@ -6,8 +6,6 @@ title: "Facter 3.1: Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-## Custom facts
-
 Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding custom facts to Facter
@@ -97,8 +95,8 @@ This allows you to do something like this:
 
 Setting aside external facts for now, most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 

--- a/source/facter/3.3/custom_facts.md
+++ b/source/facter/3.3/custom_facts.md
@@ -6,8 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-## Custom facts
-
 Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding custom facts to Facter
@@ -33,9 +31,9 @@ to distribute the facts to the client.
 
 Facter offers a few methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option.
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option.
+-   The environment variable 'FACTERLIB'
 
 You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
@@ -97,8 +95,8 @@ This allows you to do something like this:
 
 Setting aside external facts for now, most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -109,11 +107,11 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* If all you want to do is run the command and use the output, verbatim, as your fact's value,
+-   If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
-* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
+-   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
 It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
@@ -377,9 +375,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -453,8 +451,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -491,6 +489,6 @@ found in the stdlib module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.
+-   Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/3.4/custom_facts.md
+++ b/source/facter/3.4/custom_facts.md
@@ -6,8 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-## Custom facts
-
 Extend Facter by writing your own custom facts to provide information to Puppet.
 
 ## Adding custom facts to Facter
@@ -33,9 +31,9 @@ to distribute the facts to the client.
 
 Facter offers a few methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option.
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option.
+-   The environment variable 'FACTERLIB'
 
 You can use these methods of loading facts to do things like test files locally
 before distributing them, or you can arrange to have a specific set of facts available on certain
@@ -97,8 +95,8 @@ This allows you to do something like this:
 
 Setting aside external facts for now, most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -109,11 +107,11 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* If all you want to do is run the command and use the output, verbatim, as your fact's value,
+-   If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
-* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
+-   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
 It's important to note that *not everything that works in the terminal will work in a fact*. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements will not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
@@ -379,9 +377,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -455,8 +453,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -493,6 +491,6 @@ found in the stdlib module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.
+-   Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/3.5/custom_facts.md
+++ b/source/facter/3.5/custom_facts.md
@@ -6,7 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-
 You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
 
 ## Adding custom facts to Facter
@@ -21,9 +20,9 @@ Since you can't include arbitrary Ruby code in your manifests, the best solution
 
 Facter offers multiple methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option
+-   The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -83,8 +82,8 @@ This allows you to do something like this:
 
 Most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -95,10 +94,10 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* If all you want to do is run the command and use the output verbatim, as your fact's value,
+-   If all you want to do is run the command and use the output verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
-* In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
 It's important to note that *not everything that works in the terminal works in a fact*. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
@@ -106,8 +105,9 @@ It's important to note that *not everything that works in the terminal works in 
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you would create a new custom fact.
 
-1. Start by giving the fact a name, in this case, `hardware_platform`.
-2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+1.  Start by giving the fact a name, in this case, `hardware_platform`.
+
+2.  Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
 
     ``` ruby
     # hardware_platform.rb
@@ -119,7 +119,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact will be available to use in your manifests and templates.
+3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact will be available to use in your manifests and templates.
 
 ## Using other facts
 
@@ -360,9 +360,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path for your version of Windows. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. At the moment the following extensions are supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -452,8 +452,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -490,6 +490,6 @@ found in the stdlib module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
-* Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.
+-   Distributing executable facts through pluginsync requires Puppet 3.4.0 or greater.

--- a/source/facter/3.6/custom_facts.md
+++ b/source/facter/3.6/custom_facts.md
@@ -6,7 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-
 You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
 
 ## Adding custom facts to Facter
@@ -21,9 +20,9 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 Facter offers multiple methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option
+-   The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -83,8 +82,8 @@ This allows you to do something like this:
 
 Most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -95,9 +94,9 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
-* Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
+-   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
 >**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
@@ -105,8 +104,9 @@ execute shell commands:
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
 
-1. Start by giving the fact a name, in this case, `hardware_platform`.
-2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+1.  Start by giving the fact a name, in this case, `hardware_platform`.
+
+2.  Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
 
     ``` ruby
     # hardware_platform.rb
@@ -118,7 +118,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
+3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
 
 ## Using other facts
 
@@ -355,9 +355,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -447,8 +447,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -485,5 +485,5 @@ found in the `stdlib` module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.

--- a/source/facter/3.7/custom_facts.md
+++ b/source/facter/3.7/custom_facts.md
@@ -6,7 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-
 You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
 
 ## Adding custom facts to Facter
@@ -21,9 +20,9 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 Facter offers multiple methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option
+-   The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -95,18 +94,19 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
-* Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
+-   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
->**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
+> **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### Example
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
 
-1. Start by giving the fact a name, in this case, `hardware_platform`.
-2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+1.  Start by giving the fact a name, in this case, `hardware_platform`.
+
+2.  Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
 
     ``` ruby
     # hardware_platform.rb
@@ -118,7 +118,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
+3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
 
 ## Using other facts
 
@@ -355,9 +355,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -447,8 +447,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -485,5 +485,5 @@ found in the `stdlib` module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.

--- a/source/facter/3.8/custom_facts.md
+++ b/source/facter/3.8/custom_facts.md
@@ -6,7 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-
 You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
 
 ## Adding custom facts to Facter
@@ -21,9 +20,9 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 Facter offers multiple methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option
+-   The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -83,8 +82,8 @@ This allows you to do something like this:
 
 Most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -95,18 +94,19 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
-* Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
+-   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
->**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
+> **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### Example
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
 
-1. Start by giving the fact a name, in this case, `hardware_platform`.
-2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+1.  Start by giving the fact a name, in this case, `hardware_platform`.
+
+2.  Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
 
     ``` ruby
     # hardware_platform.rb
@@ -118,7 +118,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
+3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
 
 ## Using other facts
 
@@ -355,9 +355,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -447,8 +447,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -485,5 +485,5 @@ found in the `stdlib` module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.

--- a/source/facter/3.9/custom_facts.md
+++ b/source/facter/3.9/custom_facts.md
@@ -6,7 +6,6 @@ title: "Custom facts walkthrough"
 [Facter 3.0.2 release notes]: /facter/3.0/release_notes.html#facter--p-restored
 [Plugins in Modules]: /guides/plugins_in_modules.html
 
-
 You can add custom facts by writing snippets of Ruby code on the Puppet master. Puppet then uses [Plugins in Modules][] to distribute the facts to the client.
 
 ## Adding custom facts to Facter
@@ -21,9 +20,9 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 Facter offers multiple methods of loading facts:
 
-* `$LOAD\_PATH`, or the Ruby library load path
-* The `--custom-dir` command line option
-* The environment variable 'FACTERLIB'
+-   `$LOAD\_PATH`, or the Ruby library load path
+-   The `--custom-dir` command line option
+-   The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -83,8 +82,8 @@ This allows you to do something like this:
 
 Most facts have at least two elements:
 
-1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
-2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1.  A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -95,18 +94,19 @@ get that information is by executing shell commands. You can then parse and mani
 output from those commands using standard Ruby code. The Facter API gives you a few ways to
 execute shell commands:
 
-* To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
-* Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
+-   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
->**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
+> **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### Example
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
 
-1. Start by giving the fact a name, in this case, `hardware_platform`.
-2. Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
+1.  Start by giving the fact a name, in this case, `hardware_platform`.
+
+2.  Create your new fact in a file, `hardware_platform.rb` on the Puppet master server:
 
     ``` ruby
     # hardware_platform.rb
@@ -118,7 +118,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
+3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next Puppet run, the value of the new fact is available to use in your manifests and templates.
 
 ## Using other facts
 
@@ -355,9 +355,9 @@ Using this format, a single script can return multiple facts.
 
 Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
 
-- `.com` and `.exe`: binary executables
-- `.bat` and `.cmd`: batch scripts
-- `.ps1`: PowerShell scripts
+-   `.com` and `.exe`: binary executables
+-   `.bat` and `.cmd`: batch scripts
+-   `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
@@ -447,8 +447,8 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
-* The line endings can be either `LF` or `CRLF`.
-* The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+-   The line endings can be either `LF` or `CRLF`.
+-   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting
 
@@ -485,5 +485,5 @@ found in the `stdlib` module.
 
 While external facts provide a mostly-equal way to create variables for Puppet, they have a few drawbacks:
 
-* An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
-* External executable facts are forked instead of executed within the same process.
+-   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+-   External executable facts are forked instead of executed within the same process.


### PR DESCRIPTION
-   Consistently apply four-character indentations for list items on the Facter custom facts page. This resolves an issue where a code block did not render correctly, and makes future changes to this page less likely to result in similar issues.
-   Remove extraneous headings from older versions of the page.