### PR TITLE
(PA-2075) Note agent removals.

### DIFF
--- a/source/puppet/4.10/release_notes_agent.md
+++ b/source/puppet/4.10/release_notes_agent.md
@@ -58,6 +58,10 @@ This release of Puppet agent includes bug fixes and security updates.
 
 This release updates Puppet to [Puppet 4.10.12][].
 
+### Known issues
+
+-   Due to an issue with the Windows installer, Puppet agent 1.10.13 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 1.10.13 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+
 ### Bug fixes
 
 -   Previous versions of Puppet on Ruby 2.0 or newer would close and reopen HTTP connection that were idle for more than 2 seconds, causing increased load on Puppet masters. This version of Puppet ensures that the agent uses the `http_keepalive_timeout` setting when determining when to close idle connections. ([PUP-8663](https://tickets.puppetlabs.com/browse/PUP-8663))

--- a/source/puppet/4.10/release_notes_agent.md
+++ b/source/puppet/4.10/release_notes_agent.md
@@ -60,7 +60,7 @@ This release updates Puppet to [Puppet 4.10.12][].
 
 ### Known issues
 
--   Due to an issue with the Windows installer, Puppet agent 1.10.13 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 1.10.13 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+-   Due to an issue with the Windows installer, Puppet agent 1.10.13 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 1.10.13 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded or installed on their own or as part of Puppet Enterprise (PE) 2016.4.12. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
 
 ### Bug fixes
 

--- a/source/puppet/5.3/release_notes_agent.md
+++ b/source/puppet/5.3/release_notes_agent.md
@@ -48,7 +48,7 @@ This release of Puppet Platform contains several Puppet and Facter security and 
 
 ### Known issues
 
--   Due to an issue with the Windows installer, Puppet agent 5.3.7 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.3.7 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+-   Due to an issue with the Windows installer, Puppet agent 5.3.7 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.3.7 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded or installed on their own or as part of Puppet Enterprise (PE) 2017.3.7. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
 
 ### Component updates
 

--- a/source/puppet/5.3/release_notes_agent.md
+++ b/source/puppet/5.3/release_notes_agent.md
@@ -46,6 +46,11 @@ Released June 7, 2018.
 
 This release of Puppet Platform contains several Puppet and Facter security and bug fixes.
 
+### Known issues
+
+-   Due to an issue with the Windows installer, Puppet agent 5.3.7 can inadvertently change permissions on files acr
+oss a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.3.7 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+
 ### Component updates
 
 This release updates Puppet to [Puppet 5.3.7][].

--- a/source/puppet/5.3/release_notes_agent.md
+++ b/source/puppet/5.3/release_notes_agent.md
@@ -48,8 +48,7 @@ This release of Puppet Platform contains several Puppet and Facter security and 
 
 ### Known issues
 
--   Due to an issue with the Windows installer, Puppet agent 5.3.7 can inadvertently change permissions on files acr
-oss a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.3.7 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+-   Due to an issue with the Windows installer, Puppet agent 5.3.7 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.3.7 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
 
 ### Component updates
 

--- a/source/puppet/5.5/release_notes_agent.md
+++ b/source/puppet/5.5/release_notes_agent.md
@@ -45,6 +45,10 @@ This release of Puppet Platform contains several Puppet and Facter security and 
 
 This release includes component updates to [Puppet 5.5.2][], [Facter 3.11.2][], [MCollective 2.12.2][], and [pxp-agent][] 1.9.2.
 
+### Known issues
+
+-   Due to an issue with the Windows installer, Puppet agent 5.5.2 can inadvertently change permissions on files across a Windows node's filesystem during installation or upgrade. This can cause serious issues on those nodes. The Puppet agent 5.5.2 installer binaries for Windows have been removed from our downloads as well as the Chocolatey community feed, and they should not be installed if downloaded or installed on their own or as part of Puppet Enterprise (PE) 2018.1.1. ([PA-2075](https://tickets.puppetlabs.com/browse/PA-2075))
+
 ### Bug fixes
 
 -   Previous versions of Puppet on Ruby 2.0 or newer would close and reopen HTTP connection that were idle for more than 2 seconds, causing increased load on Puppet masters. This version of Puppet ensures that the agent uses the `http_keepalive_timeout` setting when determining when to close idle connections. ([PUP-8663](https://tickets.puppetlabs.com/browse/PUP-8663))


### PR DESCRIPTION
Packages for Puppet agent releases were pulled due to an issue with the Windows installer. Note this and link to the relevant ticket.