### PR TITLE
Restore minor upgrade docs.

### DIFF
--- a/source/puppet/5.0/_puppet_toc.html
+++ b/source/puppet/5.0/_puppet_toc.html
@@ -44,6 +44,7 @@
         * [Upgrade agents from 3.8.x Puppet 5.x]({{puppet}}/upgrade_major_agent.html)
         * [Upgrade servers]({{puppet}}/upgrade_major_server.html)
         * [Post-upgrade cleanup]({{puppet}}/upgrade_major_post.html)
+    * [Minor upgrades: From Puppet 4 and within Puppet 5.x]({{puppet}}/upgrade_minor.html)
 * **Configuration**
     * [About Puppet's settings]({{puppet}}/config_about_settings.html)
     * [Short list of important settings]({{puppet}}/config_important_settings.html)

--- a/source/puppet/5.0/upgrade_minor.md
+++ b/source/puppet/5.0/upgrade_minor.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: "Minor upgrades: Within Puppet 5.x"
+title: "Minor upgrades: From Puppet 4 and within Puppet 5.x"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [major upgrades]: ./upgrade_major_pre.html
 
-A minor upgrade is an upgrade from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
+A minor upgrade is an upgrade from Puppet 4 to Puppet 5, or from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
 
-### Upgrade Puppet Server
+## Upgrade Puppet Server
 
 Upgrade Puppet Server on the masters before upgrading any agents. 
 
@@ -31,7 +31,7 @@ The `puppetserver` package depends on the `puppet-agent` package, and your node'
 
 > **Note**: If you pinned or held your Puppet packages to a specific version, remove the pins or holds before continuing. On systems that use `apt`, remove any special `.pref` files from `/etc/apt/preferences.d/` that pin Puppet packages, and use the `apt-mark unhold` command on each held package. For `yum` packages locked with the versionlock plugin, edit `/etc/yum/pluginconf.d/versionlock.list` and remove the Puppet lock.
 
-### Upgrade Puppet on agents
+## Upgrade Puppet on agents
 
 You should regularly upgrade Puppet on agents, and in most cases you shouldn't need to do anything to prepare for such upgrades.
 
@@ -54,7 +54,9 @@ On Windows agents, follow the [installation guide](./install_windows.html) to up
 
 > **Note**: If you installed Puppet into a custom directory and are moving from a 32-bit version to a 64-bit version, you must specify the INSTALLDIR option and any other relevant MSI properties when re-installing.
 
-### Upgrade PuppetDB
+On macOS, follow the [installation guide](./install_osx.html) to upgrade installed Puppet packages. You don't need to uninstall Puppet first.
+
+## Upgrade PuppetDB
 
 Upgrade PuppetDB nodes independently of masters and agents. 
 

--- a/source/puppet/5.1/_puppet_toc.html
+++ b/source/puppet/5.1/_puppet_toc.html
@@ -44,6 +44,7 @@
         * [Upgrade agents from 3.8.x Puppet 5.x]({{puppet}}/upgrade_major_agent.html)
         * [Upgrade servers]({{puppet}}/upgrade_major_server.html)
         * [Post-upgrade cleanup]({{puppet}}/upgrade_major_post.html)
+    * [Minor upgrades: From Puppet 4 and within Puppet 5.x]({{puppet}}/upgrade_minor.html)
 * **Configuration**
     * [About Puppet's settings]({{puppet}}/config_about_settings.html)
     * [Short list of important settings]({{puppet}}/config_important_settings.html)

--- a/source/puppet/5.1/upgrade_minor.md
+++ b/source/puppet/5.1/upgrade_minor.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: "Minor upgrades: Within Puppet 5.x"
+title: "Minor upgrades: From Puppet 4 and within Puppet 5.x"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [major upgrades]: ./upgrade_major_pre.html
 
-A minor upgrade is an upgrade from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
+A minor upgrade is an upgrade from Puppet 4 to Puppet 5, or from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
 
-### Upgrade Puppet Server
+## Upgrade Puppet Server
 
 Upgrade Puppet Server on the masters before upgrading any agents. 
 
@@ -31,7 +31,7 @@ The `puppetserver` package depends on the `puppet-agent` package, and your node'
 
 > **Note**: If you pinned or held your Puppet packages to a specific version, remove the pins or holds before continuing. On systems that use `apt`, remove any special `.pref` files from `/etc/apt/preferences.d/` that pin Puppet packages, and use the `apt-mark unhold` command on each held package. For `yum` packages locked with the versionlock plugin, edit `/etc/yum/pluginconf.d/versionlock.list` and remove the Puppet lock.
 
-### Upgrade Puppet on agents
+## Upgrade Puppet on agents
 
 You should regularly upgrade Puppet on agents, and in most cases you shouldn't need to do anything to prepare for such upgrades.
 
@@ -54,7 +54,9 @@ On Windows agents, follow the [installation guide](./install_windows.html) to up
 
 > **Note**: If you installed Puppet into a custom directory and are moving from a 32-bit version to a 64-bit version, you must specify the INSTALLDIR option and any other relevant MSI properties when re-installing.
 
-### Upgrade PuppetDB
+On macOS, follow the [installation guide](./install_osx.html) to upgrade installed Puppet packages. You don't need to uninstall Puppet first.
+
+## Upgrade PuppetDB
 
 Upgrade PuppetDB nodes independently of masters and agents. 
 

--- a/source/puppet/5.2/_puppet_toc.html
+++ b/source/puppet/5.2/_puppet_toc.html
@@ -44,6 +44,7 @@
         * [Upgrade agents from 3.8.x Puppet 5.x]({{puppet}}/upgrade_major_agent.html)
         * [Upgrade servers]({{puppet}}/upgrade_major_server.html)
         * [Post-upgrade cleanup]({{puppet}}/upgrade_major_post.html)
+    * [Minor upgrades: From Puppet 4 and within Puppet 5.x]({{puppet}}/upgrade_minor.html)
 * **Configuration**
     * [About Puppet's settings]({{puppet}}/config_about_settings.html)
     * [Short list of important settings]({{puppet}}/config_important_settings.html)

--- a/source/puppet/5.2/upgrade_minor.md
+++ b/source/puppet/5.2/upgrade_minor.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: "Minor upgrades: Within Puppet 5.x"
+title: "Minor upgrades: From Puppet 4 and within Puppet 5.x"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [major upgrades]: ./upgrade_major_pre.html
 
-A minor upgrade is an upgrade from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
+A minor upgrade is an upgrade from Puppet 4 to Puppet 5, or from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
 
-### Upgrade Puppet Server
+## Upgrade Puppet Server
 
 Upgrade Puppet Server on the masters before upgrading any agents. 
 
@@ -31,7 +31,7 @@ The `puppetserver` package depends on the `puppet-agent` package, and your node'
 
 > **Note**: If you pinned or held your Puppet packages to a specific version, remove the pins or holds before continuing. On systems that use `apt`, remove any special `.pref` files from `/etc/apt/preferences.d/` that pin Puppet packages, and use the `apt-mark unhold` command on each held package. For `yum` packages locked with the versionlock plugin, edit `/etc/yum/pluginconf.d/versionlock.list` and remove the Puppet lock.
 
-### Upgrade Puppet on agents
+## Upgrade Puppet on agents
 
 You should regularly upgrade Puppet on agents, and in most cases you shouldn't need to do anything to prepare for such upgrades.
 
@@ -54,7 +54,9 @@ On Windows agents, follow the [installation guide](./install_windows.html) to up
 
 > **Note**: If you installed Puppet into a custom directory and are moving from a 32-bit version to a 64-bit version, you must specify the INSTALLDIR option and any other relevant MSI properties when re-installing.
 
-### Upgrade PuppetDB
+On macOS, follow the [installation guide](./install_osx.html) to upgrade installed Puppet packages. You don't need to uninstall Puppet first.
+
+## Upgrade PuppetDB
 
 Upgrade PuppetDB nodes independently of masters and agents. 
 

--- a/source/puppet/5.3/_puppet_toc.html
+++ b/source/puppet/5.3/_puppet_toc.html
@@ -44,6 +44,7 @@
         * [Upgrade agents from 3.8.x Puppet 5.x]({{puppet}}/upgrade_major_agent.html)
         * [Upgrade servers]({{puppet}}/upgrade_major_server.html)
         * [Post-upgrade cleanup]({{puppet}}/upgrade_major_post.html)
+    * [Minor upgrades: From Puppet 4 and within Puppet 5.x]({{puppet}}/upgrade_minor.html)
 * **Configuration**
     * [About Puppet's settings]({{puppet}}/config_about_settings.html)
     * [Short list of important settings]({{puppet}}/config_important_settings.html)

--- a/source/puppet/5.3/upgrade_minor.md
+++ b/source/puppet/5.3/upgrade_minor.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: "Minor upgrades: Within Puppet 5.x"
+title: "Minor upgrades: From Puppet 4 and within Puppet 5.x"
 ---
 
 [`puppetlabs/puppetdb`]: https://forge.puppetlabs.com/puppetlabs/puppetdb
 [major upgrades]: ./upgrade_major_pre.html
 
-A minor upgrade is an upgrade from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
+A minor upgrade is an upgrade from Puppet 4 to Puppet 5, or from one Puppet 5 release to another. The order in which you upgrade packages is important. Always upgrade `puppetserver` on your masters _before_ you upgrade agents. You can upgrade PuppetDB before or after you upgrade other nodes.
 
-### Upgrade Puppet Server
+## Upgrade Puppet Server
 
 Upgrade Puppet Server on the masters before upgrading any agents. 
 
@@ -31,7 +31,7 @@ The `puppetserver` package depends on the `puppet-agent` package, and your node'
 
 > **Note**: If you pinned or held your Puppet packages to a specific version, remove the pins or holds before continuing. On systems that use `apt`, remove any special `.pref` files from `/etc/apt/preferences.d/` that pin Puppet packages, and use the `apt-mark unhold` command on each held package. For `yum` packages locked with the versionlock plugin, edit `/etc/yum/pluginconf.d/versionlock.list` and remove the Puppet lock.
 
-### Upgrade Puppet on agents
+## Upgrade Puppet on agents
 
 You should regularly upgrade Puppet on agents, and in most cases you shouldn't need to do anything to prepare for such upgrades.
 
@@ -54,7 +54,9 @@ On Windows agents, follow the [installation guide](./install_windows.html) to up
 
 > **Note**: If you installed Puppet into a custom directory and are moving from a 32-bit version to a 64-bit version, you must specify the INSTALLDIR option and any other relevant MSI properties when re-installing.
 
-### Upgrade PuppetDB
+On macOS, follow the [installation guide](./install_osx.html) to upgrade installed Puppet packages. You don't need to uninstall Puppet first.
+
+## Upgrade PuppetDB
 
 Upgrade PuppetDB nodes independently of masters and agents. 
 


### PR DESCRIPTION
The minor upgrade docs were being published and linked to, but
weren't in the sidebar navigation. They also didn't note their relevance
to upgrades from Puppet 4.

Restore the docs to the nav and include the guidance about Puppet 4
upgrades from the index. Also, point to the macOS agent install docs for
upgrading those agents.