### PR TITLE
Fix _environment_conf_settings.md for puppet 4.1 - 4.3 and 5.3

### DIFF
--- a/source/puppet/4.1/_environment_conf_settings.md
+++ b/source/puppet/4.1/_environment_conf_settings.md
@@ -1,4 +1,4 @@
-In this version of Puppet, the environment.conf file is only allowed to override five settings:
+In this version of Puppet, the environment.conf file is only allowed to override four settings:
 
 * `modulepath`
 * `manifest`

--- a/source/puppet/4.2/_environment_conf_settings.md
+++ b/source/puppet/4.2/_environment_conf_settings.md
@@ -1,4 +1,4 @@
-In this version of Puppet, the environment.conf file is only allowed to override five settings:
+In this version of Puppet, the environment.conf file is only allowed to override four settings:
 
 * `modulepath`
 * `manifest`

--- a/source/puppet/4.3/_environment_conf_settings.md
+++ b/source/puppet/4.3/_environment_conf_settings.md
@@ -1,4 +1,4 @@
-In this version of Puppet, the environment.conf file is only allowed to override five settings:
+In this version of Puppet, the environment.conf file is only allowed to override four settings:
 
 * `modulepath`
 * `manifest`

--- a/source/puppet/5.3/_environment_conf_settings.md
+++ b/source/puppet/5.3/_environment_conf_settings.md
@@ -1,6 +1,7 @@
 In this version of Puppet, the environment.conf file is only allowed to override five settings:
 
-* `modulepath`
-* `manifest`
-* `config_version`
-* `environment_timeout`
+-   `modulepath`
+-   `manifest`
+-   `config_version`
+-   `environment_timeout`
+-   `static_catalogs`


### PR DESCRIPTION
Noticed there was a discrepancy between the declared and the actual numbers of overridable settings in `environment.conf`.

Correct me if I'm wrong here - I'm assuming there was an issue during this [commit](https://github.com/puppetlabs/puppet-docs/commit/27dcf500f7ab7e31473bba878b544940f7ce16b1) - maybe there are some other things that need to be checked?