### PR TITLE
(DOC-3462)(FACT-409) execution.exec is deprecated.

### DIFF
--- a/source/facter/2.0/fact_overview.markdown
+++ b/source/facter/2.0/fact_overview.markdown
@@ -40,7 +40,7 @@ Facter.add(:jruby_installed) do
   confine :kernel => "Linux"
 
   setcode do
-    jruby_path = Facter::Core::Execution.exec('which jruby')
+    jruby_path = Facter::Core::Execution.execute('which jruby')
     # if 'which jruby' exits with an error, jruby_path will be an empty string
     if jruby_path == ""
       false

--- a/source/facter/2.0/release_notes.markdown
+++ b/source/facter/2.0/release_notes.markdown
@@ -60,6 +60,10 @@ API changes:
 - Fact values can now only be accessed using the `Facter.value` method. See [Using other facts](custom_facts.html#using-other-facts) in the Custom Facts Walkthrough for more information and examples. Facts that refer to other facts with the deprecated `Facter.fact_name` notation will have to be updated.
 - Previously, Facter would treat the empty string as `nil` (a falsey value). Because Facter 2 allows resolutions to return `nil` directly, the empty string is now treated just like any other string (i.e., truthy). Custom facts that relied on this behavior in the past will need to be updated. The only exception is the string form of the `setcode` method (e.g., `setcode 'lsb_release -a'`), which still treats the empty string (or a non-zero exit code) as `nil`.
 
+### Deprecated Methods
+
+- The `Facter.execution.exec` method is deprecated and can be replaced with `Facter.execution.execute`. ([FACT-409](https://tickets.puppetlabs.com/browse/FACT-409))
+
 ### Other Features
 
 [FACT-134: Perform basic sanity checks on Facter output](https://tickets.puppetlabs.com/browse/FACT-134)

--- a/source/facter/2.1/fact_overview.markdown
+++ b/source/facter/2.1/fact_overview.markdown
@@ -40,7 +40,7 @@ Facter.add(:jruby_installed) do
   confine :kernel => "Linux"
 
   setcode do
-    jruby_path = Facter::Core::Execution.exec('which jruby')
+    jruby_path = Facter::Core::Execution.execute('which jruby')
     # if 'which jruby' exits with an error, jruby_path will be an empty string
     if jruby_path == ""
       false

--- a/source/facter/2.2/fact_overview.markdown
+++ b/source/facter/2.2/fact_overview.markdown
@@ -40,7 +40,7 @@ Facter.add(:jruby_installed) do
   confine :kernel => "Linux"
 
   setcode do
-    jruby_path = Facter::Core::Execution.exec('which jruby')
+    jruby_path = Facter::Core::Execution.execute('which jruby')
     # if 'which jruby' exits with an error, jruby_path will be an empty string
     if jruby_path == ""
       false

--- a/source/facter/2.3/fact_overview.markdown
+++ b/source/facter/2.3/fact_overview.markdown
@@ -40,7 +40,7 @@ Facter.add(:jruby_installed) do
   confine :kernel => "Linux"
 
   setcode do
-    jruby_path = Facter::Core::Execution.exec('which jruby')
+    jruby_path = Facter::Core::Execution.execute('which jruby')
     # if 'which jruby' exits with an error, jruby_path will be an empty string
     if jruby_path == ""
       false

--- a/source/facter/2.4/fact_overview.markdown
+++ b/source/facter/2.4/fact_overview.markdown
@@ -40,7 +40,7 @@ Facter.add(:jruby_installed) do
   confine :kernel => "Linux"
 
   setcode do
-    jruby_path = Facter::Core::Execution.exec('which jruby')
+    jruby_path = Facter::Core::Execution.execute('which jruby')
     # if 'which jruby' exits with an error, jruby_path will be an empty string
     if jruby_path == ""
       false

--- a/source/facter/3.0/custom_facts.md
+++ b/source/facter/3.0/custom_facts.md
@@ -110,7 +110,7 @@ execute shell commands:
 
 * If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+* If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
 * In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
@@ -129,7 +129,7 @@ Puppet master server:
 
 Facter.add('hardware_platform') do
   setcode do
-    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+    Facter::Core::Execution.execute('/bin/uname --hardware-platform')
   end
 end
 ~~~
@@ -176,7 +176,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ~~~

--- a/source/facter/3.1/custom_facts.md
+++ b/source/facter/3.1/custom_facts.md
@@ -109,7 +109,7 @@ execute shell commands:
 
 * If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-* If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+* If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
 * In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
@@ -128,7 +128,7 @@ Puppet master server:
 
 Facter.add('hardware_platform') do
   setcode do
-    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+    Facter::Core::Execution.execute('/bin/uname --hardware-platform')
   end
 end
 ~~~
@@ -175,7 +175,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ~~~

--- a/source/facter/3.3/custom_facts.md
+++ b/source/facter/3.3/custom_facts.md
@@ -109,7 +109,7 @@ execute shell commands:
 
 -   If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
 -   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
@@ -128,7 +128,7 @@ Puppet master server:
 
 Facter.add('hardware_platform') do
   setcode do
-    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+    Facter::Core::Execution.execute('/bin/uname --hardware-platform')
   end
 end
 ```
@@ -175,7 +175,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.4/custom_facts.md
+++ b/source/facter/3.4/custom_facts.md
@@ -109,7 +109,7 @@ execute shell commands:
 
 -   If all you want to do is run the command and use the output, verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')`
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')`
 from within the `setcode do`...`end` block. As always, whatever the `setcode` statement returns is used as the fact's value.
 -   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
@@ -128,7 +128,7 @@ Puppet master server:
 
 Facter.add('hardware_platform') do
   setcode do
-    Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+    Facter::Core::Execution.execute('/bin/uname --hardware-platform')
   end
 end
 ```
@@ -175,7 +175,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.5/custom_facts.md
+++ b/source/facter/3.5/custom_facts.md
@@ -96,7 +96,7 @@ execute shell commands:
 
 -   If all you want to do is run the command and use the output verbatim, as your fact's value,
 you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
 -   In any case, remember that your shell command is also a Ruby string, so you'll need to escape special characters if you want to pass them through.
 
 It's important to note that *not everything that works in the terminal works in a fact*. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
@@ -114,7 +114,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
 
     Facter.add('hardware_platform') do
       setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+        Facter::Core::Execution.execute('/bin/uname --hardware-platform')
       end
     end
     ```
@@ -159,7 +159,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.6/custom_facts.md
+++ b/source/facter/3.6/custom_facts.md
@@ -95,7 +95,7 @@ output from those commands using standard Ruby code. The Facter API gives you a 
 execute shell commands:
 
 -   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
 -   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
 >**Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
@@ -113,7 +113,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
 
     Facter.add('hardware_platform') do
       setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+        Facter::Core::Execution.execute('/bin/uname --hardware-platform')
       end
     end
     ```
@@ -158,7 +158,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.7/custom_facts.md
+++ b/source/facter/3.7/custom_facts.md
@@ -95,7 +95,7 @@ output from those commands using standard Ruby code. The Facter API gives you a 
 execute shell commands:
 
 -   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
 -   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
 > **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
@@ -113,7 +113,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
 
     Facter.add('hardware_platform') do
       setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+        Facter::Core::Execution.execute('/bin/uname --hardware-platform')
       end
     end
     ```
@@ -158,7 +158,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.8/custom_facts.md
+++ b/source/facter/3.8/custom_facts.md
@@ -95,7 +95,7 @@ output from those commands using standard Ruby code. The Facter API gives you a 
 execute shell commands:
 
 -   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
 -   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
 > **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
@@ -113,7 +113,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
 
     Facter.add('hardware_platform') do
       setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+        Facter::Core::Execution.execute('/bin/uname --hardware-platform')
       end
     end
     ```
@@ -158,7 +158,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```

--- a/source/facter/3.9/custom_facts.md
+++ b/source/facter/3.9/custom_facts.md
@@ -95,7 +95,7 @@ output from those commands using standard Ruby code. The Facter API gives you a 
 execute shell commands:
 
 -   To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
--   If your fact is more complicated than that, you can call `Facter::Core::Execution.exec('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+-   If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
 -   Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
 > **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
@@ -113,7 +113,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
 
     Facter.add('hardware_platform') do
       setcode do
-        Facter::Core::Execution.exec('/bin/uname --hardware-platform')
+        Facter::Core::Execution.execute('/bin/uname --hardware-platform')
       end
     end
     ```
@@ -158,7 +158,7 @@ An example of the confine statement would be something like the following:
 Facter.add(:powerstates) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution.exec('cat /sys/power/states')
+    Facter::Core::Execution.execute('cat /sys/power/states')
   end
 end
 ```


### PR DESCRIPTION
Facter.execution.exec was deprecated in Facter 2.0. Remove it from the custom facts doc and Facter 2.x's fact overview, and add a note about its deprecation to the 2.0 release notes.