### PR TITLE
(maint) Remove facter cli preamble.

### DIFF
--- a/lib/puppet_references/facter/facter_cli_preamble.md
+++ b/lib/puppet_references/facter/facter_cli_preamble.md
@@ -1,3 +1,0 @@
-# TEST PREABLE
-
----


### PR DESCRIPTION
Removed default value fro Facter CLI preamble. Any text that is added in the preamble will be prepended to the automatically generated cli docs.