### PR TITLE
(DOCUMENT-817) Add String-to-Number conversion option using new()

### DIFF
--- a/source/puppet/4.10/lang_data_number.md
+++ b/source/puppet/4.10/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,42 +56,55 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
 
+    The default radix of this conversion is base 10, but you can specify others.
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 
@@ -100,7 +112,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +122,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +142,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +152,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/4.10/lang_data_number.md
+++ b/source/puppet/4.10/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 

--- a/source/puppet/5.0/lang_data_number.md
+++ b/source/puppet/5.0/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,42 +56,55 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
 
+    The default radix of this conversion is base 10, but you can specify others.
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 
@@ -100,7 +112,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +122,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +142,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +152,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/5.0/lang_data_number.md
+++ b/source/puppet/5.0/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 

--- a/source/puppet/5.1/lang_data_number.md
+++ b/source/puppet/5.1/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,42 +56,55 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
 
+    The default radix of this conversion is base 10, but you can specify others.
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 
@@ -100,7 +112,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +122,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +142,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +152,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/5.1/lang_data_number.md
+++ b/source/puppet/5.1/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 

--- a/source/puppet/5.2/lang_data_number.md
+++ b/source/puppet/5.2/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,42 +56,55 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
 
+    The default radix of this conversion is base 10, but you can specify others.
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 
@@ -100,7 +112,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +122,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +142,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +152,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/5.2/lang_data_number.md
+++ b/source/puppet/5.2/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 

--- a/source/puppet/5.3/lang_data_number.md
+++ b/source/puppet/5.3/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,42 +56,55 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
 
+    The default radix of this conversion is base 10, but you can specify others.
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 
@@ -100,7 +112,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +122,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +142,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +152,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/5.3/lang_data_number.md
+++ b/source/puppet/5.3/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 

--- a/source/puppet/5.4/lang_data_number.md
+++ b/source/puppet/5.4/lang_data_number.md
@@ -80,7 +80,7 @@ $value = 0xLSD  # Error, invalid hex
 
 Numbers are automatically converted to strings when interpolated into a string. The automatic conversion uses decimal (base 10) notation.
 
