### PR TITLE
Add dependabot to repo

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,7 @@
+---
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "daily"


### PR DESCRIPTION
Dependabot will enable automated dependency updates for any gems in this repository.