### PR TITLE
(maint) Update copyright year to 2020.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The content in this documentation project is
 
-Copyright (c) 2009-2016 Puppet, Inc.
+Copyright (c) Puppet, Inc.
 
 Licensed under the Creative Commons 3.0
 with Attribution and Share Alike Clauses
@@ -15,11 +15,7 @@ OR COPYRIGHT LAW IS PROHIBITED.
 
 ==============================================
 
-The application to develop this content is
-
-Copyright (c) 2009-2017 Puppet, Inc.
-
-Based on Rails Guides:
+The application to develop this content is based on Rails Guides:
 
 Copyright (c) 2004-2009 David Heinemeier Hansson
 

--- a/README.markdown
+++ b/README.markdown
@@ -22,4 +22,4 @@ If something in the documentation doesn't seem right, or if you think something 
 
 ## Copyright
 
-Copyright (c) 2009-2019 Puppet, Inc. See LICENSE for details.
+Copyright (c) 2009-2020 Puppet, Inc. See LICENSE for details.


### PR DESCRIPTION
Removed the redundancies in the LICENSE file as well, so there should only be one place the year gets updated each year.