### PR TITLE
(maint) Generate documentation for Facter 4.

### DIFF
--- a/source/puppet/latest/core_facts.md
+++ b/source/puppet/latest/core_facts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-built_from_commit: 2499c0dff0466dcc34624e5a00e10c8b62101915
+built_from_commit: bb8dd4062108835438b2c6a793514e3b6330a1d6
 title: 'Facter: Core Facts'
 toc: columns
 canonical: "/puppet/latest/core_facts.html"
@@ -27,13 +27,6 @@ You can access facts in your Puppet manifests as `$fact_name` or `$facts[fact_na
 Return the version of the puppet-agent package that installed facter.
 
 
-**Resolution:**
-
-* All platforms: use the compile-time enabled version definition.
-
-
-([↑ Back to top](#page-nav))
-
 ### `augeas`
 
 **Type:** map
@@ -47,13 +40,6 @@ Return information about augeas.
 * `version` (string) --- The version of augparse.
 
 
-**Resolution:**
-
-* All platforms: query augparse for augeas metadata.
-
-
-([↑ Back to top](#page-nav))
-
 ### `cloud`
 
 **Type:** map
@@ -66,10 +52,6 @@ Information about the cloud instance of the node. This is currently only populat
 
 * `provider` (string) --- The cloud provider for the node.
 
-
-
-
-([↑ Back to top](#page-nav))
 
 ### `disks`
 
@@ -88,19 +70,8 @@ Return the disk (block) devices attached to the system.
     * `size` (string) --- The display size of the disk or block device, such as "1 GiB".
     * `size_bytes` (integer) --- The size of the disk or block device, in bytes.
     * `vendor` (string) --- The vendor of the disk or block device.
+    * `type` (string) --- The type of disk or block device (sshd or hdd). This fact is available only on Linux.
 
-
-**Resolution:**
-
-* AIX: query the ODM for all disk devices
-* Linux: parse the contents of `/sys/block/<device>/`.
-* Solaris: use the `kstat` function to query disk information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `dmi`
 
@@ -131,19 +102,6 @@ Return the system management information.
     * `uuid` (string) --- The product unique identifier of the system.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/` to retrieve system management information.
-* Mac OSX: use the `sysctl` function to retrieve system management information.
-* Solaris: use the `smbios`, `prtconf`, and `uname` utilities to retrieve system management information.
-* Windows: use WMI to retrieve system management information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `ec2_metadata`
 
 **Type:** map
