### PR TITLE
(DOCUMENT-719) Draft changes to major Server version upgrade docs

### DIFF
--- a/source/puppet/5.5/upgrade_major_server.markdown
+++ b/source/puppet/5.5/upgrade_major_server.markdown
@@ -52,16 +52,6 @@ To upgrade Puppet Server, you'll need to add the Puppet Platform repository to e
 
 Even after you've installed the package, **don't start the `puppetserver` service yet**! You should do a few other things first.
 
-## Upgrade PuppetDB
-
-In the pre-upgrade steps, you upgraded to PuppetDB 2.3.x, including the [`puppetdb-terminus`][puppetdb-terminus] package on your Puppet Servers. This means the upgraded Puppet Server can already communicate with your existing PuppetDB server.
-
-Now that you've upgraded Puppet Server, [upgrade PuppetDB][] to the latest version 3.x. Note that this also retires older API versions, which can break older integrations. See the [PuppetDB 3.0 release notes][] for details.
-
-Use the [`puppetlabs/puppetdb`][puppetdb_module] module to manage your PuppetDB version. Also, note that the terminus package's name is now [`puppetdb-termini`][puppetdb-termini] instead of `puppetdb-terminus`.
-
-After successfully upgrading PuppetDB to version 3, upgrade it to the latest v4 edition of PuppetDB and `puppetdb-termini`.
-
 ### Get familiar with the new binary locations
 
 In Puppet 4, we [moved][] all of Puppet's binaries on \*nix systems. They are now at `/opt/puppetlabs/bin`, which isn't in your system's `PATH` by default. You should do one of the following:
@@ -192,6 +182,16 @@ If you use [Hiera][], move its configuration and data files:
 
 > **Note**: In Puppet 4.0, the default location of hiera.yaml changed from `/etc/puppetlabs/puppet/hiera.yaml` to `/etc/puppetlabs/code/hiera.yaml`. In Puppet 4.5, its location was reverted to `/etc/puppetlabs/puppet/hiera.yaml`. If you are upgrading with a package from puppet-agent 1.5.0 or newer, it will **not** move your hiera.yaml file. If you are starting with a new installation, it will place it in the correct location.
 
+## Upgrade PuppetDB
+
+In the pre-upgrade steps, you upgraded to PuppetDB 2.3.x, including the [`puppetdb-terminus`][puppetdb-terminus] package on your Puppet Servers. This means the upgraded Puppet Server can already communicate with your existing PuppetDB server.
+
+Now that you've upgraded Puppet Server, [upgrade PuppetDB][] to the latest version 3.x. Note that this also retires older API versions, which can break older integrations. See the [PuppetDB 3.0 release notes][] for details.
+
+Use the [`puppetlabs/puppetdb`][puppetdb_module] module to manage your PuppetDB version. Also, note that the terminus package's name is now [`puppetdb-termini`][puppetdb-termini] instead of `puppetdb-terminus`.
+
+After successfully upgrading PuppetDB to version 3, upgrade it to the latest v4 edition of PuppetDB and `puppetdb-termini`.
+
 ### Start Puppet Server
 
 Puppet Server won't automatically start up on boot---you'll need to enable it. Use `puppet resource` to do this regardless of your operating system or distribution:
@@ -214,7 +214,7 @@ Enter the Puppet Server's hostname or IP address and confirm the agent can [retr
 
 Compared to the upgrade from Puppet 3 to 4, there are fewer changes when upgrading between Puppet 4 and 5. See the [Puppet 5.0 release notes](../5.0/release_notes.html), [Puppet Server 5.0 release notes](/docs/puppetserver/5.0/release_notes.html), and [PuppetDB 5.0 release notes](/docs/puppetdb/5.0/release_notes.html) for details, then review the latest version of each product's release notes.
 
-Finally, upgrade PuppetDB the latest version of PuppetDB 5, then upgrade Puppet Server and `puppetdb-termini` together on each Puppet master.
+Finally, upgrade PuppetDB to the latest version of PuppetDB 5, then upgrade Puppet Server and `puppetdb-termini` together on each Puppet master.
 
 ### Go live!
 

--- a/source/puppet/5.5/upgrade_major_server.markdown
+++ b/source/puppet/5.5/upgrade_major_server.markdown
@@ -44,13 +44,23 @@ If you have multiple Puppet masters, upgrade or replace the certificate authorit
 
 Repeat the following steps for each Puppet Server until you're running a pure Puppet 5/Puppet Server 5 infrastructure.
 
