### PR TITLE
(DOCUMENT-833) Clarify fact types and flat/structured values

### DIFF
--- a/source/facter/3.10/custom_facts.md
+++ b/source/facter/3.10/custom_facts.md
@@ -16,6 +16,16 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 > **Note:** Facter 3.0 removed the Ruby implementations of some features and replaced them with a [custom facts API](https://github.com/puppetlabs/facter/blob/master/Extensibility.md#custom-facts-compatibility). Any custom fact that requires one of the Ruby files previously stored in `lib/facter/util` fails with an error. For more information, see the [Facter 3.0 release notes](../3.0/release_notes.html).
 
+### Structured and flat facts
+
+A typical fact extracts a piece of information about a system and returns it as either as a simple value ("flat" fact) or data organized as a hash or array ("structured" fact). There are several types of facts classified by how they collect information, including:
+
+-   [Core facts](./core_facts.html), which are built into Facter and are common to almost all systems
+-   [Custom facts](#loading-custom-facts), which run Ruby code to produce a value
+-   [External facts](#external-facts), which return values from pre-defined static data, or the result of an executable script or program
+
+All fact types can produce flat or structured values.
+
 ## Loading custom facts
 
 Facter offers multiple methods of loading facts:
@@ -290,8 +300,6 @@ For more examples of aggregate resolutions, see the [aggregate resolutions](./fa
 If your Puppet masters are configured to use [PuppetDB][puppetdb], you can view and search all of the facts for any node, including custom facts. See [the PuppetDB docs][puppetdb] for more info.
 
 ## External facts
-
-### What are external facts?
 
 External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 

--- a/source/facter/3.10/fact_overview.md
+++ b/source/facter/3.10/fact_overview.md
@@ -3,8 +3,9 @@ layout: default
 title: "Overview of custom facts with examples"
 ---
 
+A typical fact in Facter is an assemblage of a few different elements and composed either
+as a simple value ("flat" fact) or structured data ("structured" fact).
 
-A typical fact in Facter is a fairly simple assemblage of just a few different elements.
 This page is an example-driven tour of those elements, and is intended as a quick primer or reference
 for authors of custom facts. You need some familiarity with Ruby to understand most of these examples.
 For a gentler introduction, check out the [Custom Facts Walkthrough](./custom_facts.html).


### PR DESCRIPTION
From the ticket:

> In a discussion with a Puppet User, it became clear that our documentation about facts is a little unclear. Specifically the concept I had to explain was that all types of fact (standard, executable or external) can return either simple or structured output.

> Here is the URL under discussion: https://puppet.com/docs/facter/3.10/custom_facts.html