### PR TITLE
Fix for typo on the "Creating Environments" page

### DIFF
--- a/source/puppet/4.10/environments_creating.markdown
+++ b/source/puppet/4.10/environments_creating.markdown
@@ -41,7 +41,7 @@ When you create an environment, you give it the following structure:
 {:.Concept}
 ## Environment resources
  
-An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `envronment.conf`. 
+An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `environment.conf`. 
  
 ### The `modulepath`
 

--- a/source/puppet/5.0/environments_creating.markdown
+++ b/source/puppet/5.0/environments_creating.markdown
@@ -45,7 +45,7 @@ When you create an environment, you give it the following structure:
 {:.Concept}
 ## Environment resources
  
-An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `envronment.conf`. 
+An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `environment.conf`. 
  
 ### The `modulepath`
 

--- a/source/puppet/5.1/environments_creating.markdown
+++ b/source/puppet/5.1/environments_creating.markdown
@@ -45,7 +45,7 @@ When you create an environment, you give it the following structure:
 {:.Concept}
 ## Environment resources
  
-An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `envronment.conf`. 
+An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `environment.conf`. 
  
 ### The `modulepath`
 

--- a/source/puppet/5.2/environments_creating.markdown
+++ b/source/puppet/5.2/environments_creating.markdown
@@ -45,7 +45,7 @@ When you create an environment, you give it the following structure:
 {:.Concept}
 ## Environment resources
  
-An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `envronment.conf`. 
+An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `environment.conf`. 
  
 ### The `modulepath`
 

--- a/source/puppet/5.3/environments_creating.markdown
+++ b/source/puppet/5.3/environments_creating.markdown
@@ -45,7 +45,7 @@ When you create an environment, you give it the following structure:
 {:.Concept}
 ## Environment resources
  
-An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `envronment.conf`. 
+An environment specifies resources that the Puppet master will use when compiling catalogs for agent nodes. The `modulepath`, the main manifest, hiera data, and the config version script, can all be specified in `environment.conf`. 
  
 ### The `modulepath`
 


### PR DESCRIPTION
Just a fix for a small but persistent typo.