### PR TITLE
(DO NOT MERGE)(DOC-3771) Remove `puppet cert` from the list of man pages

### DIFF
--- a/lib/puppet_references/puppet/man.rb
+++ b/lib/puppet_references/puppet/man.rb
@@ -27,7 +27,6 @@ module PuppetReferences
             core: %w(
           agent
           apply
-          cert
           master
           module
           resource
@@ -122,6 +121,8 @@ EOADDENDUM
         applications = application_files.map {|f| f.basename('.rb').to_s}
         applications.delete('face_base')
         applications.delete('indirection_base')
+        # DOC-3771: Puppet cert still has a Ruby file, but is disabled. Don't build or list a man page for it.
+        applications.delete('cert')
         applications
       end
 


### PR DESCRIPTION
Puppet 6 and onward don't ship a functional `puppet cert` command. However, `/lib/puppet/applications/cert.rb` still exists in the Puppet code base. Force the docs references generator to stop publishing that man page.

Filed as DO NOT MERGE so that this solution can be reviewed by someone with more Ruby experience than me.

---

The references generator is built to categorize a list of commands by grabbing a list of `.rb` files in Puppet's `/lib/puppet/applications/` path. Any commands in the list that don't have a corresponding `.rb` file are ignored, and any `.rb` files not listed are dumped into the "Unknown or new subcommands" section of the [man page index](https://puppet.com/docs/puppet/6.0/man/index.html).

As such, removing `cert` from the list won't remove `puppet cert` from the index page or generating publishing a man page. We have to intercept and remove `cert` from the list of applications built from the list of `.rb` files before man page generation starts.

The problem with doing this is that new versions of Puppet prior to Puppet 6 might still need regenerated references and man pages, and `puppet cert` hasn't been removed from those versions. This PR's change isn't version-sensitive, so this will cause `puppet cert` to be excluded from the generated man pages even if it's for a relevant older Puppet version.