### PR TITLE
(DOC-3644)(PUP-8342)(PUP-8412) Update report format docs

### DIFF
--- a/source/_includes/reportformat/8.markdown
+++ b/source/_includes/reportformat/8.markdown
@@ -1,0 +1,119 @@
+## Report Format 7
+
+This is the format of reports output by Puppet versions 5.0 and later.
+
+### Puppet::Transaction::Report
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>host</td><td>string</td><td>The host that generated this report.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>When the run began.</td></tr>
+  <tr><td>logs</td><td>array</td><td>0 or more Puppet::Util::Log objects.</td></tr>
+  <tr><td>metrics</td><td>hash</td><td>Maps from string (metric category) to Puppet::Util::Metric.</td></tr>
+  <tr><td>resource_statuses</td><td>hash</td><td>Maps from resource name to Puppet::Resource::Status</td></tr>
+  <tr><td>configuration_version</td><td>string or integer</td><td>The "configuration version" of the Puppet run. This is a string if the user has specified their own versioning scheme, otherwise an integer representing seconds since the Unix epoch.</td></tr>
+  <tr><td>transaction_uuid</td><td>string</td><td>A UUID covering the transaction. The query parameters for the catalog retrieval will have included the same UUID.</td></tr>
+  <tr><td>code_id</td><td>string</td><td>The id of the code input to the compiler.</td></tr>
+  <tr><td>job_id</td><td>string, or null</td><td>The id of the job that this transaction is a part of.</td></tr>
+  <tr><td>catalog_uuid</td><td>string</td><td>A master generated catalog uuid, useful for connecting a single catalog to multiple reports.</td></tr>
+  <tr><td>master_used</td><td>string</td><td>The name of the master that was used to compile the catalog. If failover occurred, this holds the first master successfully contacted. If this run had no master (for example, a "puppet apply" run), this field will be blank.</td></tr>
+  <tr><td>report_format</td><td>string or integer</td><td>"7", or 7</td></tr>
+  <tr><td>puppet_version</td><td>string</td><td>The version of the Puppet agent.</td></tr>
+  <tr><td>status</td><td>string</td><td>"failed", "changed", or "unchanged"</td></tr>
+  <tr><td>noop</td><td>boolean</td><td>Whether or not the Puppet run was started in noop mode.</td></tr>
+  <tr><td>noop_pending</td><td>boolean</td><td>Whether or not there are changes that Puppet decided not to apply because of noop.</td></tr>
+  <tr><td>environment</td><td>string</td><td>The environment that was used for the puppet run.</td></tr>
+  <tr><td>corrective_change</td><td>boolean</td><td>True if a change or noop event in this report was caused by an unexpected change to the system between Puppet runs.</td></tr>
+  <tr><td>cached_catalog_status</td><td>string</td><td>Whether a cached catalog was used in the run, and if so, the reason that it was used. "not_used", "explicitly_requested", or "on_failure".</td></tr>
+</table>
+
+### Puppet::Util::Log
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>file</td><td>string</td><td>the pathname of the manifest file which triggered the log message.</td></tr>
+  <tr><td>line</td><td>integer</td><td>the line number in the manifest file which triggered the log message.</td></tr>
+  <tr><td>level</td><td>symbol</td><td>severity of the message. Possible values for level are :debug, :info, :notice, :warning, :err, :alert, :emerg, :crit</td></tr>
+  <tr><td>message</td><td>string</td><td>the message itself.</td></tr>
+  <tr><td>source</td><td>string</td><td>the origin of the log message. This could be a resource, a property of a resource, or the string "Puppet".</td></tr>
+  <tr><td>tags</td><td>array</td><td>each array element is a string.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>when the message was sent.</td></tr>
+</table>
+
+The `file` and `line` attributes are not always present.
+
+### Puppet::Util::Metric
+
+A `Puppet::Util::Metric` object represents all the metrics in a single category.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>name</td><td>string</td><td>Specifies the name of the metric category. This is the same as the key associated with this metric in the metrics hash of the Puppet::Transaction::Report.</td></tr>
+  <tr><td>label</td><td>string</td><td>This is the "titleized" version of the name, underscores are replaced with spaces and the first word is capitalized.</td></tr>
+  <tr><td>values</td><td>array</td><td>All the metric values within this category. Each element is of the form [name, titleized_name, value], where name is the name of the particular metric as a string, titleized_name is the "titleized" string of the name, and value is the quantity (an integer or a float).</td></tr>
+</table>
+
+The set of particular metrics and categories which appear in a report is a fixed set. In a successful report, the categories and metrics are:
+
+* In the `time` category, there is a metric for every resource type for which there is at least one resource in the catalog, plus two additional metrics, called `config_retrieval` and `total`. Each value in the `time` category is a float.
+* In the `resources` category, the metrics are `failed`, `out_of_sync`, `changed`, and `total`. Each value in the `resources` category is an integer.
+* In the `events` category, there are up to five metrics: `success`, `failure`, `audit`, `noop`, and `total`. `total` is always present; the others are only present when their values are non-zero. Each value in the `events` category is an integer.
+* In the `changes` category, there is only one metric, called `total`. Its value is an integer.
+
+Failed reports contain no metrics.
+
+In an inspect report, there is an additional `inspect` metric in the `time` category.
+
+### Puppet::Resource::Status
+
+A Puppet::Resource::Status object represents the status of a single resource.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>resource_type</td><td>string</td><td>the resource type, capitalized.</td></tr>
+  <tr><td>title</td><td>title</td><td>the resource title.</td></tr>
+  <tr><td>resource</td><td>string</td><td>the resource name, in the form Type[title]. This is always the same as the key corresponding to this Puppet::Resource::Status object in the resource_statuses hash. Deprecated.</td></tr>
+  <tr><td>file</td><td>string</td><td>the pathname of the manifest file which declared the resource</td></tr>
+  <tr><td>line</td><td>integer</td><td>the line number in the manifest file which declared the resource</td></tr>
+  <tr><td>evaluation_time</td><td>float</td><td>the amount of time, in seconds, taken to evaluate the resource. Not present in inspect reports.</td></tr>
+  <tr><td>change_count</td><td>integer</td><td>the number of properties which changed. Always 0 in inspect reports.</td></tr>
+  <tr><td>out_of_sync_count</td><td>integer</td><td>the number of properties which were out of sync. Always 0 in inspect reports.</td></tr>
+  <tr><td>tags</td><td>array</td><td>the strings with which the resource is tagged</td></tr>
+  <tr><td>time</td><td>datetime</td><td>the time at which the resource was evaluated</td></tr>
+  <tr><td>events</td><td>array</td><td>the Puppet::Transaction::Event objects for the resource</td></tr>
+  <tr><td>out_of_sync</td><td>boolean</td><td>True if out_of_sync_count > 0, otherwise false. Deprecated.</td></tr>
+  <tr><td>changed</td><td>boolean</td><td>True if change_count > 0, otherwise false. Deprecated.</td></tr>
+  <tr><td>skipped</td><td>boolean</td><td>True if the resource was skipped, otherwise false.</td></tr>
+  <tr><td>failed</td><td>boolean</td><td>True if Puppet experienced an error while evaluating this resource, otherwise false. Deprecated.</td></tr>
+  <tr><td>containment_path</td><td>array</td><td>An array of strings; each element represents a container (type or class) that, together, make up the path of the resource in the catalog.</td></tr>
+</table>
+
+### Puppet::Transaction::Event
+
+A Puppet::Transaction::Event object represents a single event for a single resource.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>audited</td><td>boolean</td><td>true if this property is being audited, otherwise false.  True in inspect reports.</td></tr>
+  <tr><td>property</td><td>string</td><td>the property for which the event occurred. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>previous_value</td><td>string, array, or hash</td><td>the value of the property before the change (if any) was applied. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>desired_value</td><td>string, array, or hash</td><td>the value specified in the manifest.  Absent in inspect reports. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>historical_value</td><td>string, array, or hash</td><td>the audited value from a previous run of Puppet, if known.  Otherwise nil.  Absent in inspect reports. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>message</td><td>string</td><td>the log message generated by this event</td></tr>
+  <tr><td>name</td><td>symbol</td><td>the name of the event.  Absent in inspect reports.</td></tr>
+  <tr><td>status</td><td>string</td><td>one of the following strings: "success", "failure", "noop", "audit", depending on the type of the event (see below).  Always "audit" in inspect reports.</td></tr>
+  <tr><td>redacted</td><td>boolean</td><td>Whether or not this event has been redacted.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>the time at which the property was evaluated</td></tr>
+  <tr><td>corrective_change</td><td>boolean</td><td>True if this event was caused by an unexpected change to the system between Puppet runs.</td></tr>
+</table>
+
+`Puppet::Transaction::Event#status` meanings:
+
+* `success`: property was out of sync, and was successfully changed to be in sync.
+* `failure`: property was out of sync, and couldn't be changed to be in sync due to an error.
+* `noop`: property was out of sync, and wasn't changed due to noop mode.
+* `audit`: property was in sync, and was being audited.
+
+### Differences from Report Format 6
+
+* `kind` was removed from `Puppet::Transaction::Report`

