### PR TITLE
(DOC-3437) Edit and clarify SSL autosigning docs.

### DIFF
--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -27,7 +27,7 @@ The default `confdir` path depends on your operating system. [See the confdir do
 
 ## Format
 
-The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names whose certificate requests that the CA Puppet master automatically signs upon receipt.
+The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names for which the CA Puppet master will automatically sign certificate requests.
 
     rebuilt.example.com
     *.scratch.example.com
@@ -35,4 +35,6 @@ The `autosign.conf` file is a line-separated list of certnames or domain name gl
 
 Domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name (FQDN). If your certnames don't look like FQDNs, the `autosign.conf` whitelist might not be effective.
 
-> **Note:** The `autosign.conf` file can safely be an empty file or not-existent, even if the `autosign` setting is enabled. An empty or non-existent `autosign.conf` file simply does nothing.
+> **Note:** The `autosign.conf` file can safely be an empty file or not-existent, even if the `autosign` setting is enabled. An empty or non-existent `autosign.conf` file is an empty whitelist, meaning that Puppet does not autosign any requests. If you create `autosign.conf` as a non-executable file and add certnames to it, Puppet then automatically uses the file to whitelist incoming requests without needing to modify `puppet.conf`.
+>
+> To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of `puppet.conf`.

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -37,4 +37,4 @@ Domain name globs do not function as normal globs: an asterisk can only represen
 
 > **Note:** The `autosign.conf` file can safely be an empty file or not-existent, even if the `autosign` setting is enabled. An empty or non-existent `autosign.conf` file is an empty whitelist, meaning that Puppet does not autosign any requests. If you create `autosign.conf` as a non-executable file and add certnames to it, Puppet then automatically uses the file to whitelist incoming requests without needing to modify `puppet.conf`.
 >
-> To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of `puppet.conf`.
+>  +To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -10,7 +10,7 @@ The `autosign.conf` file can allow certain certificate requests to be automatica
 
 ## More about autosigning
 
-Puppet also provides a policy-based interface for autosigning, which can be more flexible and secure. The `autosign.conf` file is the simpler and less secure method.
+Since any host can request any certname, autosigning with `autosign.conf` is essentially insecure. Puppet also provides a policy-based interface for autosigning, which can be more flexible and secure but more complex to set up and configure.
 
 For more details, see [the reference page about certificate autosigning][autosigning].
 
@@ -30,7 +30,4 @@ The `autosign.conf` file is a list of certnames or domain name globs (one per li
     *.scratch.example.com
     *.local
 
-Note that domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully-qualified domain name. (That is, if your certnames don't look like FQDNs, you can't use `autosign.conf` to full effect.
-
-**Note:** Since any host can request any certname, autosigning with `autosign.conf` is essentially insecure. See [the reference page about certificate autosigning][autosigning] for more context.
-
+Note that domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name. (That is, if your certnames don't look like FQDNs, you can't use `autosign.conf` to full effect.)

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -29,12 +29,14 @@ The default `confdir` path depends on your operating system. [See the confdir do
 
 The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names for which the CA Puppet master will automatically sign certificate requests.
 
-    rebuilt.example.com
-    *.scratch.example.com
-    *.local
+```
+rebuilt.example.com
+*.scratch.example.com
+*.local
+```
 
 Domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name (FQDN). If your certnames don't look like FQDNs, the `autosign.conf` whitelist might not be effective.
 
 > **Note:** The `autosign.conf` file can safely be an empty file or not-existent, even if the `autosign` setting is enabled. An empty or non-existent `autosign.conf` file is an empty whitelist, meaning that Puppet does not autosign any requests. If you create `autosign.conf` as a non-executable file and add certnames to it, Puppet then automatically uses the file to whitelist incoming requests without needing to modify `puppet.conf`.
 >
->  +To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.
+> To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -4,30 +4,31 @@ title: "Config files: autosign.conf"
 ---
 
 [autosigning]: ./ssl_autosign.html
-[autosign]: ./configuration.html#autosign
+[autosign setting]: ./configuration.html#autosign
+[confdir]: ./dirs_confdir.html
 
-The `autosign.conf` file can allow certain certificate requests to be automatically signed. It is only valid on the CA Puppet master server; a Puppet master that is not serving as a CA will not consult `autosign.conf`.
+The `autosign.conf` file can allow certain certificate requests to be automatically signed. It is only valid on the CA Puppet master server; a Puppet master not serving as a CA does not use `autosign.conf`.
 
 ## More about autosigning
 
-Since any host can request any certname, autosigning with `autosign.conf` is essentially insecure. Puppet also provides a policy-based interface for autosigning, which can be more flexible and secure but more complex to set up and configure.
+> **Warning:** Since any host can request any certname, autosigning with `autosign.conf` is essentially **insecure**.
 
-For more details, see [the reference page about certificate autosigning][autosigning].
+Puppet also provides a policy-based autosigning interface using custom policy executables, which can be more flexible and secure than the `autosign.conf` whitelist but more complex to configure.
+
+For more information, see [the documentation about certificate autosigning][autosigning].
 
 ## Location
 
-The `autosign.conf` file is located at `$confdir/autosign.conf` by default. Its location is configurable with the [`autosign` setting][autosign].
+The `autosign.conf` file is located at `$confdir/autosign.conf` by default. To change this path, configure the [`autosign` setting][autosign setting] in `puppet.conf` or as a command-line flag.
 
-The location of the `confdir` depends on your OS. [See the confdir documentation for details.][confdir]
-
-[confdir]: ./dirs_confdir.html
+The default `confdir` path depends on your operating system. [See the confdir documentation for more information.][confdir]
 
 ## Format
 
-The `autosign.conf` file is a list of certnames or domain name globs (one per line). Each line represents a node name or group of node names whose certificate requests should be automatically signed when the CA Puppet master receives them.
+The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names whose certificate requests that the CA Puppet master should automatically sign upon receipt.
 
     rebuilt.example.com
     *.scratch.example.com
     *.local
 
-Note that domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name. (That is, if your certnames don't look like FQDNs, you can't use `autosign.conf` to full effect.)
+Domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name (FQDN). If your certnames don't look like FQDNs, the `autosign.conf` whitelist might not be effective.

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -27,7 +27,7 @@ The default `confdir` path depends on your operating system. [See the confdir do
 
 ## Format
 
-The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names whose certificate requests that the CA Puppet master should automatically sign upon receipt.
+The `autosign.conf` file is a line-separated list of certnames or domain name globs. Each line represents a node name or group of node names whose certificate requests that the CA Puppet master automatically signs upon receipt.
 
     rebuilt.example.com
     *.scratch.example.com

--- a/source/puppet/5.3/config_file_autosign.markdown
+++ b/source/puppet/5.3/config_file_autosign.markdown
@@ -11,7 +11,7 @@ The `autosign.conf` file can allow certain certificate requests to be automatica
 
 ## More about autosigning
 
-> **Warning:** Since any host can request any certname, autosigning with `autosign.conf` is essentially **insecure**.
+> **Warning:** Because any host can provide any certname when requesting a certificate, basic autosigning is essentially **insecure**. Use it only when you fully trust any computer capable of connecting to the Puppet master.
 
 Puppet also provides a policy-based autosigning interface using custom policy executables, which can be more flexible and secure than the `autosign.conf` whitelist but more complex to configure.
 
@@ -19,9 +19,11 @@ For more information, see [the documentation about certificate autosigning][auto
 
 ## Location
 
-The `autosign.conf` file is located at `$confdir/autosign.conf` by default. To change this path, configure the [`autosign` setting][autosign setting] in `puppet.conf` or as a command-line flag.
+Puppet looks for `autosign.conf` at `$confdir/autosign.conf` by default. To change this path, configure the [`autosign` setting][autosign setting] in the `[master]` section of `puppet.conf`.
 
 The default `confdir` path depends on your operating system. [See the confdir documentation for more information.][confdir]
+
+> **Note:** The `autosign.conf` file must not be executable by the Puppet master's user account. If the `autosign` setting points to an executable file, Puppet instead treats it like a custom policy executable even if it contains a valid `autosign.conf` whitelist.
 
 ## Format
 
@@ -32,3 +34,5 @@ The `autosign.conf` file is a line-separated list of certnames or domain name gl
     *.local
 
 Domain name globs do not function as normal globs: an asterisk can only represent one or more subdomains at the front of a certname that resembles a fully qualified domain name (FQDN). If your certnames don't look like FQDNs, the `autosign.conf` whitelist might not be effective.
+
+> **Note:** The `autosign.conf` file can safely be an empty file or not-existent, even if the `autosign` setting is enabled. An empty or non-existent `autosign.conf` file simply does nothing.

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -6,9 +6,7 @@ title: "SSL configuration: autosigning certificate requests"
 [external_ca]: ./config_ssl_external_ca.html
 [csr_attributes]: ./ssl_attributes_extensions.html
 
-
-CSRs, certificates, and autosigning
------
+## CSRs, certificates, and autosigning
 
 Before Puppet agent nodes can retrieve their configuration catalogs, they need a signed certificate from the local Puppet certificate authority (CA). When using Puppet's built-in CA (that is, not [using an external CA][external_ca]), agents will submit a certificate signing request (CSR) to the CA Puppet master and will retrieve a signed certificate once one is available.
 
@@ -16,9 +14,7 @@ By default, these CSRs must be manually signed by an admin user, using either th
 
 Alternately, you can configure the CA Puppet master to automatically sign certain CSRs to speed up the process of bringing new agent nodes into the deployment.
 
-
 > **Important security note:** Autosigning CSRs will change the nature of your deployment's security, and you should be sure you understand the implications before configuring it. Each kind of autosigning has its own security impact.
-
 
 ## Disabling autosigning
 
@@ -38,8 +34,7 @@ To enable naïve autosigning, set `autosign = true` in the `[master]` section of
 
 **You should never do this in a production deployment.** Naïve autosigning is only suitable for temporary test deployments that are incapable of serving catalogs containing sensitive information.
 
-Basic Autosigning (autosign.conf)
------
+## Basic Autosigning (autosign.conf)
 
 [inpage_basic]: #basic-autosigning-autosignconf
 
@@ -67,7 +62,6 @@ Since any host can provide any certname when requesting a certificate, basic aut
 
 With basic autosigning enabled, an attacker able to guess an unused certname allowed by `autosign.conf` would be able to obtain a signed agent certificate from the Puppet master. They would then be able to obtain a configuration catalog, which might or might not contain sensitive information (depending on your deployment's Puppet code and node classification).
 
-
 ## Policy-based autosigning
 
 In policy-based autosigning, the CA will run an external policy executable every time it receives a CSR. This executable will examine the CSR and tell the CA whether the certificate is approved for autosigning. If the executable approves, the certificate is autosigned; if not, it is left for manual review.
@@ -90,27 +84,26 @@ If you aren't embedding additional data, the CSR will contain only the node's ce
 
 Policy-based autosigning can be both fast and extremely secure, _depending on how you manage the information the policy executable is using._ For example:
 
-* If you embed a unique pre-shared key in each node when you provision it, and provide your policy executable with a database of these keys, your autosigning security will be as good as your handling of the keys --- as long as it's impractical for an attacker to acquire a PSK, it will be impractical for them to acquire a signed certificate.
-* If nodes running on a cloud service embed their instance UUIDs in their CSRs, and your executable queries the cloud provider's API to check that a node with that UUID exists in your account, your autosigning security will be as good as the security of the cloud provider's API. If an attacker can impersonate a legit user to the API and get a list of node UUIDs, or if they can create a rogue node in your account, they can acquire a signed certificate.
+-   If you embed a unique pre-shared key in each node when you provision it, and provide your policy executable with a database of these keys, your autosigning security will be as good as your handling of the keys --- as long as it's impractical for an attacker to acquire a PSK, it will be impractical for them to acquire a signed certificate.
+-   If nodes running on a cloud service embed their instance UUIDs in their CSRs, and your executable queries the cloud provider's API to check that a node with that UUID exists in your account, your autosigning security will be as good as the security of the cloud provider's API. If an attacker can impersonate a legit user to the API and get a list of node UUIDs, or if they can create a rogue node in your account, they can acquire a signed certificate.
 
 As you can see, you must think things through carefully when designing your CSR data and signing policy. As long as you can arrange reasonable end-to-end security for secret data on your nodes, you should be able to rig up a secure autosigning system.
-
 
 ### Policy executable API
 
 The API for policy executables is as follows:
 
-* **Run environment:** The executable will be run once for each incoming CSR.
-    * It will be executed by the Puppet master process and will run as the same user as the Puppet master.
-    * The Puppet master process will _block until the executable finishes running._ We expect policy executables to finish in a timely fashion; if they do not, it's possible for them to tie up all available Puppet master threads and deny service to other agent nodes. If an executable needs to perform network requests or other potentially expensive operations, the author is in charge of implementing any necessary timeouts, possibly bailing and exiting non-zero in the event of failure.
-    * (Note that under a Rack server like Passenger, there are generally multiple Puppet master processes available at any given time, so policy executables have a little bit of leeway.)
-* **Arguments:** The executable must allow a single command line argument. This argument will be the Subject CN (certname) of the incoming CSR.
-    * No other command line arguments should be provided.
-    * The Puppet master should never fail to provide this argument.
-* **Stdin:** The executable will receive the entirety of the incoming CSR on its stdin stream. The CSR will be encoded in PEM format.
-    * The stdin stream will contain nothing but the complete CSR.
-    * The Puppet master should never fail to provide the CSR on stdin.
-* **Exit status:** The executable must exit with a status of `0` if the certificate should be autosigned; it must exit with a non-zero status if it should not be autosigned.
-    * The Puppet master will treat all non-zero exit statuses as equivalent.
-* **Stdout and stderr:** Anything the executable emits on stdout or stderr will be copied to the Puppet master's log output at the `debug` log level. Puppet will otherwise ignore the executable's output; only the exit code is considered significant.
+-   **Run environment:** The executable will be run once for each incoming CSR.
+    -   It will be executed by the Puppet master process and will run as the same user as the Puppet master.
+    -   The Puppet master process will _block until the executable finishes running._ We expect policy executables to finish in a timely fashion; if they do not, it's possible for them to tie up all available Puppet master threads and deny service to other agent nodes. If an executable needs to perform network requests or other potentially expensive operations, the author is in charge of implementing any necessary timeouts, possibly bailing and exiting non-zero in the event of failure.
+    -   (Note that under a Rack server like Passenger, there are generally multiple Puppet master processes available at any given time, so policy executables have a little bit of leeway.)
+-   **Arguments:** The executable must allow a single command line argument. This argument will be the Subject CN (certname) of the incoming CSR.
+    -   No other command line arguments should be provided.
+    -   The Puppet master should never fail to provide this argument.
+-   **Stdin:** The executable will receive the entirety of the incoming CSR on its stdin stream. The CSR will be encoded in PEM format.
+    -   The stdin stream will contain nothing but the complete CSR.
+    -   The Puppet master should never fail to provide the CSR on stdin.
+-   **Exit status:** The executable must exit with a status of `0` if the certificate should be autosigned; it must exit with a non-zero status if it should not be autosigned.
+    -   The Puppet master will treat all non-zero exit statuses as equivalent.
+-   **Stdout and stderr:** Anything the executable emits on stdout or stderr will be copied to the Puppet master's log output at the `debug` log level. Puppet will otherwise ignore the executable's output; only the exit code is considered significant.
 

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -24,7 +24,7 @@ By default, the `autosign` setting in the `[master]` section of the CA Puppet ma
 -   In monolithic Puppet Enterprise (PE) installations, where all required services run on one server, `autosign.conf` exists on the master, but it is empty by default because the master doesn't need to whitelist other servers.
 -   In split PE installations, where services like PuppetDB can run on different servers, `autosign.conf` exists on the CA master and contains a whitelist of other required hosts.
 
-If the `autosign.conf` file is empty or doesn't exist, the whitelist is empty. The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a whitelist or is a custom policy executable, or until the `autosign` setting is pointed at a whitelist file or custom policy executable.
+If the `autosign.conf` file is empty or doesn't exist, the whitelist is effectively empty. The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a whitelist or is a custom policy executable, or until the `autosign` setting is pointed at a whitelist file with properly formatted content or a custom policy executable that the Puppet user has permission to run.
 
 To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.
 
@@ -54,9 +54,11 @@ The `autosign.conf` whitelist file's location and contents are described in [its
 
 Puppet looks for `autosign.conf` at the path configured in the [`autosign` setting][autosign setting] in the `[master]` section of `puppet.conf`. The default path is `$confdir/autosign.conf`, and the default `confdir` path depends on your operating system. [See the confdir documentation for more information.](./dirs_confdir.html)
 
-> **Note:** In open source Puppet, no `autosign.conf` file exists by default. In Puppet Enterprise, the file exists by default but might be empty. In both cases, basic autosigning is enabled by default but doesn't autosign any certificates because an blank or non-existent whitelist is considered empty and no hostnames are whitelisted by default.
+If the `autosign.conf` file pointed to by the `autosign` setting is a file that the Puppet user can execute, Puppet instead attempts to run it as a custom policy executable even if it contains a valid `autosign.conf` whitelist.
 
-The `autosign.conf` file must not be executable by the Puppet master's user account. If the `autosign` setting points to an executable file, Puppet instead attempts to execute it as a custom policy executable even if it contains a valid `autosign.conf` whitelist.
+> **Note:** In open source Puppet, no `autosign.conf` file exists by default. In Puppet Enterprise, the file exists by default but might be empty. In both cases, the basic autosigning feature is technically enabled by default but doesn't autosign any certificates because the whitelist is effectively empty.
+>
+> The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a properly formatted whitelist or is a custom policy executable that the Puppet user has permission to run, or until the `autosign` setting is pointed at a whitelist file with properly formatted content or a custom policy executable that the Puppet user has permission to run.
 
 ### Security implications of basic autosigning
 

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -26,7 +26,7 @@ By default, the `autosign` setting in the `[master]` section of the CA Puppet ma
 
 If the `autosign.conf` file is empty or doesn't exist, the whitelist is empty. The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a whitelist or is a custom policy executable, or until the `autosign` setting is pointed at a whitelist file or custom policy executable.
 
-To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if autosign.conf or a custom policy executable exists.
+To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.
 
 For more information about the different autosigning methods, see [basic autosigning][inpage_basic] and [policy-based autosigning][inpage_policy]. For more information about the `autosign` setting in `puppet.conf`, see the [configuration reference](./configuration.html#autosign).
 
@@ -40,7 +40,7 @@ To enable naïve autosigning, set `autosign = true` in the `[master]` section of
 
 ### Security implications of naïve autosigning
 
-**You should never do this in a production deployment.** Naïve autosigning is only suitable for temporary test deployments that are incapable of serving catalogs containing sensitive information.
+**Never do this in a production deployment.** Naïve autosigning is suitable only for temporary test deployments incapable of serving catalogs containing sensitive information.
 
 ## Basic autosigning (autosign.conf)
 

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -24,9 +24,9 @@ By default, the `autosign` setting in the `[master]` section of the CA Puppet ma
 -   In monolithic Puppet Enterprise (PE) installations, where all required services run on one server, `autosign.conf` exists on the master, but it is empty by default because the master doesn't need to whitelist other servers.
 -   In split PE installations, where services like PuppetDB can run on different servers, `autosign.conf` exists on the CA master and contains a whitelist of other required hosts.
 
-If the `autosign.conf` file is empty or doesn't exist, the whitelist is effectively empty. The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a whitelist or is a custom policy executable, or until the `autosign` setting is pointed at a whitelist file with properly formatted content or a custom policy executable that the Puppet user has permission to run.
+If the `autosign.conf` file is empty or doesn't exist, the whitelist is effectively empty. The CA Puppet master therefore doesn't autosign any certificates until the default `autosign.conf` file, or the `autosign` setting's path if configured, is a non-executable whitelist file with properly formatted content or a custom policy executable that the Puppet user has permission to run.
 
-To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if `autosign.conf` or a custom policy executable exists.
+To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if the `autosign.conf` file or a custom policy executable exists.
 
 For more information about the different autosigning methods, see [basic autosigning][inpage_basic] and [policy-based autosigning][inpage_policy]. For more information about the `autosign` setting in `puppet.conf`, see the [configuration reference](./configuration.html#autosign).
 

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -18,13 +18,17 @@ Alternately, you can configure the CA Puppet master to automatically sign certai
 
 ## Disabling autosigning
 
-By default, the CA Puppet master's `autosign` setting defaults to `$confdir/autosign.conf`.
+By default, the `autosign` setting in the `[master]` section of the CA Puppet master's `puppet.conf` file is set to `$confdir/autosign.conf`, which means the basic autosigning functionality is enabled upon installation. However, depending on your installation method, there might not be a whitelist at that location once the Puppet master is running.
 
-In open source Puppet, this file doesn't exist by default. In Puppet Enterprise, it exists but is empty by default. In either case, the autosigning feature is enabled but the whitelist is empty, so the CA Puppet master doesn't autosign any certificates. In other words, the feature is implicity disabled until the `autosign.conf` file contains a whitelist or is a custom policy executable. For more information, see [basic autosigning][inpage_basic] and [policy-based autosigning][inpage_policy].
+-   In open source Puppet, `autosign.conf` doesn't exist by default.
+-   In monolithic Puppet Enterprise (PE) installations, where all required services run on one server, `autosign.conf` exists on the master, but it is empty by default because the master doesn't need to whitelist other servers.
+-   In split PE installations, where services like PuppetDB can run on different servers, `autosign.conf` exists on the CA master and contains a whitelist of other required hosts.
+
+If the `autosign.conf` file is empty or doesn't exist, the whitelist is empty. The CA Puppet master therefore doesn't autosign any certificates until the `autosign.conf` file contains a whitelist or is a custom policy executable, or until the `autosign` setting is pointed at a whitelist file or custom policy executable.
 
 To _explicitly_ disable autosigning, set `autosign = false` in the `[master]` section of the CA Puppet master's `puppet.conf`, which disables CA autosigning even if autosign.conf or a custom policy executable exists.
 
-For more information about the `autosign` setting, see the [configuration reference](./configuration.html#autosign).
+For more information about the different autosigning methods, see [basic autosigning][inpage_basic] and [policy-based autosigning][inpage_policy]. For more information about the `autosign` setting in `puppet.conf`, see the [configuration reference](./configuration.html#autosign).
 
 ## Naïve autosigning
 

--- a/source/puppet/5.3/ssl_autosign.markdown
+++ b/source/puppet/5.3/ssl_autosign.markdown
@@ -54,9 +54,9 @@ The `autosign.conf` whitelist file's location and contents are described in [its
 
 Puppet looks for `autosign.conf` at the path configured in the [`autosign` setting][autosign setting] in the `[master]` section of `puppet.conf`. The default path is `$confdir/autosign.conf`, and the default `confdir` path depends on your operating system. [See the confdir documentation for more information.](./dirs_confdir.html)
 
-> **Note:** In open source Puppet, no `autosign.conf` file exists by default. In Puppet Enterprise, the file exists but is empty. In both cases, basic autosigning is enabled by default but doesn't autosign any certificates because an blank or non-existent whitelist is considered empty and no hostnames are whitelisted by default.
+> **Note:** In open source Puppet, no `autosign.conf` file exists by default. In Puppet Enterprise, the file exists by default but might be empty. In both cases, basic autosigning is enabled by default but doesn't autosign any certificates because an blank or non-existent whitelist is considered empty and no hostnames are whitelisted by default.
 
-The `autosign.conf` file must not be executable by the Puppet master's user account. If the `autosign` setting points to an executable file, Puppet instead treats it like a custom policy executable even if it contains a valid `autosign.conf` whitelist.
+The `autosign.conf` file must not be executable by the Puppet master's user account. If the `autosign` setting points to an executable file, Puppet instead attempts to execute it as a custom policy executable even if it contains a valid `autosign.conf` whitelist.
 
 ### Security implications of basic autosigning
 
@@ -99,8 +99,7 @@ The API for policy executables is as follows:
 
 -   **Run environment:** The executable will be run once for each incoming CSR.
     -   It will be executed by the Puppet master process and will run as the same user as the Puppet master.
-    -   The Puppet master process will _block until the executable finishes running._ We expect policy executables to finish in a timely fashion; if they do not, it's possible for them to tie up all available Puppet master threads and deny service to other agent nodes. If an executable needs to perform network requests or other potentially expensive operations, the author is in charge of implementing any necessary timeouts, possibly bailing and exiting non-zero in the event of failure.
-    -   (Note that under a Rack server like Passenger, there are generally multiple Puppet master processes available at any given time, so policy executables have a little bit of leeway.)
+    -   The Puppet master process will _block until the executable finishes running._ We expect policy executables to finish in a timely fashion; if they do not, it's possible for them to tie up all available Puppet master threads and deny service to other agents. If an executable needs to perform network requests or other potentially expensive operations, the author is in charge of implementing any necessary timeouts, possibly bailing and exiting non-zero in the event of failure. Alternatively, signing requests consume JRubies on a Puppet Server master but might not block all requests while the pool contains available JRubies, and won't block non-Ruby requests.
 -   **Arguments:** The executable must allow a single command line argument. This argument will be the Subject CN (certname) of the incoming CSR.
     -   No other command line arguments should be provided.
     -   The Puppet master should never fail to provide this argument.


### PR DESCRIPTION
Autosigning works slightly differently in open source Puppet, monolithic Puppet Enterprise, and split Puppet Enterprise installations. Clarify this, and reorganize other docs on basic autosigning for additional clarification.