### PR TITLE
(DOCUMENT-734) Update links to PuppetDB and Server.

### DIFF
--- a/source/puppet/4.10/index.md
+++ b/source/puppet/4.10/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: {{hiera}}/
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/5.1/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html

--- a/source/puppet/4.2/index.md
+++ b/source/puppet/4.2/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: /facter/latest/
 [Hiera 3]: /hiera/latest/
-[Puppet Server 2.1]: /puppetserver/latest/
-[PuppetDB 3]: /puppetdb/latest/
+[Puppet Server]: /puppetserver/2.1/
+[PuppetDB]: /puppetdb/3.1/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.2 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.1][].
-* A `puppetdb` package that installs [PuppetDB 3][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.3/index.md
+++ b/source/puppet/4.3/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: /facter/latest/
 [Hiera 3]: /hiera/latest/
-[Puppet Server 2.2]: /puppetserver/latest/
-[PuppetDB 3]: /puppetdb/latest/
+[Puppet Server]: /puppetserver/2.2/
+[PuppetDB]: /puppetdb/3.2/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.3 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.2][].
-* A `puppetdb` package that installs [PuppetDB 3][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.4/index.md
+++ b/source/puppet/4.4/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: {{facter}}/
 [Hiera 3]: {{hiera}}/
-[Puppet Server 2.3]: {{puppetserver}}/
-[PuppetDB 3]: {{puppetdb}}/
+[Puppet Server]: /puppetserver/2.3/
+[PuppetDB]: /puppetdb/4.0/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.4 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.3][].
-* A `puppetdb` package that installs [PuppetDB 3][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.5/index.md
+++ b/source/puppet/4.5/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: {{facter}}/
 [Hiera 3]: {{hiera}}/
-[Puppet Server 2.4]: {{puppetserver}}/
-[PuppetDB 4]: {{puppetdb}}/
+[Puppet Server]: /puppetserver/2.4/
+[PuppetDB]: /puppetdb/4.1/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.5 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.4][].
-* A `puppetdb` package that installs [PuppetDB 4][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.6/index.md
+++ b/source/puppet/4.6/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: {{facter}}/
 [Hiera 3]: {{hiera}}/
-[Puppet Server 2.4]: {{puppetserver}}/
-[PuppetDB 4]: {{puppetdb}}/
+[Puppet Server]: /puppetserver/2.4/
+[PuppetDB]: /puppetdb/4.2/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.6 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.4][].
-* A `puppetdb` package that installs [PuppetDB 4][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.7/index.md
+++ b/source/puppet/4.7/index.md
@@ -9,8 +9,8 @@ toc: false
 [pre-install instructions]: ./install_pre.html
 [Facter 3]: {{facter}}/
 [Hiera 3]: {{hiera}}/
-[Puppet Server 2.4]: {{puppetserver}}/
-[PuppetDB 4]: {{puppetdb}}/
+[Puppet Server]: /puppetserver/2.4/
+[PuppetDB]: /puppetdb/4.2/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -33,8 +33,8 @@ For an introduction to how Puppet manages systems, see the [Overview of Puppet's
 Puppet 4.7 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
-* A `puppetserver` package that installs [Puppet Server 2.4][].
-* A `puppetdb` package that installs [PuppetDB 4][].
+* A `puppetserver` package that installs [Puppet Server][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.8/index.md
+++ b/source/puppet/4.8/index.md
@@ -10,7 +10,7 @@ toc: false
 [Facter 3]: {{facter}}/
 [Hiera 3]: {{hiera}}/
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB 4]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/4.2/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html
@@ -34,7 +34,7 @@ Puppet 4.8 consists of:
 
 * A `puppet-agent` "All-in-One" package that installs Puppet, Ruby, [Facter 3][], [Hiera 3][], and supporting code.
 * A `puppetserver` package that installs [Puppet Server][].
-* A `puppetdb` package that installs [PuppetDB 4][].
+* A `puppetdb` package that installs [PuppetDB][].
 
 To install these, read the [pre-install instructions][], then see the Puppet installation guides for [Linux][Linux installation], [Windows][Windows installation], and [Mac OS X][OSX installation].
 

--- a/source/puppet/4.9/index.md
+++ b/source/puppet/4.9/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: {{hiera}}/
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/4.3/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [OSX installation]: ./install_osx.html

--- a/source/puppet/5.0/index.md
+++ b/source/puppet/5.0/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: ./hiera_intro.html
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/4.4/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [macOS installation]: ./install_osx.html

--- a/source/puppet/5.1/index.md
+++ b/source/puppet/5.1/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: ./hiera_intro.html
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/5.0/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [macOS installation]: ./install_osx.html

--- a/source/puppet/5.2/index.md
+++ b/source/puppet/5.2/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: ./hiera_intro.html
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/5.1/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [macOS installation]: ./install_osx.html

--- a/source/puppet/5.3/index.md
+++ b/source/puppet/5.3/index.md
@@ -9,7 +9,7 @@ toc: false
 [Facter]: {{facter}}/
 [Hiera]: ./hiera_intro.html
 [Puppet Server]: {{puppetserver}}/
-[PuppetDB]: {{puppetdb}}/
+[PuppetDB]: /puppetdb/5.1/
 [Linux installation]: ./install_linux.html
 [Windows installation]: ./install_windows.html
 [macOS installation]: ./install_osx.html


### PR DESCRIPTION
Autogenerated version links to PuppetDB and Puppet Server did not always link to the version corresponding to that Puppet release on each Puppet release's index page.

-   Update those links on index pages to specify the appropriate version.
-   Remove some version-specific text in link text.