### PR TITLE
Removing three pages from the toc 

### DIFF
--- a/source/puppet/6.0/_puppet_toc.html
+++ b/source/puppet/6.0/_puppet_toc.html
@@ -96,9 +96,7 @@
     * [Running Puppet commands on Windows]({{puppet}}/services_commands_windows.html)
     * **Puppet master**
         * [Puppet Server]({{puppetserver}}/services_master_puppetserver.html)
-        * [The rack Puppet master]({{puppet}}/services_master_rack.html)
         * [Configuring a Server with Passenger and Apache]({{puppet}}/passenger.html)
-        * [The WEBrick Puppet master]({{puppet}}/services_master_webrick.html)
     * [Puppet agent on *nix]({{puppet}}/services_agent_unix.html)
     * [Puppet agent on Windows]({{puppet}}/services_agent_windows.html)
     * [Puppet apply]({{puppet}}/services_apply.html)
@@ -270,7 +268,6 @@
         * [puppet agent]({{puppet}}/man/agent.html)
         * [puppet apply]({{puppet}}/man/apply.html)
         * [puppet cert]({{puppet}}/man/cert.html)
-        * [puppet master]({{puppet}}/man/master.html)
         * [puppet module]({{puppet}}/man/module.html)
         * [puppet resource]({{puppet}}/man/resource.html)
         * [puppet lookup]({{puppet}}/man/lookup.html)


### PR DESCRIPTION
The WEBrick Puppet master, Rack Puppet master and puppet-master command were all removed in Puppet 6. 