### PR TITLE
Fix OS family fact value

### DIFF
--- a/source/puppet/4.10/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.10/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/4.6/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.6/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/4.7/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.7/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/4.8/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.8/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/4.9/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/4.9/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/5.0/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/5.0/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/5.1/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/5.1/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/5.2/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/5.2/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/5.3/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/5.3/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```

--- a/source/puppet/5.4/lang_facts_and_builtin_vars.markdown
+++ b/source/puppet/5.4/lang_facts_and_builtin_vars.markdown
@@ -77,7 +77,7 @@ All facts appear in Puppet as [top-scope variables][topscope]. They can be acces
 Example, with the osfamily fact:
 
 ``` puppet
-if $osfamily == 'redhat' {
+if $osfamily == 'RedHat' {
   # ...
 }
 ```
@@ -108,7 +108,7 @@ Facts also appear in a `$facts` hash. They can be accessed in manifests as `$fac
 Example, with the `os.family` fact:
 
 ``` puppet
-if $facts['os']['family'] == 'redhat' {
+if $facts['os']['family'] == 'RedHat' {
   # ...
 }
 ```


### PR DESCRIPTION
The fact value exposed by facter on RHEL-like systems is "RedHat", not "redhat".