### PR TITLE
(DOC-4857) Use cloned facter to generate CLI man page

### DIFF
--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -15,7 +15,10 @@ module PuppetReferences
         require 'open3'
         puts 'Building CLI documentation page for facter.'
         OUTPUT_DIR.mkpath
-        raw_text, err, exit_code = Open3.capture3("ruby #{PuppetReferences::FACTER_DIR}/lib/docs/generate_cli.rb")
+        Bundler.with_unbundled_env do
+          Open3.capture3("BUNDLE_GEMFILE=#{PuppetReferences::FACTER_DIR}/Gemfile bundle update")
+        end
+        raw_text, err, exit_code = Open3.capture3("BUNDLE_GEMFILE=#{PuppetReferences::FACTER_DIR}/Gemfile bundle exec facter man")
         if exit_code != 0
           puts "Encountered an error while building the facter cli docs, will abort: #{err}"
           return


### PR DESCRIPTION
Right now the docs project depends on `puppet` which in turn depends on `facter`. Because of this, the man page that was generated for `facter` was for the `facter` that was provided by `puppet`, not the one that was cloned.

The fix uses the facter that was cloned to generate the man page. 