--- a/source/_includes/reportformat/8.markdown
+++ b/source/_includes/reportformat/8.markdown
@@ -1,6 +1,6 @@
-## Report Format 7
+## Report Format 8
 
-This is the format of reports output by Puppet versions 5.0 and later.
+This is the format of reports output by Puppet versions 5.4.z. It does not include backward-incompatible changes to [report format 7](../5.3/format_report.html).
 
 ### Puppet::Transaction::Report
 
@@ -20,6 +20,7 @@ This is the format of reports output by Puppet versions 5.0 and later.
   <tr><td>report_format</td><td>string or integer</td><td>"7", or 7</td></tr>
   <tr><td>puppet_version</td><td>string</td><td>The version of the Puppet agent.</td></tr>
   <tr><td>status</td><td>string</td><td>"failed", "changed", or "unchanged"</td></tr>
+  <tr><td>transaction_completed</td><td>boolean</td><td>Whether the transaction completed. For instance, if the transaction didn't have an unrescued exception, transaction_completed should be true.</td></tr>
   <tr><td>noop</td><td>boolean</td><td>Whether or not the Puppet run was started in noop mode.</td></tr>
   <tr><td>noop_pending</td><td>boolean</td><td>Whether or not there are changes that Puppet decided not to apply because of noop.</td></tr>
   <tr><td>environment</td><td>string</td><td>The environment that was used for the puppet run.</td></tr>
