### PR TITLE
(DOC-2699) Restore and add ppAuthCertExt OID range/certext docs

### DIFF
--- a/source/puppet/4.10/_registered_oids.md
+++ b/source/puppet/4.10/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.10/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.10/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/4.3/_registered_oids.md
+++ b/source/puppet/4.3/_registered_oids.md
@@ -27,8 +27,3 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
-
-The "ppAuthCertExt" OID range contains the following OIDs:
-
-1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
-1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.3/_registered_oids.md
+++ b/source/puppet/4.3/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.4/_registered_oids.md
+++ b/source/puppet/4.4/_registered_oids.md
@@ -27,8 +27,3 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
-
-The "ppAuthCertExt" OID range contains the following OIDs:
-
-1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
-1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.4/_registered_oids.md
+++ b/source/puppet/4.4/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.5/_registered_oids.md
+++ b/source/puppet/4.5/_registered_oids.md
@@ -27,8 +27,3 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
-
-The "ppAuthCertExt" OID range contains the following OIDs:
-
-1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
-1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.5/_registered_oids.md
+++ b/source/puppet/4.5/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.6/_registered_oids.md
+++ b/source/puppet/4.6/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.6/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.6/ssl_attributes_extensions.markdown
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates
@@ -56,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -65,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -110,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -164,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/4.7/_registered_oids.md
+++ b/source/puppet/4.7/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.7/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.7/ssl_attributes_extensions.markdown
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates
@@ -56,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -65,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -110,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -164,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/4.8/_registered_oids.md
+++ b/source/puppet/4.8/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.8/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.8/ssl_attributes_extensions.markdown
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
-canonical: "/puppet/latest/ssl_attributes_extensions.html"
 ---
 
 [cert_request]: ./subsystem_agent_master_comm.html#check-for-keys-and-certificates
@@ -56,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -65,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -110,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -164,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/4.9/_registered_oids.md
+++ b/source/puppet/4.9/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/4.9/ssl_attributes_extensions.markdown
+++ b/source/puppet/4.9/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/5.0/_registered_oids.md
+++ b/source/puppet/5.0/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/5.0/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.0/ssl_attributes_extensions.markdown
@@ -111,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/latest/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 

--- a/source/puppet/5.0/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.0/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/5.1/_registered_oids.md
+++ b/source/puppet/5.1/_registered_oids.md
@@ -27,3 +27,9 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/5.1/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.1/ssl_attributes_extensions.markdown
@@ -111,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/latest/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 

--- a/source/puppet/5.1/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.1/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/5.2/_registered_oids.md
+++ b/source/puppet/5.2/_registered_oids.md
@@ -27,3 +27,9 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/5.2/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.2/ssl_attributes_extensions.markdown
@@ -111,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/latest/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 

--- a/source/puppet/5.2/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.2/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.

--- a/source/puppet/5.3/_registered_oids.md
+++ b/source/puppet/5.3/_registered_oids.md
@@ -27,3 +27,8 @@ Numeric ID              | Short Name         | Descriptive Name
 1.3.6.1.4.1.34380.1.1.23 | `pp_cloudplatform` | Puppet Node Cloud Platform Name
 1.3.6.1.4.1.34380.1.1.24 | `pp_apptier`      | Puppet Node Application Tier
 1.3.6.1.4.1.34380.1.1.25 | `pp_hostname`     | Puppet Node Hostname
+
+The "ppAuthCertExt" OID range contains the following OIDs:
+
+1.3.6.1.4.1.34380.1.3.1  | `pp_authorization` | Certificate Extension Authorization
+1.3.6.1.4.1.34380.1.3.13 | `pp_auth_role` | Puppet Node Role Name for Authorization

--- a/source/puppet/5.3/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.3/ssl_attributes_extensions.markdown
@@ -111,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/latest/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 

--- a/source/puppet/5.3/ssl_attributes_extensions.markdown
+++ b/source/puppet/5.3/ssl_attributes_extensions.markdown
@@ -55,7 +55,7 @@ See the respective sections below for information about how each hash is used an
 
 ### Default behavior
 
-By default, Puppet's CA tools don't do anything with custom attributes. The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
+The `puppet cert list` command doesn't display custom attributes for pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing.
 
 ### Configurable behavior
 
@@ -64,6 +64,8 @@ If you use [policy-based autosigning][autosign_policy], your policy executable r
 The simplest use is to embed a pre-shared key of some kind in the custom attributes. A policy executable can compare it to a list of known keys and autosign certificates for any pre-authorized nodes.
 
 A more complex use might be to embed an instance-specific ID and write a policy executable that can check it against a list of your recently requested instances on a public cloud, like EC2 or GCE.
+
+If you use Puppet Server 2.5.0 or newer, you can also sign requests using authorization extensions and the `--allow-authorization-extensions` flag for `puppet cert sign`.
 
 ### Manually checking for custom attributes in CSRs
 
@@ -109,7 +111,7 @@ Visibility of extensions is somewhat limited:
 * The `puppet cert list` command _does not_ display custom attributes for any pending CSRs, and [basic autosigning (autosign.conf)][autosign_basic] doesn't check them before signing. Either use [policy-based autosigning][autosign_policy] or inspect CSRs manually with the `openssl` command (see below).
 * The `puppet cert print` command _does_ display any extensions in a signed certificate, under the "X509v3 extensions" section.
 
-Puppet's authorization system (`auth.conf`) does not use certificate extensions.
+Puppet's authorization system (`auth.conf`) does not use certificate extensions, but [Puppet Server's authorization system](/puppetserver/2.7/config_file_auth.html), which is based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and requires them for requests to write access rules.
 
 ### Configurable behavior
 
@@ -163,9 +165,11 @@ X509v3 extensions:
 
 ### Recommended OIDs for extensions
 
-Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs.
+Extension request OIDs **must** be under the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`), "ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or "ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs.
 
-Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, as well as a private OID range ("ppPrivCertExt") for site-specific extension information. There are several benefits to using the registered OIDs:
+Puppet provides several registered OIDs (under "ppRegCertExt") for the most common kinds of extension information, a private OID range ("ppPrivCertExt") for site-specific extension information, and an OID range for safe authorization to Puppet Server ("ppAuthCertExt").
+
+There are several benefits to using the registered OIDs:
 
 * You can reference them in `csr_attributes.yaml` with their short names instead of their numeric IDs.
 * You can access them in `$trusted[extensions]` with their short names instead of their numeric IDs.


### PR DESCRIPTION
At some point the ppAuthCertExt OID range was removed from the _registered_oids.md partial. Restore those and add them to all versions since 4.6. Add minimal docs about the auth range.

**Two files were changed — _registered_oids.md and ssl_attributes_extensions.markdown — but this PR modifies 21 files because the same changes to are duplicated across all relevant versions of the Puppet docs. No need to review each version unless different behavior is expected for specific versions.**