### PR TITLE
(HOLD FOR RELEASE) Publish latest Server and DB 5.1.x docs.

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -658,8 +658,7 @@ documents:
     nav: /puppet/5.3/_puppet_toc.html
     external_source:
       repo: git://github.com/puppetlabs/puppetserver.git
-      commit: a7c0b28b167ab23631600c3563bb33736538c991
-      # commit: origin/5.1.x
+      commit: origin/5.1.x
       subdirectory: documentation
     my_versions:
       puppet: "5.3"
@@ -810,8 +809,7 @@ documents:
     nav: ./_puppetdb_nav.html
     external_source:
       repo: git://github.com/puppetlabs/puppetdb.git
-      commit: 4e7472f278b93ad3bc2ec0a1071f28e06cc0d8da
-      # commit: origin/5.1.x
+      commit: origin/5.1.x
       subdirectory: documentation
     hide: true
   /puppetdb/5.0:


### PR DESCRIPTION
Remove commit pins and publish from the 5.1.x branches when they're released.