@@ -114,6 +115,6 @@ A Puppet::Transaction::Event object represents a single event for a single resou
 * `noop`: property was out of sync, and wasn't changed due to noop mode.
 * `audit`: property was in sync, and was being audited.
 
-### Differences from Report Format 6
+### Differences from Report Format 7
 
-* `kind` was removed from `Puppet::Transaction::Report`
+* `transaction_completed` was added to `Puppet::Transaction::Report`

--- a/source/_includes/reportformat/9.markdown
+++ b/source/_includes/reportformat/9.markdown
@@ -32,7 +32,6 @@ This is the format of reports output by Puppet versions 5.5.0 and newer. It does
 
 <table>
   <tr><th>Property</th><th>Type</th><th>Description</th></tr>
-  <tr><td>provider_used</td><td>string</td><td>The name of the provider used by the resource.</td></tr>
   <tr><td>file</td><td>string</td><td>the pathname of the manifest file which triggered the log message.</td></tr>
   <tr><td>line</td><td>integer</td><td>the line number in the manifest file which triggered the log message.</td></tr>
   <tr><td>level</td><td>symbol</td><td>severity of the message. Possible values for level are :debug, :info, :notice, :warning, :err, :alert, :emerg, :crit</td></tr>
@@ -75,6 +74,7 @@ A Puppet::Resource::Status object represents the status of a single resource.
   <tr><td>resource_type</td><td>string</td><td>the resource type, capitalized.</td></tr>
   <tr><td>title</td><td>title</td><td>the resource title.</td></tr>
   <tr><td>resource</td><td>string</td><td>the resource name, in the form Type[title]. This is always the same as the key corresponding to this Puppet::Resource::Status object in the resource_statuses hash. Deprecated.</td></tr>
+  <tr><td>provider_used</td><td>string</td><td>The name of the provider used by the resource.</td></tr>
   <tr><td>file</td><td>string</td><td>the pathname of the manifest file which declared the resource</td></tr>
   <tr><td>line</td><td>integer</td><td>the line number in the manifest file which declared the resource</td></tr>
   <tr><td>evaluation_time</td><td>float</td><td>the amount of time, in seconds, taken to evaluate the resource. Not present in inspect reports.</td></tr>
