### PR TITLE
(PDB-4209) Add section to docs for PuppetDB 6.1.0

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -698,6 +698,15 @@ documents:
       commit: bbc73f6da0a17eac4fbf84758b477ec9dd4cebb2
       subdirectory: documentation
 
+  /puppetdb/6.1:
+    doc: puppetdb
+    version: "6.1"
+    nav: ./_puppetdb_nav.html
+    external_source:
+      repo: git://github.com/puppetlabs/puppetdb.git
+      commit: origin/master
+      subdirectory: documentation
+    hide: true
   /puppetdb/6.0:
     doc: puppetdb
     version: "6.0"


### PR DESCRIPTION
Pointing this section at master because 6.1.0 was a foss only release which was
made off of a temporary branch that was on the tip of master.

I think when we do cut a long lived branch we can change the docs to point there for 6.1 and any other foss releases that come out in between so long as they have the same content and we should be fine, but I'm not 100% sure. 