### PR TITLE
Remove versions

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -625,28 +625,7 @@ documents:
     my_versions:
       puppet: "latest"
     hide: true
-  /puppetserver/6.5:
-    doc: puppetserver
-    version: "6.5"
-    nav: /puppet/6.7/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: fd33c7c78fa5fdd1369f1a1095edab4fab3dd8b2
-      subdirectory: documentation
-    my_versions:
-      puppet: "6.7"
-    hide: true
-  /puppetserver/6.4:
-    doc: puppetserver
-    version: "6.4"
-    nav: /puppet/6.5/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: d436f3e82b6ef7169bba032bfeaca99163d3fa2b
-      subdirectory: documentation
-    my_versions:
-      puppet: "6.5"
-    hide: true
+
   /puppetserver/6.3:
     doc: puppetserver
     version: "6.3"
@@ -659,31 +638,6 @@ documents:
       puppet: "6.4"
     hide: true
 
-  /puppetserver/6.2:
-    doc: puppetserver
-    version: "6.2"
-    nav: /puppet/6.2/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: 5c89e0f170250b0716437df467e7321145cc87c5
-      subdirectory: documentation
-    my_versions:
-      puppet: "6.2"
-      facter: "3.12"
-    hide: true
-    
-  /puppetserver/6.1:
-    doc: puppetserver
-    version: "6.1"
-    nav: /puppet/6.1/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: 6.1.0
-      subdirectory: documentation
-    my_versions:
-      puppet: "6.1"
-      facter: "3.12"
-    hide: true
   /puppetserver/6.0:
     doc: puppetserver
     version: "6.0"
@@ -710,112 +664,6 @@ documents:
       facter: "3.11"
       hiera: "3.4"
     hide: true
-  /puppetserver/5.2:
-    doc: puppetserver
-    version: "5.2"
-    nav: /puppet/5.4/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: d5a633fdbfed4850dbfc401e8410c5bede1d8a4e
-      subdirectory: documentation
-    my_versions:
-      puppet: "5.4"
-      facter: "3.10"
-      hiera: "3.4"
-    hide: true
-  /puppetserver/5.1:
-    doc: puppetserver
-    version: "5.1"
-    nav: /puppet/5.3/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: a7c0b28b167ab23631600c3563bb33736538c991
-      subdirectory: documentation
-    my_versions:
-      puppet: "5.3"
-      facter: "3.9"
-      hiera: "3.4"
-    hide: true
-  /puppetserver/5.0:
-    doc: puppetserver
-    version: "5.0"
-    nav: /puppet/5.0/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: be96921aab5d434cd8ddf5a87de40132dfa5bd43
-      subdirectory: documentation
-    my_versions:
-      puppet: "5.0"
-      facter: "3.7"
-      hiera: "3.4"
-    hide: true
-  /puppetserver/2.8:
-    doc: puppetserver
-    version: "2.8"
-    nav: /puppet/4.10/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: e0cd7cb971c83d2ff0ff6221c84f54d53db9d8d6
-      subdirectory: documentation
-    hide: true
-  /puppetserver/2.7:
-    doc: puppetserver
-    version: "2.7"
-    nav: /puppet/4.9/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: b4fbbf035287318694e4313d5d3d3a9eea2d707a
-      subdirectory: documentation
-    my_versions:
-      puppet: "4.9"
-      facter: "3.5"
-      hiera: "3.2"
-    hide: true
-  /puppetserver/2.6:
-    doc: puppetserver
-    version: "2.6"
-    nav: /puppet/4.6/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: 2d3bc286bc5822f35ff04273156f8921e1603d19
-      subdirectory: documentation
-    my_versions:
-      puppet: "4.6"
-      facter: "3.3"
-      hiera: "3.2"
-    hide: true
-  /puppetserver/2.5:
-    doc: puppetserver
-    version: "2.5"
-    nav: /puppet/4.6/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: ba86848
-      subdirectory: documentation
-    my_versions:
-      puppet: "4.6"
-      facter: "3.3"
-      hiera: "3.2"
-  /puppetserver/2.4:
-    doc: puppetserver
-    version: "2.4"
-    nav: /puppet/4.5/_puppet_toc.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: 522083d
-      subdirectory: documentation
-    my_versions:
-      puppet: "4.5"
-      facter: "3.1"
-      hiera: "3.2"
-  /puppetserver/1.1:
-    doc: puppetserver
-    version: "1.1"
-    nav: /_includes/puppet_3_8.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetserver.git
-      commit: bbc73f6da0a17eac4fbf84758b477ec9dd4cebb2
-      subdirectory: documentation
 
   /puppetdb/latest:
     doc: puppetdb

--- a/source/_config.yml
+++ b/source/_config.yml
@@ -390,51 +390,6 @@ documents:
       hiera: "3.4"
       puppetserver: "5.3"
     hide: true
