### PR TITLE
(DIP-329) Replace man with ronn commands

### DIFF
--- a/lib/puppet_references/man_command.rb
+++ b/lib/puppet_references/man_command.rb
@@ -3,15 +3,9 @@ require 'puppet_references/puppet_command'
 module PuppetReferences
   class ManCommand < PuppetReferences::PuppetCommand
     attr_reader :name
-    FACES_THAT_RUIN_EVERYTHING = %w(resource)
     def initialize(name, puppet_dir = PuppetReferences::PUPPET_DIR)
       @name = name
-      if FACES_THAT_RUIN_EVERYTHING.include?(@name)
-        super("puppet #{@name} --help", puppet_dir)
-      else
-        super("puppet man man #{@name} --render-as s", puppet_dir)
-      end
-
+      super("puppet #{@name} --help", puppet_dir)
     end
   end
 end


### PR DESCRIPTION
Replaces deprecated man commands in docs build with
`puppet <command> --help`.
See:
- [#8146](https://github.com/puppetlabs/puppet/pull/8146)
- [PUP-10502](https://tickets.puppetlabs.com/browse/PUP-10502)