### PR TITLE
(DOCUMENT-779) Remove escape sequence CRLF breaks.

### DIFF
--- a/source/puppet/4.1/resources_file_windows.markdown
+++ b/source/puppet/4.1/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.10/resources_file_windows.markdown
+++ b/source/puppet/4.10/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.2/resources_file_windows.markdown
+++ b/source/puppet/4.2/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.3/resources_file_windows.markdown
+++ b/source/puppet/4.3/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.4/resources_file_windows.markdown
+++ b/source/puppet/4.4/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.5/resources_file_windows.markdown
+++ b/source/puppet/4.5/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.6/resources_file_windows.markdown
+++ b/source/puppet/4.6/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.7/resources_file_windows.markdown
+++ b/source/puppet/4.7/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.8/resources_file_windows.markdown
+++ b/source/puppet/4.8/resources_file_windows.markdown
@@ -90,7 +90,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/4.9/resources_file_windows.markdown
+++ b/source/puppet/4.9/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/5.0/resources_file_windows.markdown
+++ b/source/puppet/5.0/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/5.1/resources_file_windows.markdown
+++ b/source/puppet/5.1/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/5.2/resources_file_windows.markdown
+++ b/source/puppet/5.2/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.

--- a/source/puppet/5.3/resources_file_windows.markdown
+++ b/source/puppet/5.3/resources_file_windows.markdown
@@ -88,7 +88,6 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-    * If the manifest, template, or source file is saved with LF line endings, you can use the `\r\n` escape sequence to create literal CRLFs.
 * Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.


### PR DESCRIPTION
Remove a line from the documentation stating that the `/r/n` escape
sequence can create CRLF line breaks in template file output, per
[DOCUMENT-779](https://tickets.puppetlabs.com/browse/DOCUMENT-779)
and [PUP-8240](https://tickets.puppetlabs.com/browse/PUP-8240).