@@ -118,4 +118,4 @@ A Puppet::Transaction::Event object represents a single event for a single resou
 
 ### Differences from Report Format 8
 
-* `provider_used` was added to `Puppet::Util::Log`
+* `provider_used` was added to `Puppet::Report::Status`

--- a/source/_includes/reportformat/9.markdown
+++ b/source/_includes/reportformat/9.markdown
@@ -1,0 +1,120 @@
+## Report Format 8
+
+This is the format of reports output by Puppet versions 5.4.z. It does not include backward-incompatible changes to [report format 7](../5.3/format_report.html).
+
+### Puppet::Transaction::Report
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>host</td><td>string</td><td>The host that generated this report.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>When the run began.</td></tr>
+  <tr><td>logs</td><td>array</td><td>0 or more Puppet::Util::Log objects.</td></tr>
+  <tr><td>metrics</td><td>hash</td><td>Maps from string (metric category) to Puppet::Util::Metric.</td></tr>
+  <tr><td>resource_statuses</td><td>hash</td><td>Maps from resource name to Puppet::Resource::Status</td></tr>
+  <tr><td>configuration_version</td><td>string or integer</td><td>The "configuration version" of the Puppet run. This is a string if the user has specified their own versioning scheme, otherwise an integer representing seconds since the Unix epoch.</td></tr>
+  <tr><td>transaction_uuid</td><td>string</td><td>A UUID covering the transaction. The query parameters for the catalog retrieval will have included the same UUID.</td></tr>
+  <tr><td>code_id</td><td>string</td><td>The id of the code input to the compiler.</td></tr>
+  <tr><td>job_id</td><td>string, or null</td><td>The id of the job that this transaction is a part of.</td></tr>
+  <tr><td>catalog_uuid</td><td>string</td><td>A master generated catalog uuid, useful for connecting a single catalog to multiple reports.</td></tr>
+  <tr><td>master_used</td><td>string</td><td>The name of the master that was used to compile the catalog. If failover occurred, this holds the first master successfully contacted. If this run had no master (for example, a "puppet apply" run), this field will be blank.</td></tr>
+  <tr><td>report_format</td><td>string or integer</td><td>"7", or 7</td></tr>
+  <tr><td>puppet_version</td><td>string</td><td>The version of the Puppet agent.</td></tr>
+  <tr><td>status</td><td>string</td><td>"failed", "changed", or "unchanged"</td></tr>
+  <tr><td>transaction_completed</td><td>boolean</td><td>Whether the transaction completed. For instance, if the transaction didn't have an unrescued exception, transaction_completed should be true.</td></tr>
+  <tr><td>noop</td><td>boolean</td><td>Whether or not the Puppet run was started in noop mode.</td></tr>
+  <tr><td>noop_pending</td><td>boolean</td><td>Whether or not there are changes that Puppet decided not to apply because of noop.</td></tr>
+  <tr><td>environment</td><td>string</td><td>The environment that was used for the puppet run.</td></tr>
+  <tr><td>corrective_change</td><td>boolean</td><td>True if a change or noop event in this report was caused by an unexpected change to the system between Puppet runs.</td></tr>
+  <tr><td>cached_catalog_status</td><td>string</td><td>Whether a cached catalog was used in the run, and if so, the reason that it was used. "not_used", "explicitly_requested", or "on_failure".</td></tr>
+</table>
+
+### Puppet::Util::Log
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>file</td><td>string</td><td>the pathname of the manifest file which triggered the log message.</td></tr>
+  <tr><td>line</td><td>integer</td><td>the line number in the manifest file which triggered the log message.</td></tr>
+  <tr><td>level</td><td>symbol</td><td>severity of the message. Possible values for level are :debug, :info, :notice, :warning, :err, :alert, :emerg, :crit</td></tr>
+  <tr><td>message</td><td>string</td><td>the message itself.</td></tr>
+  <tr><td>source</td><td>string</td><td>the origin of the log message. This could be a resource, a property of a resource, or the string "Puppet".</td></tr>
+  <tr><td>tags</td><td>array</td><td>each array element is a string.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>when the message was sent.</td></tr>
+</table>
+
+The `file` and `line` attributes are not always present.
+
+### Puppet::Util::Metric
+
+A `Puppet::Util::Metric` object represents all the metrics in a single category.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>name</td><td>string</td><td>Specifies the name of the metric category. This is the same as the key associated with this metric in the metrics hash of the Puppet::Transaction::Report.</td></tr>
+  <tr><td>label</td><td>string</td><td>This is the "titleized" version of the name, underscores are replaced with spaces and the first word is capitalized.</td></tr>
+  <tr><td>values</td><td>array</td><td>All the metric values within this category. Each element is of the form [name, titleized_name, value], where name is the name of the particular metric as a string, titleized_name is the "titleized" string of the name, and value is the quantity (an integer or a float).</td></tr>
+</table>
+
+The set of particular metrics and categories which appear in a report is a fixed set. In a successful report, the categories and metrics are:
+
+* In the `time` category, there is a metric for every resource type for which there is at least one resource in the catalog, plus two additional metrics, called `config_retrieval` and `total`. Each value in the `time` category is a float.
+* In the `resources` category, the metrics are `failed`, `out_of_sync`, `changed`, and `total`. Each value in the `resources` category is an integer.
+* In the `events` category, there are up to five metrics: `success`, `failure`, `audit`, `noop`, and `total`. `total` is always present; the others are only present when their values are non-zero. Each value in the `events` category is an integer.
+* In the `changes` category, there is only one metric, called `total`. Its value is an integer.
+
+Failed reports contain no metrics.
+
+In an inspect report, there is an additional `inspect` metric in the `time` category.
+
+### Puppet::Resource::Status
+
+A Puppet::Resource::Status object represents the status of a single resource.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>resource_type</td><td>string</td><td>the resource type, capitalized.</td></tr>
+  <tr><td>title</td><td>title</td><td>the resource title.</td></tr>
+  <tr><td>resource</td><td>string</td><td>the resource name, in the form Type[title]. This is always the same as the key corresponding to this Puppet::Resource::Status object in the resource_statuses hash. Deprecated.</td></tr>
+  <tr><td>file</td><td>string</td><td>the pathname of the manifest file which declared the resource</td></tr>
+  <tr><td>line</td><td>integer</td><td>the line number in the manifest file which declared the resource</td></tr>
+  <tr><td>evaluation_time</td><td>float</td><td>the amount of time, in seconds, taken to evaluate the resource. Not present in inspect reports.</td></tr>
+  <tr><td>change_count</td><td>integer</td><td>the number of properties which changed. Always 0 in inspect reports.</td></tr>
+  <tr><td>out_of_sync_count</td><td>integer</td><td>the number of properties which were out of sync. Always 0 in inspect reports.</td></tr>
+  <tr><td>tags</td><td>array</td><td>the strings with which the resource is tagged</td></tr>
+  <tr><td>time</td><td>datetime</td><td>the time at which the resource was evaluated</td></tr>
+  <tr><td>events</td><td>array</td><td>the Puppet::Transaction::Event objects for the resource</td></tr>
+  <tr><td>out_of_sync</td><td>boolean</td><td>True if out_of_sync_count > 0, otherwise false. Deprecated.</td></tr>
+  <tr><td>changed</td><td>boolean</td><td>True if change_count > 0, otherwise false. Deprecated.</td></tr>
+  <tr><td>skipped</td><td>boolean</td><td>True if the resource was skipped, otherwise false.</td></tr>
+  <tr><td>failed</td><td>boolean</td><td>True if Puppet experienced an error while evaluating this resource, otherwise false. Deprecated.</td></tr>
+  <tr><td>containment_path</td><td>array</td><td>An array of strings; each element represents a container (type or class) that, together, make up the path of the resource in the catalog.</td></tr>
+</table>
+
+### Puppet::Transaction::Event
+
+A Puppet::Transaction::Event object represents a single event for a single resource.
+
+<table>
+  <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>audited</td><td>boolean</td><td>true if this property is being audited, otherwise false.  True in inspect reports.</td></tr>
+  <tr><td>property</td><td>string</td><td>the property for which the event occurred. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>previous_value</td><td>string, array, or hash</td><td>the value of the property before the change (if any) was applied. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>desired_value</td><td>string, array, or hash</td><td>the value specified in the manifest.  Absent in inspect reports. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>historical_value</td><td>string, array, or hash</td><td>the audited value from a previous run of Puppet, if known.  Otherwise nil.  Absent in inspect reports. This value will be missing if the provider errored out before it could be determined.</td></tr>
+  <tr><td>message</td><td>string</td><td>the log message generated by this event</td></tr>
+  <tr><td>name</td><td>symbol</td><td>the name of the event.  Absent in inspect reports.</td></tr>
+  <tr><td>status</td><td>string</td><td>one of the following strings: "success", "failure", "noop", "audit", depending on the type of the event (see below).  Always "audit" in inspect reports.</td></tr>
+  <tr><td>redacted</td><td>boolean</td><td>Whether or not this event has been redacted.</td></tr>
+  <tr><td>time</td><td>datetime</td><td>the time at which the property was evaluated</td></tr>
+  <tr><td>corrective_change</td><td>boolean</td><td>True if this event was caused by an unexpected change to the system between Puppet runs.</td></tr>
+</table>
+
+`Puppet::Transaction::Event#status` meanings:
+
+* `success`: property was out of sync, and was successfully changed to be in sync.
+* `failure`: property was out of sync, and couldn't be changed to be in sync due to an error.
+* `noop`: property was out of sync, and wasn't changed due to noop mode.
+* `audit`: property was in sync, and was being audited.
+
+### Differences from Report Format 7
+
+* `transaction_completed` was added to `Puppet::Transaction::Report`