@@ -154,16 +112,6 @@ Return the Amazon Elastic Compute Cloud (EC2) instance metadata.
 Please see the [EC2 instance metadata documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the contents of this fact.
 
 
-
-**Resolution:**
-
-* EC2: query the EC2 metadata endpoint and parse the response.
-
-**Caveats:**
-
-* All platforms: `libfacter` must be built with `libcurl` support.
-
-([↑ Back to top](#page-nav))
 
 ### `ec2_userdata`
 
@@ -176,16 +124,6 @@ Please see the [EC2 instance user data documentation](http://docs.aws.amazon.com
 
 
 
-**Resolution:**
-
-* EC2: query the EC2 user data endpoint and parse the response.
-
-**Caveats:**
-
-* All platforms: `libfacter` must be built with `libcurl` support.
-
-([↑ Back to top](#page-nav))
-
 ### `env_windows_installdir`
 
 **Type:** string
@@ -194,18 +132,6 @@ Please see the [EC2 instance user data documentation](http://docs.aws.amazon.com
 
 Return the path of the directory in which Puppet was installed.
 
-
-**Resolution:**
-
-* Windows: This fact is specific to the Windows MSI generated environment, and is
-*   set using the `environment.bat` script that configures the runtime environment
-*   for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
-
-**Caveats:**
-
-* This fact is specific to Windows, and will not resolve on any other platform.
-
-([↑ Back to top](#page-nav))
 
 ### `facterversion`
 
@@ -216,13 +142,6 @@ Return the path of the directory in which Puppet was installed.
 Return the version of facter.
 
 
-**Resolution:**
-
-* All platforms: use the built-in version of libfacter.
-
-
-([↑ Back to top](#page-nav))
-
 ### `filesystems`
 
 **Type:** string
@@ -231,20 +150,6 @@ Return the version of facter.
 
 Return the usable file systems for block or disk devices.
 
-
-**Resolution:**
-
-* AIX: parse the contents of `/etc/vfs` to retrieve the usable file systems.
-* Linux: parse the contents of `/proc/filesystems` to retrieve the usable file systems.
-* Mac OSX: use the `getfsstat` function to retrieve the usable file systems.
-* Solaris: use the `sysdef` utility to retrieve the usable file systems.
-
-**Caveats:**
-
-* Linux: The proc file system must be mounted.
-* Mac OSX: The usable file systems is limited to the file system of mounted devices.
-
-([↑ Back to top](#page-nav))
 
 ### `fips_enabled`
 
@@ -255,16 +160,9 @@ Return the usable file systems for block or disk devices.
 Return whether the platform is in FIPS mode
 
 
-**Resolution:**
+**Details:**
 
-* Linux: parse the contents of `/proc/sys/crypto/fips_enabled` which if non-zero indicates fips mode has been enabled.
-* Windows: check if key `HKEY_LOCAL_MACHINE/System/CurrentControlSet/Control/Lsa/FipsAlgorithmPolicy/Enabled` is 1 or 0
-
-**Caveats:**
-
-* Linux: Limited to linux redhat family only
-
-([↑ Back to top](#page-nav))
+Only available on Windows and Redhat linux family
 
 ### `gce`
 
@@ -277,16 +175,6 @@ Please see the [GCE metadata documentation](https://cloud.google.com/compute/doc
 
 
 
-**Resolution:**
-
-* GCE: query the GCE metadata endpoint and parse the response.
-
-**Caveats:**
-
-* All platforms: `libfacter` must be built with `libcurl` support.
-
-([↑ Back to top](#page-nav))
-
 ### `hypervisors`
 
 **Type:** map
@@ -296,13 +184,6 @@ Please see the [GCE metadata documentation](https://cloud.google.com/compute/doc
 Experimental fact: Return the names of any detected hypervisors and any collected metadata about them.
 
 
-
-**Resolution:**
-
-* All platforms: Use the external `whereami` library to gather hypervisor data, if available.
-
-
-([↑ Back to top](#page-nav))
 
 ### `identity`
 
@@ -321,14 +202,6 @@ Return the identity information of the user running facter.
 * `privileged` (boolean) --- True if facter is running as a privileged process or false if not.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information; use the result of the `geteuid() == 0` test as the value of the privileged element
-* Windows: use the `GetUserNameExW` function to retrieve the identity information; use the `GetTokenInformation` to get the current process token elevation status and use it as the value of the privileged element on versions of Windows supporting the token elevation, on older versions of Windows use the `CheckTokenMembership` to test whether the well known local Administrators group SID is enabled in the current thread impersonation token and use the test result as the value of the privileged element
-
-
-([↑ Back to top](#page-nav))
-
 ### `is_virtual`
 
 **Type:** boolean
@@ -337,16 +210,6 @@ Return the identity information of the user running facter.
 
 Return whether or not the host is a virtual machine.
 
-
-**Resolution:**
-
-* Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine status.
-* Mac OSX: use the system profiler to retrieve virtual machine status.
-* Solaris: use the `zonename` utility to retrieve virtual machine status.
-* Windows: use WMI to retrieve virtual machine status.
-
-
-([↑ Back to top](#page-nav))
 
 ### `kernel`
 
@@ -357,14 +220,6 @@ Return whether or not the host is a virtual machine.
 Return the kernel's name.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the kernel name.
-* Windows: use the value of `windows` for all Windows versions.
-
-
-([↑ Back to top](#page-nav))
-
 ### `kernelmajversion`
 
 **Type:** string
@@ -373,14 +228,6 @@ Return the kernel's name.
 
 Return the kernel's major version.
 
-
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the kernel's major version.
-* Windows: use the file version of `kernel32.dll` to retrieve the kernel's major version.
-
-
-([↑ Back to top](#page-nav))
 
 ### `kernelrelease`
 
@@ -391,14 +238,6 @@ Return the kernel's major version.
 Return the kernel's release.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the kernel's release.
-* Windows: use the file version of `kernel32.dll` to retrieve the kernel's release.
-
-
-([↑ Back to top](#page-nav))
-
 ### `kernelversion`
 
 **Type:** string
@@ -408,14 +247,6 @@ Return the kernel's release.
 Return the kernel's version.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the kernel's version.
-* Windows: use the file version of `kernel32.dll` to retrieve the kernel's version.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ldom`
 
 **Type:** map
@@ -424,13 +255,6 @@ Return the kernel's version.
 
 Return Solaris LDom information from the `virtinfo` utility.
 
-
-**Resolution:**
-
-* Solaris: use the `virtinfo` utility to retrieve LDom information.
-
-
-([↑ Back to top](#page-nav))
 
 ### `load_averages`
 
@@ -446,13 +270,6 @@ Return the load average over the last 1, 5 and 15 minutes.
 * `5m` (double) --- The system load average over the last 5 minutes.
 * `15m` (double) --- The system load average over the last 15 minutes.
 
-
-**Resolution:**
-
-* POSIX platforms: use `getloadavg` function to retrieve the system load averages.
-
-
-([↑ Back to top](#page-nav))
 
 ### `memory`
 
@@ -483,16 +300,6 @@ Return the system memory information.
     * `used_bytes` (integer) --- The size of the used amount of system memory, in bytes.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the system memory information.
-* Mac OSX: use the `sysctl` function to retrieve the system memory information.
-* Solaris: use the `kstat` function to retrieve the system memory information.
-* Windows: use the `GetPerformanceInfo` function to retrieve the system memory information.
-
-
-([↑ Back to top](#page-nav))
-
 ### `mountpoints`
 
 **Type:** map
@@ -515,16 +322,6 @@ Return the current mount points of the system.
     * `used` (string) --- The display size of the used space, such as "1 GiB".
     * `used_bytes` (integer) --- The size of the used space, in bytes.
 
-
-**Resolution:**
-
-* AIX: use the `mntctl` function to retrieve the mount points.
-* Linux: use the `setmntent` function to retrieve the mount points.
-* Mac OSX: use the `getfsstat` function to retrieve the mount points.
-* Solaris: parse the contents of `/etc/mnttab` to retrieve the mount points.
-
-
-([↑ Back to top](#page-nav))
 
 ### `networking`
 
@@ -565,19 +362,6 @@ Return the networking information for the system.
 * `primary` (string) --- The name of the primary interface.
 * `scope6` (string) --- The IPv6 scope of the default network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interfaces.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interfaces.
-* Solaris: use the `ioctl` function to retrieve the network interfaces.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interfaces.
-
-**Caveats:**
-
-* Windows Server 2003: the `GetAdaptersInfo` function is used for DHCP and netmask lookup. This function does not support IPv6 netmasks.
-
-([↑ Back to top](#page-nav))
 
 ### `os`
 
@@ -630,16 +414,6 @@ Return information about the host operating system.
     * `system32` (string) --- The path to the System32 directory.
 
 
-**Resolution:**
-
-* Linux: use the `lsb_release` utility and parse the contents of release files in `/etc` to retrieve the OS information.
-* OSX: use the `sw_vers` utility to retrieve the OS information.
-* Solaris: parse the contents of `/etc/release` to retrieve the OS information.
-* Windows: use WMI to retrieve the OS information.
-
-
-([↑ Back to top](#page-nav))
-
 ### `partitions`
 
 **Type:** map
@@ -662,17 +436,6 @@ Return the disk partitions of the system.
     * `backing_file` (string) --- The path to the file backing the partition.
 
 
-**Resolution:**
-
-* AIX: use the ODM to retrieve list of logical volumes; use `lvm_querylv` function to get details
-* Linux: use `libblkid` to retrieve the disk partitions.
-
-**Caveats:**
-
-* Linux: `libfacter` must be built with `libblkid` support.
-
-([↑ Back to top](#page-nav))
-
 ### `path`
 
 **Type:** string
@@ -681,13 +444,6 @@ Return the disk partitions of the system.
 
 Return the PATH environment variable.
 
-
-**Resolution:**
-
-* All platforms: retrieve the value of the PATH environment variable.
-
-
-([↑ Back to top](#page-nav))
 
 ### `processors`
 
@@ -706,16 +462,6 @@ Return information about the system's processors.
 * `speed` (string) --- The speed of the processors, such as "2.0 GHz".
 
 
-**Resolution:**
-
-* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the processor information.
-* Mac OSX: use the `sysctl` function to retrieve the processor information.
-* Solaris: use the `kstat` function to retrieve the processor information.
-* Windows: use WMI to retrieve the processor information.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ruby`
 
 **Type:** map
@@ -730,16 +476,6 @@ Return information about the Ruby loaded by facter.
 * `sitedir` (string) --- The path to Ruby's site library directory.
 * `version` (string) --- The version of Ruby.
 
-
-**Resolution:**
-
-* All platforms: Use `RbConfig`, `RUBY_PLATFORM`, and `RUBY_VERSION` to retrieve information about Ruby.
-
-**Caveats:**
-
-* All platforms: facter must be able to locate `libruby`.
-
-([↑ Back to top](#page-nav))
 
 ### `solaris_zones`
 
@@ -761,13 +497,6 @@ Return information about Solaris zones.
         * `status` (string) --- The status of the Solaris zone.
         * `uuid` (string) --- The unique identifier of the Solaris zone.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` and `zonename` utilities to retrieve information about the Solaris zones.
-
-
-([↑ Back to top](#page-nav))
 
 ### `ssh`
 
@@ -805,16 +534,6 @@ Return SSH public keys and fingerprints.
     * `type` (string) --- The exact type of the key, i.e. "ssh-rsa".
 
 
-**Resolution:**
-
-* POSIX platforms: parse SSH public key files and derive fingerprints.
-
-**Caveats:**
-
-* POSIX platforms: facter must be built with OpenSSL support.
-
-([↑ Back to top](#page-nav))
-
 ### `system_profiler`
 
 **Type:** map
@@ -848,13 +567,6 @@ Return information from the Mac OSX system profiler.
 * `username` (string) --- The name of the user running facter.
 
 
-**Resolution:**
-
-* Mac OSX: use the `system_profiler` utility to retrieve system profiler information.
-
-
-([↑ Back to top](#page-nav))
-
 ### `system_uptime`
 
 **Type:** map
@@ -871,16 +583,6 @@ Return the system uptime information.
 * `uptime` (string) --- The full uptime string.
 
 
-**Resolution:**
-
-* Linux: use the `sysinfo` function to retrieve the system uptime.
-* POSIX platforms: use the `uptime` utility to retrieve the system uptime.
-* Solaris: use the `kstat` function to retrieve the system uptime.
-* Windows: use WMI to retrieve the system uptime.
-
-
-([↑ Back to top](#page-nav))
-
 ### `timezone`
 
 **Type:** string
@@ -890,14 +592,6 @@ Return the system uptime information.
 Return the system timezone.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `localtime_r` function to retrieve the system timezone.
-* Windows: use the `localtime_s` function to retrieve the system timezone.
-
-
-([↑ Back to top](#page-nav))
-
 ### `virtual`
 
 **Type:** string
@@ -906,16 +600,6 @@ Return the system timezone.
 
 Return the hypervisor name for virtual machines or "physical" for physical machines.
 
-
-**Resolution:**
-
-* Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine name.
-* Mac OSX: use the system profiler to retrieve virtual machine name.
-* Solaris: use the `zonename` utility to retrieve virtual machine name.
-* Windows: use WMI to retrieve virtual machine name.
-
-
-([↑ Back to top](#page-nav))
 
 ### `xen`
 
@@ -930,16 +614,6 @@ Return metadata for the Xen hypervisor.
 * `domains` (array) --- list of strings identifying active Xen domains.
 
 
-**Resolution:**
-
-* POSIX platforms: use `/usr/lib/xen-common/bin/xen-toolstack` to locate xen admin commands if available, otherwise fallback to `/usr/sbin/xl` or `/usr/sbin/xm`. Use the found command to execute the `list` query.
-
-**Caveats:**
-
-* POSIX platforms: confined to Xen privileged virtual machines.
-
-([↑ Back to top](#page-nav))
-
 ### `zfs_featurenumbers`
 
 **Type:** string
@@ -948,16 +622,6 @@ Return metadata for the Xen hypervisor.
 
 Return the comma-delimited feature numbers for ZFS.
 
-
-**Resolution:**
-
-* Solaris: use the `zfs` utility to retrieve the feature numbers for ZFS
-
-**Caveats:**
-
-* Solaris: the `zfs` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zfs_version`
 
@@ -968,16 +632,6 @@ Return the comma-delimited feature numbers for ZFS.
 Return the version for ZFS.
 
 
-**Resolution:**
-
-* Solaris: use the `zfs` utility to retrieve the version for ZFS
-
-**Caveats:**
-
-* Solaris: the `zfs` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zpool_featureflags`
 
 **Type:** string
@@ -986,16 +640,6 @@ Return the version for ZFS.
 
 Return the comma-delimited feature flags for ZFS storage pools.
 
-
-**Resolution:**
-
-* Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools
-
-**Caveats:**
-
-* Solaris: the `zpool` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zpool_featurenumbers`
 
@@ -1006,16 +650,6 @@ Return the comma-delimited feature flags for ZFS storage pools.
 Return the comma-delimited feature numbers for ZFS storage pools.
 
 
-**Resolution:**
-
-* Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools
-
-**Caveats:**
-
-* Solaris: the `zpool` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zpool_version`
 
 **Type:** string
@@ -1025,16 +659,18 @@ Return the comma-delimited feature numbers for ZFS storage pools.
 Return the version for ZFS storage pools.
 
 
-**Resolution:**
+### `nim_type`
 
-* Solaris: use the `zpool` utility to retrieve the version for ZFS storage pools
+**Type:** string
 
-**Caveats:**
+**Purpose:**
 
-* Solaris: the `zpool` utility must be present.
+Tells if the node is master or standalone inside an AIX Nim environment.
 
-([↑ Back to top](#page-nav))
 
+**Details:**
+
+Is Available only on AIX.
 ## Legacy Facts
 
 ### `architecture`
@@ -1048,17 +684,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the operating system's hardware architecture.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the OS hardware architecture.
-* Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware architecture.
-
-**Caveats:**
-
-* Linux: Debian, Gentoo, kFreeBSD, and Ubuntu use "amd64" for "x86_64" and Gentoo uses "x86" for "i386".
-
-([↑ Back to top](#page-nav))
-
 ### `augeasversion`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1069,13 +694,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the version of augeas.
 
-
-**Resolution:**
-
-* All platforms: query augparse for the augeas version.
-
-
-([↑ Back to top](#page-nav))
 
 ### `blockdevices`
 
@@ -1088,17 +706,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return a comma-separated list of block devices.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/block/<device>/`.
-* Solaris: use the `kstat` function to query disk information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `blockdevice_<devicename>_model`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1109,17 +716,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the model name of block devices attached to the system.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/block/<device>/device/model` to retrieve the model name/number for a device.
-* Solaris: use the `kstat` function to query disk information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `blockdevice_<devicename>_size`
 
@@ -1132,17 +728,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the size of a block device in bytes.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes).
-* Solaris: use the `kstat` function to query disk information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `blockdevice_<devicename>_vendor`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1153,17 +738,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the vendor name of block devices attached to the system.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/block/<device>/device/vendor` to retrieve the vendor for a device.
-* Solaris: use the `kstat` function to query disk information.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `bios_release_date`
 
@@ -1176,17 +750,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the release date of the system BIOS.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/bios_date` to retrieve the system BIOS release date.
-* Solaris: use the `smbios` utility to retrieve the system BIOS release date.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `bios_vendor`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1197,17 +760,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the vendor of the system BIOS.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/bios_vendor` to retrieve the system BIOS vendor.
-* Solaris: use the `smbios` utility to retrieve the system BIOS vendor.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `bios_version`
 
@@ -1220,17 +772,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the version of the system BIOS.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/bios_version` to retrieve the system BIOS version.
-* Solaris: use the `smbios` utility to retrieve the system BIOS version.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `boardassettag`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1241,16 +782,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system board asset tag.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/board_asset_tag` to retrieve the system board asset tag.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `boardmanufacturer`
 
@@ -1263,16 +794,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system board manufacturer.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/board_vendor` to retrieve the system board manufacturer.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `boardproductname`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1283,16 +804,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system board product name.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/board_name` to retrieve the system board product name.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `boardserialnumber`
 
@@ -1305,16 +816,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system board serial number.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/board_serial` to retrieve the system board serial number.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `chassisassettag`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1326,17 +827,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system chassis asset tag.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/chassis_asset_tag` to retrieve the system chassis asset tag.
-* Solaris: use the `smbios` utility to retrieve the system chassis asset tag.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `chassistype`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1347,17 +837,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system chassis type.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/chassis_type` to retrieve the system chassis type.
-* Solaris: use the `smbios` utility to retrieve the system chassis type.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `dhcp_servers`
 
@@ -1375,16 +854,6 @@ Return the DHCP servers for the system.
 * `system` (ip) --- The DHCP server for the default interface.
 
 
-**Resolution:**
-
-* Linux: parse `dhclient` lease files or use the `dhcpcd` utility to retrieve the DHCP servers.
-* Mac OSX: use the `ipconfig` utility to retrieve the DHCP servers.
-* Solaris: use the `dhcpinfo` utility to retrieve the DHCP servers.
-* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the DHCP servers.
-
-
-([↑ Back to top](#page-nav))
-
 ### `domain`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1395,14 +864,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the network domain of the system.
 
-
-**Resolution:**
-
-* POSIX platforms: use the `getaddrinfo` function to retrieve the network domain.
-* Windows: query the registry to retrieve the network domain; falls back to the primary interface's domain if not set in the registry.
-
-
-([↑ Back to top](#page-nav))
 
 ### `fqdn`
 
@@ -1415,14 +876,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the fully qualified domain name (FQDN) of the system.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `getaddrinfo` function to retrieve the FQDN or use host and domain names.
-* Windows: use the host and domain names to build the FQDN.
-
-
-([↑ Back to top](#page-nav))
-
 ### `gid`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1433,13 +886,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the group identifier (GID) of the user running facter.
 
-
-**Resolution:**
-
-* POSIX platforms: use the `getegid` fuction to retrieve the group identifier.
-
-
-([↑ Back to top](#page-nav))
 
 ### `hardwareisa`
 
@@ -1452,14 +898,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the hardware instruction set architecture (ISA).
 
 
-**Resolution:**
-
-* POSIX platforms: use `uname` to retrieve the hardware ISA.
-* Windows: use WMI to retrieve the hardware ISA.
-
-
-([↑ Back to top](#page-nav))
-
 ### `hardwaremodel`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1470,14 +908,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the operating system's hardware model.
 
-
-**Resolution:**
-
-* POSIX platforms: use the `uname` function to retrieve the OS hardware model.
-* Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware model.
-
-
-([↑ Back to top](#page-nav))
 
 ### `hostname`
 
@@ -1490,14 +920,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the host name of the system.
 
 
-**Resolution:**
-
-* POSIX platforms: use the `gethostname` function to retrieve the host name
-* Windows: use the `GetComputerNameExW` function to retrieve the host name.
-
-
-([↑ Back to top](#page-nav))
-
 ### `id`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1508,13 +930,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the user identifier (UID) of the user running facter.
 
-
-**Resolution:**
-
-* POSIX platforms: use the `geteuid` fuction to retrieve the user identifier.
-
-
-([↑ Back to top](#page-nav))
 
 ### `interfaces`
 
@@ -1527,16 +942,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the comma-separated list of network interface names.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface names.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface names.
-* Solaris: use the `ioctl` function to retrieve the network interface names.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface names.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ipaddress`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1547,16 +952,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv4 address for the default network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
 
 ### `ipaddress6`
 
@@ -1569,16 +964,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv6 address for the default network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ipaddress6_<interface>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1589,16 +974,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv6 address for a network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
 
 ### `ipaddress_<interface>`
 
@@ -1611,16 +986,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv4 address for a network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ldom_<name>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1631,13 +996,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return Solaris LDom information.
 
-
-**Resolution:**
-
-* Solaris: use the `virtinfo` utility to retrieve LDom information.
-
-
-([↑ Back to top](#page-nav))
 
 ### `lsbdistcodename`
 
@@ -1650,16 +1008,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Linux Standard Base (LSB) distribution code name.
 
 
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB distribution code name.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
-
 ### `lsbdistdescription`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1670,16 +1018,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Linux Standard Base (LSB) distribution description.
 
-
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB distribution description.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
 
 ### `lsbdistid`
 
@@ -1692,16 +1030,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Linux Standard Base (LSB) distribution identifier.
 
 
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB distribution identifier.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
-
 ### `lsbdistrelease`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1712,16 +1040,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Linux Standard Base (LSB) distribution release.
 
-
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB distribution release.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
 
 ### `lsbmajdistrelease`
 
@@ -1734,16 +1052,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Linux Standard Base (LSB) major distribution release.
 
 
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB major distribution release.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
-
 ### `lsbminordistrelease`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1754,16 +1062,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Linux Standard Base (LSB) minor distribution release.
 
-
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB minor distribution release.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
 
 ### `lsbrelease`
 
@@ -1776,16 +1074,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Linux Standard Base (LSB) release.
 
 
-**Resolution:**
-
-* Linux: use the `lsb_release` utility to retrieve the LSB release.
-
-**Caveats:**
-
-* Linux: Requires that the `lsb_release` utility be installed.
-
-([↑ Back to top](#page-nav))
-
 ### `macaddress`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1796,16 +1084,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the MAC address for the default network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
 
 ### `macaddress_<interface>`
 
@@ -1818,16 +1096,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the MAC address for a network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface address.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface address.
-* Solaris: use the `ioctl` function to retrieve the network interface address.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address.
-
-
-([↑ Back to top](#page-nav))
-
 ### `macosx_buildversion`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1838,13 +1106,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Mac OSX build version.
 
-
-**Resolution:**
-
-* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX build version.
-
-
-([↑ Back to top](#page-nav))
 
 ### `macosx_productname`
 
@@ -1857,13 +1118,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Mac OSX product name.
 
 
-**Resolution:**
-
-* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product name.
-
-
-([↑ Back to top](#page-nav))
-
 ### `macosx_productversion`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1874,13 +1128,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Mac OSX product version.
 
-
-**Resolution:**
-
-* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product version.
-
-
-([↑ Back to top](#page-nav))
 
 ### `macosx_productversion_major`
 
@@ -1893,13 +1140,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Mac OSX product major version.
 
 
-**Resolution:**
-
-* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product major version.
-
-
-([↑ Back to top](#page-nav))
-
 ### `macosx_productversion_minor`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1910,13 +1150,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Mac OSX product minor version.
 
-
-**Resolution:**
-
-* Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product minor version.
-
-
-([↑ Back to top](#page-nav))
 
 ### `manufacturer`
 
@@ -1929,18 +1162,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system manufacturer.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/sys_vendor` to retrieve the system manufacturer.
-* Solaris: use the `prtconf` utility to retrieve the system manufacturer.
-* Windows: use WMI to retrieve the system manufacturer.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `memoryfree`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1951,16 +1172,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the display size of the free system memory, such as "1 GiB".
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory.
-* Mac OSX: use the `sysctl` function to retrieve the free system memory.
-* Solaris: use the `kstat` function to retrieve the free system memory.
-* Windows: use the `GetPerformanceInfo` function to retrieve the free system memory.
-
-
-([↑ Back to top](#page-nav))
 
 ### `memoryfree_mb`
 
@@ -1973,16 +1184,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the size of the free system memory, in mebibytes.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory.
-* Mac OSX: use the `sysctl` function to retrieve the free system memory.
-* Solaris: use the `kstat` function to retrieve the free system memory.
-* Windows: use the `GetPerformanceInfo` function to retrieve the free system memory.
-
-
-([↑ Back to top](#page-nav))
-
 ### `memorysize`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -1993,16 +1194,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the display size of the total system memory, such as "1 GiB".
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory.
-* Mac OSX: use the `sysctl` function to retrieve the total system memory.
-* Solaris: use the `kstat` function to retrieve the total system memory.
-* Windows: use the `GetPerformanceInfo` function to retrieve the total system memory.
-
-
-([↑ Back to top](#page-nav))
 
 ### `memorysize_mb`
 
@@ -2015,16 +1206,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the size of the total system memory, in mebibytes.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory.
-* Mac OSX: use the `sysctl` function to retrieve the total system memory.
-* Solaris: use the `kstat` function to retrieve the total system memory.
-* Windows: use the `GetPerformanceInfo` function to retrieve the total system memory.
-
-
-([↑ Back to top](#page-nav))
-
 ### `mtu_<interface>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2035,16 +1216,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the Maximum Transmission Unit (MTU) for a network interface.
 
-
-**Resolution:**
-
-* Linux: use the `ioctl` function to retrieve the network interface MTU.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface MTU.
-* Solaris: use the `ioctl` function to retrieve the network interface MTU.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface MTU.
-
-
-([↑ Back to top](#page-nav))
 
 ### `netmask`
 
@@ -2057,16 +1228,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv4 netmask for the default network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
-* Solaris: use the `ioctl` function to retrieve the network interface netmask.
-* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask.
-
-
-([↑ Back to top](#page-nav))
-
 ### `netmask6`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2077,19 +1238,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv6 netmask for the default network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
-* Solaris: use the `ioctl` function to retrieve the network interface netmask.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask.
-
-**Caveats:**
-
-* Windows Server 2003: IPv6 netmasks are not supported.
-
-([↑ Back to top](#page-nav))
 
 ### `netmask6_<interface>`
 
@@ -2102,19 +1250,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv6 netmask for a network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
-* Solaris: use the `ioctl` function to retrieve the network interface netmask.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask.
-
-**Caveats:**
-
-* Windows Server 2003: IPv6 netmasks are not supported.
-
-([↑ Back to top](#page-nav))
-
 ### `netmask_<interface>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2125,16 +1260,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv4 netmask for a network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface netmask.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask.
-* Solaris: use the `ioctl` function to retrieve the network interface netmask.
-* Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask.
-
-
-([↑ Back to top](#page-nav))
 
 ### `network`
 
@@ -2147,16 +1272,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv4 network for the default network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface network.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
-* Solaris: use the `ioctl` function to retrieve the network interface network.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
-
-
-([↑ Back to top](#page-nav))
-
 ### `network6`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2167,16 +1282,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv6 network for the default network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface network.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
-* Solaris: use the `ioctl` function to retrieve the network interface network.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
-
-
-([↑ Back to top](#page-nav))
 
 ### `network6_<interface>`
 
@@ -2189,16 +1294,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv6 network for a network interface.
 
 
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface network.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
-* Solaris: use the `ioctl` function to retrieve the network interface network.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
-
-
-([↑ Back to top](#page-nav))
-
 ### `network_<interface>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2209,16 +1304,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv4 network for a network interface.
 
-
-**Resolution:**
-
-* Linux: use the `getifaddrs` function to retrieve the network interface network.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface network.
-* Solaris: use the `ioctl` function to retrieve the network interface network.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network.
-
-
-([↑ Back to top](#page-nav))
 
 ### `operatingsystem`
 
@@ -2231,14 +1316,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the name of the operating system.
 
 
-**Resolution:**
-
-* All platforms: default to the kernel name.
-* Linux: use various release files in `/etc` to retrieve the OS name.
-
-
-([↑ Back to top](#page-nav))
-
 ### `operatingsystemmajrelease`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2249,19 +1326,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the major release of the operating system.
 
-
-**Resolution:**
-
-* All platforms: default to the major version of the kernel release.
-* Linux: parse the contents of release files in `/etc` to retrieve the OS major release.
-* Solaris: parse the contents of `/etc/release` to retrieve the OS major release.
-* Windows: use WMI to retrieve the OS major release.
-
-**Caveats:**
-
-* Linux: for Ubuntu, the major release is X.Y, such as "10.4".
-
-([↑ Back to top](#page-nav))
 
 ### `operatingsystemrelease`
 
@@ -2274,16 +1338,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the release of the operating system.
 
 
-**Resolution:**
-
-* All platforms: default to the kernel release.
-* Linux: parse the contents of release files in `/etc` to retrieve the OS release.
-* Solaris: parse the contents of `/etc/release` to retrieve the OS release.
-* Windows: use WMI to retrieve the OS release.
-
-
-([↑ Back to top](#page-nav))
-
 ### `osfamily`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2294,16 +1348,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the family of the operating system.
 
-
-**Resolution:**
-
-* All platforms: default to the kernel name.
-* Linux: map various Linux distributions to their base distribution. For example, Ubuntu is a "Debian" distro.
-* Solaris: map various Solaris-based operating systems to the "Solaris" family.
-* Windows: use "windows" as the family name.
-
-
-([↑ Back to top](#page-nav))
 
 ### `physicalprocessorcount`
 
@@ -2316,19 +1360,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the count of physical processors.
 
 
-**Resolution:**
-
-* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of physical processors.
-* Mac OSX: use the `sysctl` function to retrieve the count of physical processors.
-* Solaris: use the `kstat` function to retrieve the count of physical processors.
-* Windows: use WMI to retrieve the count of physical processors.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `processor<N>`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2339,16 +1370,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the model string of processor N.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/cpuinfo` to retrieve the processor model string.
-* Mac OSX: use the `sysctl` function to retrieve the processor model string.
-* Solaris: use the `kstat` function to retrieve the processor model string.
-* Windows: use WMI to retrieve the processor model string.
-
-
-([↑ Back to top](#page-nav))
 
 ### `processorcount`
 
@@ -2361,19 +1382,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the count of logical processors.
 
 
-**Resolution:**
-
-* Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of logical processors.
-* Mac OSX: use the `sysctl` function to retrieve the count of logical processors.
-* Solaris: use the `kstat` function to retrieve the count of logical processors.
-* Windows: use WMI to retrieve the count of logical processors.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
-
 ### `productname`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2384,19 +1392,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system product name.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product name.
-* Mac OSX: use the `sysctl` function to retrieve the system product name.
-* Solaris: use the `smbios` utility to retrieve the system product name.
-* Windows: use WMI to retrieve the system product name.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `rubyplatform`
 
@@ -2409,16 +1404,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the platform Ruby was built for.
 
 
-**Resolution:**
-
-* All platforms: use `RUBY_PLATFORM` from the Ruby loaded by facter.
-
-**Caveats:**
-
-* All platforms: facter must be able to locate `libruby`.
-
-([↑ Back to top](#page-nav))
-
 ### `rubysitedir`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2429,16 +1414,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the path to Ruby's site library directory.
 
-
-**Resolution:**
-
-* All platforms: use `RbConfig` from the Ruby loaded by facter.
-
-**Caveats:**
-
-* All platforms: facter must be able to locate `libruby`.
-
-([↑ Back to top](#page-nav))
 
 ### `rubyversion`
 
@@ -2451,16 +1426,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the version of Ruby.
 
 
-**Resolution:**
-
-* All platforms: use `RUBY_VERSION` from the Ruby loaded by facter.
-
-**Caveats:**
-
-* All platforms: facter must be able to locate `libruby`.
-
-([↑ Back to top](#page-nav))
-
 ### `scope6`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2471,16 +1436,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the IPv6 scope for the default network interface.
 
-
-**Resolution:**
-
-* Linux: parse the contents of /proc/net/if_inet6 to retrieve the network interface scope.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface scope.
-* Solaris: use the `ioctl` function to retrieve the network interface scope.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface scope.
-
-
-([↑ Back to top](#page-nav))
 
 ### `scope6_<interface>`
 
@@ -2493,16 +1448,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IPv6 scope for the default network interface.
 
 
-**Resolution:**
-
-* Linux: parse the contents of /proc/net/if_inet6 to retrieve the network interface scope.
-* Mac OSX: use the `getifaddrs` function to retrieve the network interface scope.
-* Solaris: use the `ioctl` function to retrieve the network interface scope.
-* Windows: use the `GetAdaptersAddresses` function to retrieve the network interface scope.
-
-
-([↑ Back to top](#page-nav))
-
 ### `selinux`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2513,13 +1458,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return whether Security-Enhanced Linux (SELinux) is enabled.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/self/mounts` to determine if SELinux is enabled.
-
-
-([↑ Back to top](#page-nav))
 
 ### `selinux_config_mode`
 
@@ -2532,13 +1470,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the configured Security-Enhanced Linux (SELinux) mode.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux mode.
-
-
-([↑ Back to top](#page-nav))
-
 ### `selinux_config_policy`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2549,13 +1480,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the configured Security-Enhanced Linux (SELinux) policy.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux policy.
-
-
-([↑ Back to top](#page-nav))
 
 ### `selinux_current_mode`
 
@@ -2568,13 +1492,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the current Security-Enhanced Linux (SELinux) mode.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode.
-
-
-([↑ Back to top](#page-nav))
-
 ### `selinux_enforced`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2585,13 +1502,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return whether Security-Enhanced Linux (SELinux) is enforced.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode.
-
-
-([↑ Back to top](#page-nav))
 
 ### `selinux_policyversion`
 
@@ -2604,13 +1514,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the Security-Enhanced Linux (SELinux) policy version.
 
 
-**Resolution:**
-
-* Linux: parse the contents of `<mountpoint>/policyvers` to retrieve the SELinux policy version.
-
-
-([↑ Back to top](#page-nav))
-
 ### `serialnumber`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2621,18 +1524,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system product serial number.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product serial number.
-* Solaris: use the `smbios` utility to retrieve the system product serial number.
-* Windows: use WMI to retrieve the system product serial number.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `sp_<name>`
 
@@ -2645,13 +1536,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return Mac OSX system profiler information.
 
 
-**Resolution:**
-
-* Mac OSX: use the `system_profiler` utility to retrieve system profiler information.
-
-
-([↑ Back to top](#page-nav))
-
 ### `ssh<algorithm>key`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2662,16 +1546,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the SSH public key for the algorithm.
 
-
-**Resolution:**
-
-* POSIX platforms: parse SSH public key files.
-
-**Caveats:**
-
-* POSIX platforms: facter must be built with OpenSSL support.
-
-([↑ Back to top](#page-nav))
 
 ### `sshfp_<algorithm>`
 
@@ -2684,16 +1558,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the SSH fingerprints for the algorithm's public key.
 
 
-**Resolution:**
-
-* POSIX platforms: derive the SHA1 and SHA256 fingerprints; delimit with a new line character.
-
-**Caveats:**
-
-* POSIX platforms: facter must be built with OpenSSL support.
-
-([↑ Back to top](#page-nav))
-
 ### `swapencrypted`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2704,13 +1568,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return whether or not the swap is encrypted.
 
-
-**Resolution:**
-
-* Mac OSX: use the `sysctl` function to retrieve swap encryption status.
-
-
-([↑ Back to top](#page-nav))
 
 ### `swapfree`
 
@@ -2723,15 +1580,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the display size of the free swap memory, such as "1 GiB".
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory.
-* Mac OSX: use the `sysctl` function to retrieve the free swap memory.
-* Solaris: use the `swapctl` function to retrieve the free swap memory.
-
-
-([↑ Back to top](#page-nav))
-
 ### `swapfree_mb`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2742,15 +1590,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the size of the free swap memory, in mebibytes.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory.
-* Mac OSX: use the `sysctl` function to retrieve the free swap memory.
-* Solaris: use the `swapctl` function to retrieve the free swap memory.
-
-
-([↑ Back to top](#page-nav))
 
 ### `swapsize`
 
@@ -2763,15 +1602,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the display size of the total swap memory, such as "1 GiB".
 
 
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
-* Mac OSX: use the `sysctl` function to retrieve the total swap memory.
-* Solaris: use the `swapctl` function to retrieve the total swap memory.
-
-
-([↑ Back to top](#page-nav))
-
 ### `swapsize_mb`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2782,15 +1612,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the size of the total swap memory, in mebibytes.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
-* Mac OSX: use the `sysctl` function to retrieve the total swap memory.
-* Solaris: use the `swapctl` function to retrieve the total swap memory.
-
-
-([↑ Back to top](#page-nav))
 
 ### `windows_edition_id`
 
@@ -2803,13 +1624,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the type of Windows edition, Server or Desktop Edition variant.
 
 
-**Resolution:**
-
-* Windows: query the registry to retrieve the type of edition (ServerStandard|Professional|Enterprise).
-
-
-([↑ Back to top](#page-nav))
-
 ### `windows_installation_type`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2820,13 +1634,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return Windows installation type (Server|Server Core|Client).
 
-
-**Resolution:**
-
-* Windows: query the registry to retrive data to differentiate Server, Server Core, Client.
-
-
-([↑ Back to top](#page-nav))
 
 ### `windows_product_name`
 
@@ -2839,13 +1646,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return Windows textual product name.
 
 
-**Resolution:**
-
-* Windows: uery the registry to retrive textual product name.
-
-
-([↑ Back to top](#page-nav))
-
 ### `windows_release_id`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2856,13 +1656,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return Windows Build Version of the form YYMM.
 
-
-**Resolution:**
-
-* Windows: query the registry to retrieve the build version number.
-
-
-([↑ Back to top](#page-nav))
 
 ### `system32`
 
@@ -2875,13 +1668,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the path to the System32 directory on Windows.
 
 
-**Resolution:**
-
-* Windows: use the `SHGetFolderPath` function to retrieve the path to the System32 directory.
-
-
-([↑ Back to top](#page-nav))
-
 ### `uptime`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2892,16 +1678,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system uptime.
 
-
-**Resolution:**
-
-* Linux: use the `sysinfo` function to retrieve the system uptime.
-* POSIX platforms: use the `uptime` utility to retrieve the system uptime.
-* Solaris: use the `kstat` function to retrieve the system uptime.
-* Windows: use WMI to retrieve the system uptime.
-
-
-([↑ Back to top](#page-nav))
 
 ### `uptime_days`
 
@@ -2914,16 +1690,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system uptime days.
 
 
-**Resolution:**
-
-* Linux: use the `sysinfo` function to retrieve the system uptime days.
-* POSIX platforms: use the `uptime` utility to retrieve the system uptime days.
-* Solaris: use the `kstat` function to retrieve the system uptime days.
-* Windows: use WMI to retrieve the system uptime days.
-
-
-([↑ Back to top](#page-nav))
-
 ### `uptime_hours`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2934,16 +1700,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system uptime hours.
 
-
-**Resolution:**
-
-* Linux: use the `sysinfo` function to retrieve the system uptime hours.
-* POSIX platforms: use the `uptime` utility to retrieve the system uptime hours.
-* Solaris: use the `kstat` function to retrieve the system uptime hours.
-* Windows: use WMI to retrieve the system uptime hours.
-
-
-([↑ Back to top](#page-nav))
 
 ### `uptime_seconds`
 
@@ -2956,16 +1712,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the system uptime seconds.
 
 
-**Resolution:**
-
-* Linux: use the `sysinfo` function to retrieve the system uptime seconds.
-* POSIX platforms: use the `uptime` utility to retrieve the system uptime seconds.
-* Solaris: use the `kstat` function to retrieve the system uptime seconds.
-* Windows: use WMI to retrieve the system uptime seconds.
-
-
-([↑ Back to top](#page-nav))
-
 ### `uuid`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -2976,17 +1722,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the system product unique identifier.
 
-
-**Resolution:**
-
-* Linux: parse the contents of `/sys/class/dmi/id/product_uuid` to retrieve the system product unique identifier.
-* Solaris: use the `smbios` utility to retrieve the system product unique identifier.
-
-**Caveats:**
-
-* Linux: kernel 2.6+ is required due to the reliance on sysfs.
-
-([↑ Back to top](#page-nav))
 
 ### `xendomains`
 
@@ -2999,16 +1734,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return a list of comma-separated active Xen domain names.
 
 
-**Resolution:**
-
-* POSIX platforms: see the `xen` structured fact.
-
-**Caveats:**
-
-* POSIX platforms: confined to Xen privileged virtual machines.
-
-([↑ Back to top](#page-nav))
-
 ### `zone_<name>_brand`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -3019,16 +1744,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the brand for the Solaris zone.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the brand for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zone_<name>_iptype`
 
@@ -3041,16 +1756,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the IP type for the Solaris zone.
 
 
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the IP type for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zone_<name>_name`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -3061,16 +1766,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the name for the Solaris zone.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the name for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zone_<name>_uuid`
 
@@ -3083,16 +1778,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the unique identifier for the Solaris zone.
 
 
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the unique identifier for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zone_<name>_id`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -3103,16 +1788,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the zone identifier for the Solaris zone.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the zone identifier for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zone_<name>_path`
 
@@ -3125,16 +1800,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the zone path for the Solaris zone.
 
 
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the zone path for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zone_<name>_status`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -3145,16 +1810,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the zone state for the Solaris zone.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the zone state for the Solaris zone.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
 
 ### `zonename`
 
@@ -3167,16 +1822,6 @@ This legacy fact is hidden by default in Facter's command-line output.
 Return the name of the current Solaris zone.
 
 
-**Resolution:**
-
-* Solaris: use the `zonename` utility to retrieve the current zone name.
-
-**Caveats:**
-
-* Solaris: the `zonename` utility must be present.
-
-([↑ Back to top](#page-nav))
-
 ### `zones`
 
 This legacy fact is hidden by default in Facter's command-line output.
@@ -3187,14 +1832,4 @@ This legacy fact is hidden by default in Facter's command-line output.
 
 Return the count of Solaris zones.
 
-
-**Resolution:**
-
-* Solaris: use the `zoneadm` utility to retrieve the count of Solaris zones.
-
-**Caveats:**
-
-* Solaris: the `zoneadm` utility must be present.
-
-([↑ Back to top](#page-nav))
 


### PR DESCRIPTION
Updated the documentation for Facter 4.

The main changes are:
* dropping the Resolution section
* dropping the Caveats section
* add nim_type fact
* add 'details' section for some facts