### PR TITLE
Add closing tag to table row

### DIFF
--- a/source/puppet/5.5/about_agent.md
+++ b/source/puppet/5.5/about_agent.md
@@ -24,7 +24,7 @@ See the table for details about which components shipped in which `puppet-agent`
 
   <tbody>
   <tr><td><a href="/puppet/5.5/release_notes_agent.html#puppet-agent-5512">5.5.12</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-5512">5.5.12</a></td> <td><a href="/facter/3.11/release_notes.html#facter-3116">3.11.8</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-5510">3.4.6</a></td> <td><a href="/mcollective/current/releasenotes.html">2.12.4</a></td> <td>2.4.5</td> <td>1.0.2n</td></tr> 
-  <tr><td><em>5.5.11</em></td><td>No release this version</td> <td><em>-</em></td> 
+ <tr><td><em>5.5.11</em></td><td>No release this version</td> <td><em>-</em></td> <td>-</td> <td>-</td> <td>-</td> <td>-</td></tr> 
   <tr><td><a href="/puppet/5.5/release_notes_agent.html#puppet-agent-5510">5.5.10</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-5510">5.5.10</a></td> <td><a href="/facter/3.11/release_notes.html#facter-3116">3.11.6</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-5510">3.4.5</a></td> <td><a href="/mcollective/current/releasenotes.html">2.12.4</a></td> <td>2.4.5</td> <td>1.0.2n</td></tr>
     <tr><td><em>5.5.9</em></td><td>No release this version</td> <td><em>-</em></td> <td>-</td> <td>-</td> <td>-</td> <td>-</td></tr>
   <tr><td><a href="/puppet/5.5/release_notes_agent.html#puppet-agent-558">5.5.8</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-558">5.5.8</a></td> <td><a href="/facter/3.11/release_notes.html#facter-3116">3.11.6</a></td> <td><a href="/puppet/5.5/release_notes.html#puppet-558">3.4.5</a></td> <td><a href="/mcollective/current/releasenotes.html">2.12.4</a></td> <td>2.4.4</td> <td>1.0.2n</td></tr>


### PR DESCRIPTION
@jbondpdx I don't know if this issue is related to publishing, but one table row was missing a closing tag. GitHub's Preview Changes doesn't seem to mind. Maybe the Jenkins build doe?