--- a/source/_includes/reportformat/9.markdown
+++ b/source/_includes/reportformat/9.markdown
@@ -1,6 +1,6 @@
-## Report Format 8
+## Report Format 9
 
-This is the format of reports output by Puppet versions 5.4.z. It does not include backward-incompatible changes to [report format 7](../5.3/format_report.html).
+This is the format of reports output by Puppet versions 5.5.0 and newer. It does not include backward-incompatible changes to [report format 8](../5.4/format_report.html).
 
 ### Puppet::Transaction::Report
 
@@ -32,6 +32,7 @@ This is the format of reports output by Puppet versions 5.4.z. It does not inclu
 
 <table>
   <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  <tr><td>provider_used</td><td>string</td><td>The name of the provider used by the resource.</td></tr>
   <tr><td>file</td><td>string</td><td>the pathname of the manifest file which triggered the log message.</td></tr>
   <tr><td>line</td><td>integer</td><td>the line number in the manifest file which triggered the log message.</td></tr>
   <tr><td>level</td><td>symbol</td><td>severity of the message. Possible values for level are :debug, :info, :notice, :warning, :err, :alert, :emerg, :crit</td></tr>
@@ -115,6 +116,6 @@ A Puppet::Transaction::Event object represents a single event for a single resou
 * `noop`: property was out of sync, and wasn't changed due to noop mode.
 * `audit`: property was in sync, and was being audited.
 
