### PR TITLE
Remove bundler version spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,3 @@ DEPENDENCIES
   vlad (~> 1.4)
   vlad-git (~> 2.1)
   yard (~> 0.9)
-
-BUNDLED WITH
-   2.1.4


### PR DESCRIPTION
Removing the specification of using bundler 2.1.4 since our Jenkins workers don't have that version installed.