### PR TITLE
Fix incorrect method names in Facter::Util::IP

### DIFF
--- a/source/facter/2.4/fact_overview.markdown
+++ b/source/facter/2.4/fact_overview.markdown
@@ -158,8 +158,8 @@ Facter.add(:networking, :type => :aggregate) do
     interfaces = {}
     Facter::Util::IP.get_interfaces.each do |interface|
       interfaces[interface] = {
-        'ipaddress' => Facter::Util::IP.get_ipaddress_value(interface),
-        'netmask'   => Facter::Util::IP.get_netmask_value(interface),
+        'ipaddress' => Facter::Util::IP.get_interface_value(interface, 'ipaddress'),
+        'netmask'   => Facter::Util::IP.get_interface_value(interface, 'netmask'),
       }
     end
 


### PR DESCRIPTION
It looks like there are no `get_ipaddress_value` and `get_netmask_value` methods in `Facter::Util::IP` and instead one should use the [`get_interface_value`](https://www.rubydoc.info/gems/facter/Facter/Util/IP#get_interface_value-class_method) method.