### PR TITLE
(DOC-3797) Remove `puppet cert` and "leftovers"

### DIFF
--- a/lib/puppet_references/puppet/man.rb
+++ b/lib/puppet_references/puppet/man.rb
@@ -27,7 +27,6 @@ module PuppetReferences
             core: %w(
           agent
           apply
-          cert
           lookup
           master
           module
@@ -66,7 +65,7 @@ module PuppetReferences
         }
         all_in_categories = categories.values.flatten
         # Don't let new commands drop off into The Nothing:
-        leftovers = commands - all_in_categories
+        # leftovers = commands - all_in_categories
         # Clean up any commands that don't exist in this version of Puppet:
         categories.values.each do |list|
           list.reject! {|sub| !commands.include?(sub)}
@@ -102,21 +101,6 @@ Most users can ignore these subcommands. They're only useful for certain niche w
 #{ categories[:weird].reduce('') {|memo, item| memo << "- [puppet #{item}](./#{item}.html)\n"} }
 
 EOT
-        # Handle any leftovers that aren't in categories
-        unless leftovers.empty?
-          index_text << <<EOADDENDUM
-## Puppet Enterprise-specific subcommands
-
-Puppet Enterprise (PE) has some unique subcommands, such as `puppet infrastructure`. For reference information about these commands, use the `puppet help` command, such as `puppet help infrastructure`. For usage information, see the [Puppet Enterprise documentation](https://puppet.com/docs/pe/).
-
-New or uncategorized subcommands
------
-
-These subcommands have not yet been added to any of the categories above.
-
-#{ leftovers.reduce('') {|memo, item| memo << "- [puppet #{item}](./#{item}.html)\n"} }
-EOADDENDUM
-        end
         # write index
         filename = OUTPUT_DIR + 'index.md'
         filename.open('w') {|f| f.write(index_text)}

--- a/source/puppet/6.0/man/index.md
+++ b/source/puppet/6.0/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.1/man/index.md
+++ b/source/puppet/6.1/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.10/man/index.md
+++ b/source/puppet/6.10/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.2/man/index.md
+++ b/source/puppet/6.2/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.3/man/index.md
+++ b/source/puppet/6.3/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.4/man/index.md
+++ b/source/puppet/6.4/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.5/man/index.md
+++ b/source/puppet/6.5/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.6/man/index.md
+++ b/source/puppet/6.6/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 

--- a/source/puppet/6.7/man/index.md
+++ b/source/puppet/6.7/man/index.md
@@ -16,11 +16,9 @@ These subcommands form the core of Puppet's tool set, and every user should unde
 
 - [puppet agent](./agent.html)
 - [puppet apply](./apply.html)
-- [puppet cert](./cert.html)
 - [puppet lookup](./lookup.html)
 - [puppet module](./module.html)
 - [puppet resource](./resource.html)
-
 
 > Note: The `puppet cert` command is available only in Puppet versions prior to 6.0. For 6.0 and later, use the [`puppetserver cert`command](https://puppet.com/docs/puppet/6.0/puppet_server_ca_cli.html).
 


### PR DESCRIPTION
The build scripts add "leftovers" -- `puppet` commands that aren't
explicitly listed as core, niche, etc. This was once a good idea;
now, thanks to `puppet cert`, it makes it impossible to complete
remove commands that have been disabled but still have scripts in
puppetlabs/puppet.

Remove the leftovers functionality and `puppet cert`. Any new
commands will need to be explicitly added to `core`, etc.
sections in `puppet-docs/lib/puppet_references/puppet/man.rb`.