### PR TITLE
(DOC-3716) Document Timestamp and Timespan types

### DIFF
--- a/source/puppet/5.5/lang_data_abstract.md
+++ b/source/puppet/5.5/lang_data_abstract.md
@@ -117,6 +117,40 @@ Note that you can use capture groups in the regular expressions, but they won't 
 * `Pattern[/\A[a-z].*/]` --- matches any string that begins with a lowercase letter.
 * `Pattern[/\A[a-z].*/, /\Anone\Z/]` --- matches the above **or** the exact string `"none"`.
 
+### `Timestamp`
+
+The `Timestamp` data type matches special [strings][], [floats][], or [integers][] representing a time and date, or `default`, representing an infinite point in the past or future.
+
+It takes up to two parameters, and requires at least one. A `Timestamp` with one parameter represents a single point in time, while two parameters represent a range of time, with the first parameter being the `from` value and the second being the `to` value.
+
+#### Parameters
+
+The full signature for `Timestamp` is:
+
+    Timestamp[ <TIMESTAMP VALUE>, (<RANGE LIMIT>) ]
+
+Position | Parameter | Data Type | Default Value | Description
+---------|-----------|-----------|---------------|------------
+1 | Timestamp Value | String, Float, Integer, or `default` | `default` (-Infinity in a range) | Point in time if passed alone, or `from` value in a range if passed with a second parameter
+2 | Range Limit | String, Float, Integer, or `default` | `default` (+Infinity) | The `to` value in a range
+
+`Timestamp` values are interpreted depending on their format.
+
+* A String in the format of `YYYY-MM-DD` represents the time 00:00:00.0 UTC on the specified year (`YYYY`), month (`MM`), and day (`DD`)
+* A String in the format of `YYYY-MM-DD`T`HH:MM:SS.SSS` represents a specific hour (`HH`), minute (`MM`), and decimal second (`SS.SSS`) of UTC on the specified date
+* An Integer or Float represents the seconds passed since the Unix epoch
+* `default` is used in ranges and represents infinity as the maximum floating point value, either negative (as the `from` value of a range) or positive (as the `to` value)
+
+A `Timestamp` range with either end defined as `default` (infinity) is an _open range_, while a range with both ends defined as an exact timestamp is a _closed range_. Range values can be negative.
+
+The `Timestamp` type is not enumerable.
+
+#### Examples:
+
+* `Timestamp['2000-01-01T00:00:00.000', default]` --- an open range of time from the start of the 21st century to an infinte point in the future
+* `Timestamp['2012-10-10']` --- the exact Timestamp 2012-10-10T00:00:00.0 UTC
+* `Timestamp[default, 1433116800]` --- an open range of time from an infinite point in the past to 2015-06-01T00:00:00 UTC, here expressed as seconds since the Unix epoch
+* `Timestamp['2010-01-01', '2015-12-31T23:59:59.999999999']` --- a closed range of time between the start of 2010 and the end of 2015
 
 ### `Enum`
 
@@ -281,7 +315,6 @@ It takes no parameters.
 ### `Any`
 
 The `Any` data type matches _any_ value of _any_ data type.
-
 
 ## Unusual types
 

--- a/source/puppet/5.5/lang_data_abstract.md
+++ b/source/puppet/5.5/lang_data_abstract.md
@@ -119,7 +119,7 @@ Note that you can use capture groups in the regular expressions, but they won't 
 
 ### `Timespan`
 