-### Differences from Report Format 7
+### Differences from Report Format 8
 
-* `transaction_completed` was added to `Puppet::Transaction::Report`
+* `provider_used` was added to `Puppet::Util::Log`

--- a/source/puppet/5.4/format_report.markdown
+++ b/source/puppet/5.4/format_report.markdown
@@ -4,6 +4,6 @@ title: "Formats: Reports"
 ---
 
 
-This version of Puppet uses report format 7.
+This version of Puppet uses report format 8.
 
-{% include reportformat/7.markdown %}
+{% include reportformat/8.markdown %}

--- a/source/puppet/5.5/format_report.markdown
+++ b/source/puppet/5.5/format_report.markdown
@@ -4,6 +4,6 @@ title: "Formats: Reports"
 ---
 
 
-This version of Puppet uses report format 7.
+This version of Puppet uses report format 9.
 
-{% include reportformat/7.markdown %}
+{% include reportformat/9.markdown %}


### PR DESCRIPTION
Puppet 5.4.0 and 5.5.0 introduced new features to the report format, and each new feature incremented the report format version. This PR updates the report format schema docs to reflect these changes. See also https://github.com/puppetlabs/puppet/commit/8d9df3993 and https://github.com/puppetlabs/puppet/commit/8927d52650f303764bb4bb4944c4a7d1d17404a1, and https://github.com/gguillotte/puppet-docs/commit/11c0481a8146d75740e91e76b8cefff310c22917#commitcomment-29353100.

@joshcooper @jhelwig @kris-bosland pertinent commits to review in this PR are 734a0d8 and 046eed6, which contain the docs changes between report versions.