-If you need to convert numbers to non-decimal string representations, you can use [the `sprintf` function.](./function.html#sprintf)
+To convert numbers to non-decimal string representations, you can use the [`sprintf` function](./function.html#sprintf), or you can create a new string object with the `new()` function and [specify its format](./function.html#conversion-to-string).
 
 ## Converting strings to numbers
 
@@ -88,9 +88,23 @@ If you need to convert numbers to non-decimal string representations, you can us
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
--   Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
--   Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
+-   Create a new `Integer` or `Float` object using the string as a parameter, such as `$mynum = Integer($mystring)`. This invokes the type's `new()` function, which can convert objects of other types --- including Strings --- into [Integers](./function.html#conversion-to-integer) and [Floats](./function.html#conversion-to-float).
+
+    The default radix of this conversion is base 10, but you can specify others.
 -   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
+
+> **Deprecation note:** Puppet 4.10.2 deprecated numeric coercion, which silently and automatically converted strings into numbers by adding a number to a string (for example, `$mynum = '10' + 0` would result in `$mynum` being assigned the number 10.) This now logs a Warning, or generates an Error if `--strict` is enabled.
+>
+> To ensure that your code works with future versions of Puppet, create new instances of numeric objects to convert String values to numeric types.
+
+### Examples
+
+Converting a string to an integer and float:
+
+    $mystring = '10';                  # $mystring == '10'
+    $myinteger = Integer($mystring);   # $myinteger == 10
+    $myfloat = Integer($mystring);     # $myfloat == 10.0
+    $myhexint = Integer($mystring, 16) # $myhexint == 16; '10' in base 16
 
 ## The `Integer` data type
 

--- a/source/puppet/5.4/lang_data_number.md
+++ b/source/puppet/5.4/lang_data_number.md
@@ -7,7 +7,6 @@ title: "Language: Data types: Numbers"
 [data type]: ./lang_data_type.html
 [variant]: ./lang_data_abstract.html#variant
 
-
 Numbers in the Puppet language are normal integers and floating point numbers.
 
 You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
@@ -16,38 +15,38 @@ You can work with numbers using Puppet's [arithmetic operators.][arithmetic]
 
 Numbers are written without quotation marks, and can consist only of:
 
-* Digits
-* An optional negative sign (`-`; this is actually [the unary negation operator](./lang_expressions.html#subtraction-and-negation) rather than part of the number)
-    * Explicit positive signs (`+`) aren't allowed, since there's no unary `+` operator.
-* An optional decimal point (which results in a floating point value)
-* A prefix, for octal or hexidecimal bases
-* An optional `e` or `E` for scientific notation of floating point values
+-   Digits.
+-   An optional negative sign (`-`). This is the [unary negation operator](./lang_expressions.html#subtraction-and-negation), rather than part of the number.
+    -   Explicit positive signs (`+`) aren't allowed, because there's no unary `+` operator.
+-   An optional decimal point, which results in a floating point value.
+-   A prefix, for octal or hexidecimal bases.
+-   An optional `e` or `E` for scientific notation of floating point values.
 
 ### Integers
 
 Integers are numbers without decimal points.
 
-If you divide two integers, the result _will not_ be a float; instead, Puppet will truncate the remainder. (That is, `2/3 == 0`.)
+If you divide two integers, the result _is not_ a floating point number. Instead, Puppet truncates the remainder. For example, `2/3 == 0`.
 
 ### Floating point numbers
 
-Floating point numbers ("floats") are numbers that include a fractional value after a decimal point (even if that fractional value is zero, like `2.0`).
+Floating point numbers ("floats") are numbers that include a fractional value after a decimal point, even if that fractional value is zero (such as `2.0`).
 
-If an expression includes both integer and float values, the result will be a float.
+If an expression includes both integer and float values, the result is a float.
 
 ``` puppet
 $some_number = 8 * -7.992           # evaluates to -63.936
 $another_number = $some_number / 4  # evaluates to -15.984
 ```
 
-Floating point numbers between -1 and 1 cannot start with a bare decimal point; they must have a zero before the decimal point.
+Floating point numbers between -1 and 1 cannot start with a bare decimal point. They must have a zero before the decimal point.
 
 ``` puppet
-$product = 8 * .12 # syntax error
-$product = 8 * 0.12 # OK
+$product = 8 * .12   # syntax error
+$product = 8 * 0.12  # OK
 ```
 
-You can express floating point numbers in scientific notation: append `e` or `E` plus an exponent, and the preceding number will be multiplied by 10 to the power of that exponent. Numbers in scientific notation are always floats.
+To express floating point numbers in scientific notation, append `e` or `E` and an exponent. Puppet multiplies the preceding number by 10 to the power of that exponent. Numbers in scientific notation are always floats.
 
 ``` puppet
 $product = 8 * 3e5  # evaluates to 240000.0
@@ -57,24 +56,24 @@ $product = 8 * 3e5  # evaluates to 240000.0
 
 Integer values can be expressed in decimal notation (base 10), octal notation (base 8), and hexadecimal notation (base 16).
 
-* _Non-zero_ decimal integers must not start with a `0`.
-* Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
-* Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
+-   _Non-zero_ decimal integers must not start with a `0`.
+-   Octal values have a prefix of `0`, which can be followed by a sequence of octal digits 0-7.
+-   Hexadecimal values have a prefix of `0x` or `0X`, which can be followed by hexadecimal digits 0-9, a-f, or A-F.
 
 Floats can't be expressed in octal or hex.
 
 ``` puppet
-# octal
-$value = 0777   # evaluates to decimal 511
-$value = 0789   # Error, invalid octal
-$value = 0777.3 # Error, invalid octal
+# Octal
+$value = 0777    # evaluates to decimal 511
+$value = 0789    # Error, invalid octal
+$value = 0777.3  # Error, invalid octal
 
-# hexadecimal
-$value = 0x777 # evaluates to decimal 1911
-$value = 0xdef # evaluates to decimal 3567
-$value = 0Xdef # same as above
-$value = 0xDEF # same as above
-$value = 0xLSD # Error, invalid hex
+# Hexadecimal
+$value = 0x777  # evaluates to decimal 1911
+$value = 0xdef  # evaluates to decimal 3567
+$value = 0Xdef  # same as above
+$value = 0xDEF  # same as above
+$value = 0xLSD  # Error, invalid hex
 ```
 
 ## Converting numbers to strings
@@ -85,14 +84,13 @@ If you need to convert numbers to non-decimal string representations, you can us
 
 ## Converting strings to numbers
 
-The [arithmetic operators][arithmetic] will automatically convert strings to numbers.
+[Arithmetic operators][arithmetic] automatically convert strings to numbers.
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
-* Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
-
+-   Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+-   Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
+-   Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 ## The `Integer` data type
 
@@ -100,7 +98,7 @@ The [data type][] of integers is `Integer`.
 
 By default, `Integer` matches whole numbers of any size (within the limits of available memory).
 
-You can use parameters to restrict which values `Integer` will match.
+You can use parameters to restrict which values `Integer` matches.
 
 ### Parameters
 
@@ -110,20 +108,19 @@ The full signature for `Integer` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Integer` | infinity | The maximum value for the integer. This parameter accepts the special value `default`, which will use its default value.
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Integer` | negative infinity | The minimum value for the integer. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Integer` | infinity          | The maximum value for the integer. This parameter accepts the special value `default`, which uses its default value.
 
 Practically speaking, the integer size limit is the range of a 64-bit signed integer (−9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), which is the maximum size that can roundtrip safely between the components in the Puppet ecosystem.
 
 ### Examples
 
-* `Integer` --- matches any integer.
-* `Integer[0]` --- matches any integer greater than or equal to 0.
-* `Integer[default, 0]` --- matches any integer less than or equal to 0.
-* `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
-
+-   `Integer` --- matches any integer.
+-   `Integer[0]` --- matches any integer greater than or equal to 0.
+-   `Integer[default, 0]` --- matches any integer less than or equal to 0.
+-   `Integer[2, 8]` --- matches any integer from 2 to 8, inclusive.
 
 ## The `Float` data type
 
@@ -131,7 +128,7 @@ The [data type][] of floating point numbers is `Float`.
 
 By default, `Float` matches floating point numbers within the limitations of Ruby's [Float class](http://www.ruby-doc.org/core/Float.html). Practically speaking, this means a 64 bit double precision floating point value.
 
-You can use parameters to restrict which values `Float` will match.
+You can use parameters to restrict which values `Float` matches.
 
 ### Parameters
 
@@ -141,25 +138,22 @@ The full signature for `Float` is:
 
 All of these parameters are optional. They must be listed in order; if you need to specify a later parameter, you must specify values for any prior ones.
 
-Position | Parameter        | Data Type | Default Value | Description
----------| -----------------|-----------|---------------|------------
-1 | Min value | `Float` | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which will use its default value.
-2 | Max value | `Float` | infinity | The maximum value for the float. This parameter accepts the special value `default`, which will use its default value.
-
+Position | Parameter        | Data type | Default value     | Description
+---------| -----------------|-----------|-------------------|-----------------------------
+1        | Minimum value    | `Float`   | negative infinity | The minimum value for the float. This parameter accepts the special value `default`, which uses its default value.
+2        | Maximum value    | `Float`   | infinity          | The maximum value for the float. This parameter accepts the special value `default`, which uses its default value.
 
 ### Examples
 
-* `Float` --- matches any floating point number.
-* `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
-* `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
-
+-   `Float` --- matches any floating point number.
+-   `Float[1.6]` --- matches any floating point number greater than or equal to 1.6.
+-   `Float[1.6, 3.501]` --- matches any floating point number from 1.6 to 3.501, inclusive.
 
 ## The `Numeric` data type
 
 The [data type][] of all numbers, both integer and floating point, is `Numeric`.
 
 It matches any integer or floating point number, and takes no parameters.
-
 
 ### Related data types
 

--- a/source/puppet/5.4/lang_data_number.md
+++ b/source/puppet/5.4/lang_data_number.md
@@ -89,7 +89,8 @@ The [arithmetic operators][arithmetic] will automatically convert strings to num
 
 In all other contexts (resource attributes, function arguments, etc.), Puppet _won't_ automatically convert strings to numbers, but you can:
 
-* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.)
+* Use the `Integer` data type to recast the string, such as `$mynum = Integer($mystring)`. The default radix of this conversion is base 10.
+* Add 0 to manually convert a string to a number. (For example, `$mystring = "85"; $mynum = 0 + $mystring`.) Note that this can fail as part of [Bolt plans](/bolt/latest/writing_plans.html).
 * Use [the `scanf` function](./function.html#scanf) to manually extract numbers from strings. This function can also account for surrounding non-numerical text.
 
 


### PR DESCRIPTION
Authored string-to-number docs were not updated when Puppet 4.5.0 added `new()`, resulting in deprecated information remaining in Puppet 4.10 and 5.x docs.

-   Update those docs to reflect new methods of converting strings to other types.
-   Add a deprecation note for numeric coercion.
-   Add examples.