-### Install the latest Puppet Server
+### Install the latest Puppet Server 2.x
 
 Our software releases are grouped into the Puppet Platform.
 
 To upgrade Puppet Server, you'll need to add the Puppet Platform repository to each node's package manager. Follow the [Puppet Server installation instructions]({{puppetserver}}/install_from_packages.html) to [enable the Puppet Platform repository](./puppet_platform.html) and install the `puppetserver` package.
 
 Even after you've installed the package, **don't start the `puppetserver` service yet**! You should do a few other things first.
+
+## Upgrade PuppetDB
+
+In the pre-upgrade steps, you upgraded to PuppetDB 2.3.x, including the [`puppetdb-terminus`][puppetdb-terminus] package on your Puppet Servers. This means the upgraded Puppet Server can already communicate with your existing PuppetDB server.
+
+Now that you've upgraded Puppet Server, [upgrade PuppetDB][] to the latest version 3.x. Note that this also retires older API versions, which can break older integrations. See the [PuppetDB 3.0 release notes][] for details.
+
+Use the [`puppetlabs/puppetdb`][puppetdb_module] module to manage your PuppetDB version. Also, note that the terminus package's name is now [`puppetdb-termini`][puppetdb-termini] instead of `puppetdb-terminus`.
+
+After successfully upgrading PuppetDB to version 3, upgrade it to the latest v4 edition of PuppetDB and `puppetdb-termini`.
 
 ### Get familiar with the new binary locations
 
@@ -180,7 +190,7 @@ If you use [Hiera][], move its configuration and data files:
 2. Move your Hiera data files to somewhere inside `/etc/puppetlabs/code`.
 3. Update file references in `hiera.yaml` accordingly.
 
->**Note**: In Puppet 4.0, the default location of hiera.yaml changed from `/etc/puppetlabs/puppet/hiera.yaml` to `/etc/puppetlabs/code/hiera.yaml`. In Puppet 4.5, its location was reverted to `/etc/puppetlabs/puppet/hiera.yaml`. If you are upgrading with a package from puppet-agent 1.5.0 or newer, it will **not** move your hiera.yaml file. If you are starting with a new installation, it will place it in the correct location.
+> **Note**: In Puppet 4.0, the default location of hiera.yaml changed from `/etc/puppetlabs/puppet/hiera.yaml` to `/etc/puppetlabs/code/hiera.yaml`. In Puppet 4.5, its location was reverted to `/etc/puppetlabs/puppet/hiera.yaml`. If you are upgrading with a package from puppet-agent 1.5.0 or newer, it will **not** move your hiera.yaml file. If you are starting with a new installation, it will place it in the correct location.
 
 ### Start Puppet Server
 
@@ -200,17 +210,15 @@ Log into any Puppet agent and test its connection to the upgraded Puppet Server:
 
 Enter the Puppet Server's hostname or IP address and confirm the agent can [retrieve and apply a catalog][].
 
+### Upgrade to Puppet Platform 5
+
+Compared to the upgrade from Puppet 3 to 4, there are fewer changes when upgrading between Puppet 4 and 5. See the [Puppet 5.0 release notes](../5.0/release_notes.html), [Puppet Server 5.0 release notes](/docs/puppetserver/5.0/release_notes.html), and [PuppetDB 5.0 release notes](/docs/puppetdb/5.0/release_notes.html) for details, then review the latest version of each product's release notes.
+
+Finally, upgrade PuppetDB the latest version of PuppetDB 5, then upgrade Puppet Server and `puppetdb-termini` together on each Puppet master.
+
 ### Go live!
 
 At this point, Puppet Server is ready to serve nodes in production. If you pulled the server back to stage the upgrade, you can now push the node back into use.
-
-##  Optional: Upgrade PuppetDB
-
-In the pre-upgrade steps, you upgraded to PuppetDB 2.3.x, including the [`puppetdb-terminus`][puppetdb-terminus] package on your Puppet Servers. This means the upgraded Puppet Server can already communicate with your existing PuppetDB server.
-
-Now that you've upgraded Puppet Server, you can [upgrade PuppetDB][] to version 3 if you want. Be careful: it adds some cool improvements, but it also retires older API versions, which can break older integrations. See the [PuppetDB 3.0 release notes][] for details.
-
-Use the [`puppetlabs/puppetdb`][puppetdb_module] module to manage your PuppetDB version. Also, note that the terminus package's name is now [`puppetdb-termini`][puppetdb-termini] instead of `puppetdb-terminus`.
 
 ## You're done upgrading Puppet Server!
 


### PR DESCRIPTION
There are concerns about the order of steps in the major version upgrade docs from Puppet 3 to Puppet 5, particularly around PuppetDB upgrades now being necessary rather than optional. See [DOCUMENT-719](https://tickets.puppetlabs.com/browse/DOCUMENT-719) for details.