### PR TITLE
(maint) (re)Add a puppet_references config file and skip download feature

### DIFF
--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -9,6 +9,7 @@ module PuppetReferences
   PE_SERVER_DIR = BASE_DIR + 'vendor/pe-puppetserver'
   OUTPUT_DIR = BASE_DIR + 'references_output'
 
+  require 'puppet_references/config'
   require 'puppet_references/util'
   require 'puppet_references/repo'
   require 'puppet_references/reference'
@@ -45,7 +46,8 @@ module PuppetReferences
         PuppetReferences::Puppet::TypeStrings,
         PuppetReferences::Puppet::Functions
     ]
-    repo = PuppetReferences::Repo.new('puppet', PUPPET_DIR)
+    config = PuppetReferences::Config.read
+    repo = PuppetReferences::Repo.new('puppet', PUPPET_DIR, nil, config['puppet']['repo'])
     real_commit = repo.checkout(commit)
     repo.update_bundle
     build_from_list_of_classes(references, real_commit)

--- a/lib/puppet_references/config.rb
+++ b/lib/puppet_references/config.rb
@@ -1,0 +1,8 @@
+require 'yaml'
+module PuppetReferences
+  class Config
+    def self.read
+      YAML.load(File.read(File.join(File.dirname(__FILE__), 'config.yaml')))
+    end
+  end
+end

--- a/lib/puppet_references/config.yaml
+++ b/lib/puppet_references/config.yaml
@@ -1,0 +1,5 @@
+---
+puppet:
+  repo:
+    # False defaults make true overrides easier to read/code
+    skip_download: false


### PR DESCRIPTION
This commit was accidentally removed during some shenanigans, re-adding.
