### PR TITLE
(DOC-4857) Generate Facter CLI docs page

### DIFF
--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -22,6 +22,7 @@ module PuppetReferences
   require 'puppet_references/puppet/type_strings'
   require 'puppet_references/puppet/functions'
   require 'puppet_references/facter/core_facts'
+  require 'puppet_references/facter/facter_cli'
   require 'puppet_references/version_tables/config'
   require 'puppet_references/version_tables/data/pe'
   require 'puppet_references/version_tables/data/agent'
@@ -44,7 +45,8 @@ module PuppetReferences
 
   def self.build_facter_references(commit)
     references = [
-        PuppetReferences::Facter::CoreFacts
+        PuppetReferences::Facter::CoreFacts,
+        PuppetReferences::Facter::FacterCli
     ]
     repo = PuppetReferences::Repo.new('facter', FACTER_DIR)
     real_commit = repo.checkout(commit)

--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -1,0 +1,34 @@
+require 'puppet_references'
+module PuppetReferences
+  module Facter
+    class FacterCli < PuppetReferences::Reference
+      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + 'facter'
+      PREAMBLE_FILE = Pathname.new(__FILE__).dirname + 'facter_cli_preamble.md'
+      PREAMBLE = PREAMBLE_FILE.read
+
+      def initialize(*args)
+        @latest = '/puppet/latest'
+        super(*args)
+      end
+
+      def build_all
+        require 'open3'
+        puts 'Building CLI documentation page for facter.'
+        OUTPUT_DIR.mkpath
+        raw_text, err, exit_code = Open3.capture3("ruby #{PuppetReferences::FACTER_DIR}/lib/docs/generate_cli.rb")
+        if exit_code != 0
+          puts "Encountered an error while building the facter cli docs, will abort: #{err}"
+          return
+        end
+
+        header_data = {title: 'Facter: CLI',
+                       toc: 'columns',
+                       canonical: "#{@latest}/cli.html"}
+        content = make_header(header_data) + PREAMBLE + raw_text
+        filename = OUTPUT_DIR + 'cli.md'
+        filename.open('w') {|f| f.write(content)}
+        puts 'CLI documentation is done!'
+      end
+    end
+  end
+end

--- a/lib/puppet_references/facter/facter_cli_preamble.md
+++ b/lib/puppet_references/facter/facter_cli_preamble.md
@@ -1,0 +1,3 @@
+# TEST PREABLE
+
+---


### PR DESCRIPTION
Added logic for generating Facter CLI documentation similar to the one for core facts. The same rake task that is used for core facts should be used, with the same arguments. The rake task will now generate `cli.md` in addition to `core_facts.md`.

If an older version of facter is used (older than 5.0.52) the CLI docs will not get generated and an error message will be displayed when running the rake task, but the core facts documentation will still be generated.