### PR TITLE
(DOC-3452) Fix regex in capture variable example.

### DIFF
--- a/source/puppet/4.1/lang_conditional.markdown
+++ b/source/puppet/4.1/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.10/lang_conditional.markdown
+++ b/source/puppet/4.10/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.2/lang_conditional.markdown
+++ b/source/puppet/4.2/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.3/lang_conditional.markdown
+++ b/source/puppet/4.3/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.4/lang_conditional.markdown
+++ b/source/puppet/4.4/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.5/lang_conditional.markdown
+++ b/source/puppet/4.5/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.6/lang_conditional.markdown
+++ b/source/puppet/4.6/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.7/lang_conditional.markdown
+++ b/source/puppet/4.7/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.8/lang_conditional.markdown
+++ b/source/puppet/4.8/lang_conditional.markdown
@@ -279,7 +279,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/4.9/lang_conditional.markdown
+++ b/source/puppet/4.9/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/5.0/lang_conditional.markdown
+++ b/source/puppet/5.0/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/5.1/lang_conditional.markdown
+++ b/source/puppet/5.1/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/5.2/lang_conditional.markdown
+++ b/source/puppet/5.2/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```

--- a/source/puppet/5.3/lang_conditional.markdown
+++ b/source/puppet/5.3/lang_conditional.markdown
@@ -278,7 +278,7 @@ If you use regular expression cases, any captures from parentheses in the patter
 
 ``` puppet
 case $trusted['hostname'] {
-  /www(d+)/: { notice("Welcome to web server number ${1}"); include role::web }
+  /www(\d+)/: { notice("Welcome to web server number ${1}"); include role::web }
   default:   { include role::generic }
 }
 ```


### PR DESCRIPTION
> On the following page (https://puppet.com/docs/puppet/5.3/lang_conditional.html#regex-capture-variables-2), there is a regular expression that reads:
>
> > `/www(d+)/`
>
> This should read instead as:
>
> > `/www(\d+)/`