-The `Timespan` data type matches a Timespan; [strings][], [floats][], or [integers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
+The `Timespan` data type matches a Timespan; [strings][], or [numbers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
 
 It takes up to two parameters, and defaults to an infinite range to the past and future.
 
@@ -134,10 +134,14 @@ Position | Parameter | Data Type | Default Value | Description
 1 | Timespan Start or Length | String, Float, Integer, or `default` | `default` (-Infinity in a span) | Length of the timespan if passed alone, or the `from` value in a range if passed with a second parameter
 2 | Timespan End | String, Float, Integer, or `default` | `default` (+Infinity), or none if only one value is passed | The `to` value in a range
 
-`Timeframe` values are interpreted depending on their format.
+`Timespan` values are interpreted depending on their format.
 
 * A String in the format of `D-HH:MM:SS` represents a span of days (`D`), hours (`HH`), minutes (`MM`), and seconds (`SS`)
 * An Integer or Float represents a number of seconds
+
+A `Timespan` range with either end defined as `default` (infinity) is an _open range_, while any other span is a _closed range_. The span's range is inclusive.
+
+The `Timespan` type is not enumerable.
 
 #### Examples:
 
@@ -147,7 +151,7 @@ Position | Parameter | Data Type | Default Value | Description
 
 ### `Timestamp`
 
-The `Timestamp` data type matches a Timestamp; [strings][], [floats][], or [integers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
+The `Timestamp` data type matches a Timestamp; [strings][] or [numbers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
 
 It takes up to two parameters, and defaults to an infinite range to the past and future. A `Timestamp` with one parameter represents a single point in time, while two parameters represent a range of time, with the first parameter being the `from` value and the second being the `to` value.
 
@@ -160,7 +164,7 @@ The full signature for `Timestamp` is:
 Position | Parameter | Data Type | Default Value | Description
 ---------|-----------|-----------|---------------|------------
 1 | Timestamp Value | String, Float, Integer, or `default` | `default` (-Infinity in a range) | Point in time if passed alone, or `from` value in a range if passed with a second parameter
-2 | Range Limit | String, Float, Integer, or `default` | `default` (+Infinity) | The `to` value in a range
+2 | Range Limit | String, Float, Integer, or `default` | `default` (+Infinity), or none if only one value is passed | The `to` value in a range
 
 `Timestamp` values are interpreted depending on their format.
 
@@ -169,7 +173,7 @@ Position | Parameter | Data Type | Default Value | Description
 * An Integer or Float represents the seconds passed since the Unix epoch
 * `default` is used in ranges and represents infinity as the maximum floating point value, either negative (as the `from` value of a range) or positive (as the `to` value)
 
-A `Timestamp` range with either end defined as `default` (infinity) is an _open range_, while a range with both ends defined as an exact timestamp is a _closed range_. Range values can be negative.
+A `Timestamp` range with either end defined as `default` (infinity) is an _open range_, while a range with both ends defined as an exact timestamp is a _closed range_. Range values can be negative, and the range is inclusive.
 
 The `Timestamp` type is not enumerable.
 

--- a/source/puppet/5.5/lang_data_abstract.md
+++ b/source/puppet/5.5/lang_data_abstract.md
@@ -117,17 +117,45 @@ Note that you can use capture groups in the regular expressions, but they won't 
 * `Pattern[/\A[a-z].*/]` --- matches any string that begins with a lowercase letter.
 * `Pattern[/\A[a-z].*/, /\Anone\Z/]` --- matches the above **or** the exact string `"none"`.
 
+### `Timespan`
+
+The `Timespan` data type matches a Timespan; [strings][], [floats][], or [integers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
+
+It takes up to two parameters, and defaults to an infinite range to the past and future.
+
+#### Parameters
+
+The full signature for `Timespan` is:
+
+    Timespan[ (<TIMESPAN START OR LENGTH>, (<TIMESPAN END>)) ]
+
+Position | Parameter | Data Type | Default Value | Description
+---------|-----------|-----------|---------------|------------
+1 | Timespan Start or Length | String, Float, Integer, or `default` | `default` (-Infinity in a span) | Length of the timespan if passed alone, or the `from` value in a range if passed with a second parameter
+2 | Timespan End | String, Float, Integer, or `default` | `default` (+Infinity), or none if only one value is passed | The `to` value in a range
+
+`Timeframe` values are interpreted depending on their format.
+
+* A String in the format of `D-HH:MM:SS` represents a span of days (`D`), hours (`HH`), minutes (`MM`), and seconds (`SS`)
+* An Integer or Float represents a number of seconds
+
+#### Examples:
+
+* `Timespan[2]` --- a timespan of 2 seconds
+* `Timespan[77.3]` --- a timespan of 1 minute, 17 seconds, and 300 milliseconds (77.3 seconds)
+* `Timespan['1-00:00:00', '2-00:00:00']` --- a timespan between 1 and 2 days
+
 ### `Timestamp`
 
-The `Timestamp` data type matches special [strings][], [floats][], or [integers][] representing a time and date, or `default`, representing an infinite point in the past or future.
+The `Timestamp` data type matches a Timestamp; [strings][], [floats][], or [integers][] that represent a time and date; or `default`, which represents an infinite point in the past or future.
 
-It takes up to two parameters, and requires at least one. A `Timestamp` with one parameter represents a single point in time, while two parameters represent a range of time, with the first parameter being the `from` value and the second being the `to` value.
+It takes up to two parameters, and defaults to an infinite range to the past and future. A `Timestamp` with one parameter represents a single point in time, while two parameters represent a range of time, with the first parameter being the `from` value and the second being the `to` value.
 
 #### Parameters
 
 The full signature for `Timestamp` is:
 
-    Timestamp[ <TIMESTAMP VALUE>, (<RANGE LIMIT>) ]
+    Timestamp[ (<TIMESTAMP VALUE>, (<RANGE LIMIT>)) ]
 
 Position | Parameter | Data Type | Default Value | Description
 ---------|-----------|-----------|---------------|------------


### PR DESCRIPTION
Puppet 4 added Timestamp and Timespan types, but were not documented outside of the `new()` function and [Puppet language specification](https://github.com/puppetlabs/puppet-specifications/blob/master/language/expressions.md#timespan-type--). Add documentation for these types to the abstract data type docs.