-  /puppet/5.4:
-    doc: puppet
-    version: "5.4"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.10"
-      hiera: "3.4"
-      puppetserver: "5.2"
-    hide: true
-  /puppet/5.3:
-    doc: puppet
-    version: "5.3"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.9"
-      hiera: "3.4"
-      puppetserver: "5.1"
-    hide: true
-  /puppet/5.2:
-    doc: puppet
-    version: "5.2"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.9"
-      hiera: "3.4"
-      puppetserver: "5.1"
-    hide: true
-  /puppet/5.1:
-    doc: puppet
-    version: "5.1"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.8"
-      hiera: "3.4"
-      puppetserver: "5.0"
-    hide: true
-  /puppet/5.0:
-    doc: puppet
-    version: "5.0"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.7"
-      hiera: "3.4"
-      puppetserver: "5.0"
-    hide: true
   /puppet/4.10:
     doc: puppet
     version: "4.10"
@@ -444,50 +399,6 @@ documents:
       hiera: "3.3"
       puppetserver: "2.6"
     hide: true
-  /puppet/4.9:
-    doc: puppet
-    version: "4.9"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.6"
-      hiera: "3.3"
-      puppetserver: "2.7"
-    hide: true
-  /puppet/4.8:
-    doc: puppet
-    version: "4.8"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.5"
-      hiera: "3.2"
-      puppetserver: "2.7"
-    hide: true
-  /puppet/4.7:
-    doc: puppet
-    version: "4.7"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.4"
-      hiera: "3.2"
-      puppetserver: "2.6"
-    hide: true
-  /puppet/4.6:
-    doc: puppet
-    version: "4.6"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.4"
-      hiera: "3.2"
-      puppetserver: "2.6"
-    hide: true
-  /puppet/4.5:
-    doc: puppet
-    version: "4.5"
-    nav: ./_puppet_toc.html
-    my_versions:
-      facter: "3.3"
-      hiera: "3.2"
-      puppetserver: "2.4"
   /puppet/3.8:
     doc: puppet
     version: "3.8"

--- a/source/_config.yml
+++ b/source/_config.yml
@@ -585,24 +585,6 @@ documents:
       commit: doc-latest
       subdirectory: documentation
     hide: true
-  /puppetdb/6.5:
-    doc: puppetdb
-    version: "6.5"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-6.5
-      subdirectory: documentation
-    hide: true
-  /puppetdb/6.4:
-    doc: puppetdb
-    version: "6.4"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-6.4
-      subdirectory: documentation
-    hide: true
   /puppetdb/6.3:
     doc: puppetdb
     version: "6.3"
@@ -612,24 +594,7 @@ documents:
       commit: doc-6.3
       subdirectory: documentation
     hide: true
-  /puppetdb/6.2:
-    doc: puppetdb
-    version: "6.2"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-6.2
-      subdirectory: documentation
-    hide: true
-  /puppetdb/6.1:
-    doc: puppetdb
-    version: "6.1"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-6.1
-      subdirectory: documentation
-    hide: true
+
   /puppetdb/6.0:
     doc: puppetdb
     version: "6.0"
@@ -648,67 +613,5 @@ documents:
       commit: doc-5.2
       subdirectory: documentation
     hide: true
-  /puppetdb/5.1:
-    doc: puppetdb
-    version: "5.1"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      # Stop just before the facts-blacklist regex docs (unreleased)
-      commit: doc-5.1
-      subdirectory: documentation
-    hide: true
-  /puppetdb/5.0:
-    doc: puppetdb
-    version: "5.0"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-5.0
-      subdirectory: documentation
-    hide: true
-  /puppetdb/4.4:
-    doc: puppetdb
-    version: "4.4"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-4.4
-      subdirectory: documentation
-    hide: true
-  /puppetdb/4.3:
-    doc: puppetdb
-    version: "4.3"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-4.3
-      subdirectory: documentation
-    hide: true
-  /puppetdb/4.2:
-    doc: puppetdb
-    version: "4.2"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-4.2
-      subdirectory: documentation
-    hide: true
-  /puppetdb/4.1:
-    doc: puppetdb
-    version: "4.1"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-4.1
-      subdirectory: documentation
-  /puppetdb/2.3:
-    doc: puppetdb
-    version: "2.3"
-    nav: ./_puppetdb_nav.html
-    external_source:
-      repo: git://github.com/puppetlabs/puppetdb.git
-      commit: doc-2.3
-      subdirectory: documentation
 
 ---


### PR DESCRIPTION
Heston, can you have a look at this PR? I'm removing a lot, so I just want a second set of eyes on it. 

The redirect commit for the Puppet Server and DB versions, if you want to refer to it, is at https://github.com/puppetlabs/picasso/pull/487

The Puppet redirects for <5.5 were merged a while back, but Server still depended on the old ToCs, so I'm just removing them now.

